### PR TITLE
LPC & LPP updates, fixes and add to demo cmds

### DIFF
--- a/api/featuresclient.go
+++ b/api/featuresclient.go
@@ -79,7 +79,11 @@ type LoadControlClientInterface interface {
 
 	// write load control limits
 	// returns an error if this failed
-	WriteLimitData(data []model.LoadControlLimitDataType) (*model.MsgCounterType, error)
+	WriteLimitData(
+		data []model.LoadControlLimitDataType,
+		deleteSelectors *model.LoadControlLimitListDataSelectorsType,
+		deleteElements *model.LoadControlLimitDataElementsType,
+	) (*model.MsgCounterType, error)
 }
 
 type MeasurementClientInterface interface {

--- a/cmd/controlbox/main.go
+++ b/cmd/controlbox/main.go
@@ -169,6 +169,8 @@ func (h *controlbox) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterfac
 		if currentLimit, err := h.uclpc.ConsumptionLimit(entity); err == nil {
 			fmt.Println("New Limit received", currentLimit.Value, "W")
 		}
+	default:
+		return
 	}
 }
 

--- a/features/client/loadcontrol.go
+++ b/features/client/loadcontrol.go
@@ -53,14 +53,31 @@ func (l *LoadControl) RequestLimitData() (*model.MsgCounterType, error) {
 
 // write load control limits
 // returns an error if this failed
-func (l *LoadControl) WriteLimitData(data []model.LoadControlLimitDataType) (*model.MsgCounterType, error) {
+func (l *LoadControl) WriteLimitData(
+	data []model.LoadControlLimitDataType,
+	deleteSelectors *model.LoadControlLimitListDataSelectorsType,
+	deleteElements *model.LoadControlLimitDataElementsType,
+) (*model.MsgCounterType, error) {
 	if len(data) == 0 {
 		return nil, api.ErrMissingData
 	}
 
+	var filters []model.FilterType
+	if deleteElements != nil && deleteSelectors != nil {
+		delFilter := model.FilterType{
+			CmdControl: &model.CmdControlType{
+				Delete: &model.ElementTagType{},
+			},
+			LoadControlLimitListDataSelectors: deleteSelectors,
+			LoadControlLimitDataElements:      deleteElements,
+		}
+		filters = append(filters, delFilter)
+	}
+	filters = append(filters, *model.NewFilterTypePartial())
+
 	cmd := model.CmdType{
 		Function: util.Ptr(model.FunctionTypeLoadControlLimitListData),
-		Filter:   []model.FilterType{*model.NewFilterTypePartial()},
+		Filter:   filters,
 		LoadControlLimitListData: &model.LoadControlLimitListDataType{
 			LoadControlLimitData: data,
 		},

--- a/features/client/loadcontrol_test.go
+++ b/features/client/loadcontrol_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"testing"
+	"time"
 
 	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
@@ -77,12 +78,12 @@ func (s *LoadControlSuite) Test_RequestLimits() {
 }
 
 func (s *LoadControlSuite) Test_WriteLimitValues() {
-	counter, err := s.loadControl.WriteLimitData(nil)
+	counter, err := s.loadControl.WriteLimitData(nil, nil, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), counter)
 
 	data := []model.LoadControlLimitDataType{}
-	counter, err = s.loadControl.WriteLimitData(data)
+	counter, err = s.loadControl.WriteLimitData(data, nil, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), counter)
 
@@ -90,9 +91,22 @@ func (s *LoadControlSuite) Test_WriteLimitValues() {
 		{
 			LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
 			Value:   model.NewScaledNumberType(10),
+			TimePeriod: &model.TimePeriodType{
+				EndTime: model.NewAbsoluteOrRelativeTimeTypeFromDuration(time.Minute * 5),
+			},
 		},
 	}
-	counter, err = s.loadControl.WriteLimitData(data)
+	counter, err = s.loadControl.WriteLimitData(data, nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	deleteSelectors := &model.LoadControlLimitListDataSelectorsType{
+		LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
+	}
+	deleteElements := &model.LoadControlLimitDataElementsType{
+		TimePeriod: &model.TimePeriodElementsType{},
+	}
+	counter, err = s.loadControl.WriteLimitData(data, deleteSelectors, deleteElements)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }

--- a/mocks/LoadControlClientInterface.go
+++ b/mocks/LoadControlClientInterface.go
@@ -191,9 +191,9 @@ func (_c *LoadControlClientInterface_RequestLimitDescriptions_Call) RunAndReturn
 	return _c
 }
 
-// WriteLimitData provides a mock function with given fields: data
-func (_m *LoadControlClientInterface) WriteLimitData(data []model.LoadControlLimitDataType) (*model.MsgCounterType, error) {
-	ret := _m.Called(data)
+// WriteLimitData provides a mock function with given fields: data, deleteSelectors, deleteElements
+func (_m *LoadControlClientInterface) WriteLimitData(data []model.LoadControlLimitDataType, deleteSelectors *model.LoadControlLimitListDataSelectorsType, deleteElements *model.LoadControlLimitDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(data, deleteSelectors, deleteElements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for WriteLimitData")
@@ -201,19 +201,19 @@ func (_m *LoadControlClientInterface) WriteLimitData(data []model.LoadControlLim
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]model.LoadControlLimitDataType) (*model.MsgCounterType, error)); ok {
-		return rf(data)
+	if rf, ok := ret.Get(0).(func([]model.LoadControlLimitDataType, *model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(data, deleteSelectors, deleteElements)
 	}
-	if rf, ok := ret.Get(0).(func([]model.LoadControlLimitDataType) *model.MsgCounterType); ok {
-		r0 = rf(data)
+	if rf, ok := ret.Get(0).(func([]model.LoadControlLimitDataType, *model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(data, deleteSelectors, deleteElements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]model.LoadControlLimitDataType) error); ok {
-		r1 = rf(data)
+	if rf, ok := ret.Get(1).(func([]model.LoadControlLimitDataType, *model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) error); ok {
+		r1 = rf(data, deleteSelectors, deleteElements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -228,13 +228,15 @@ type LoadControlClientInterface_WriteLimitData_Call struct {
 
 // WriteLimitData is a helper method to define mock.On call
 //   - data []model.LoadControlLimitDataType
-func (_e *LoadControlClientInterface_Expecter) WriteLimitData(data interface{}) *LoadControlClientInterface_WriteLimitData_Call {
-	return &LoadControlClientInterface_WriteLimitData_Call{Call: _e.mock.On("WriteLimitData", data)}
+//   - deleteSelectors *model.LoadControlLimitListDataSelectorsType
+//   - deleteElements *model.LoadControlLimitDataElementsType
+func (_e *LoadControlClientInterface_Expecter) WriteLimitData(data interface{}, deleteSelectors interface{}, deleteElements interface{}) *LoadControlClientInterface_WriteLimitData_Call {
+	return &LoadControlClientInterface_WriteLimitData_Call{Call: _e.mock.On("WriteLimitData", data, deleteSelectors, deleteElements)}
 }
 
-func (_c *LoadControlClientInterface_WriteLimitData_Call) Run(run func(data []model.LoadControlLimitDataType)) *LoadControlClientInterface_WriteLimitData_Call {
+func (_c *LoadControlClientInterface_WriteLimitData_Call) Run(run func(data []model.LoadControlLimitDataType, deleteSelectors *model.LoadControlLimitListDataSelectorsType, deleteElements *model.LoadControlLimitDataElementsType)) *LoadControlClientInterface_WriteLimitData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]model.LoadControlLimitDataType))
+		run(args[0].([]model.LoadControlLimitDataType), args[1].(*model.LoadControlLimitListDataSelectorsType), args[2].(*model.LoadControlLimitDataElementsType))
 	})
 	return _c
 }
@@ -244,7 +246,7 @@ func (_c *LoadControlClientInterface_WriteLimitData_Call) Return(_a0 *model.MsgC
 	return _c
 }
 
-func (_c *LoadControlClientInterface_WriteLimitData_Call) RunAndReturn(run func([]model.LoadControlLimitDataType) (*model.MsgCounterType, error)) *LoadControlClientInterface_WriteLimitData_Call {
+func (_c *LoadControlClientInterface_WriteLimitData_Call) RunAndReturn(run func([]model.LoadControlLimitDataType, *model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) (*model.MsgCounterType, error)) *LoadControlClientInterface_WriteLimitData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/cem/cevc/events_test.go
+++ b/usecases/cem/cevc/events_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *CEVCSuite) Test_Events() {
+func (s *CemCEVCSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -44,7 +44,7 @@ func (s *CEVCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *CEVCSuite) Test_Failures() {
+func (s *CemCEVCSuite) Test_Failures() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -61,7 +61,7 @@ func (s *CEVCSuite) Test_Failures() {
 	s.sut.evCheckIncentiveTableDescriptionUpdateRequired(s.mockRemoteEntity)
 }
 
-func (s *CEVCSuite) Test_evTimeSeriesDescriptionDataUpdate() {
+func (s *CemCEVCSuite) Test_evTimeSeriesDescriptionDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/cevc/public_scen1_test.go
+++ b/usecases/cem/cevc/public_scen1_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *CEVCSuite) Test_ChargeStrategy() {
+func (s *CemCEVCSuite) Test_ChargeStrategy() {
 	data := s.sut.ChargeStrategy(s.mockRemoteEntity)
 	assert.Equal(s.T(), ucapi.EVChargeStrategyTypeUnknown, data)
 
@@ -158,7 +158,7 @@ func (s *CEVCSuite) Test_ChargeStrategy() {
 	assert.Equal(s.T(), ucapi.EVChargeStrategyTypeTimedCharging, data)
 }
 
-func (s *CEVCSuite) Test_EnergySingleDemand() {
+func (s *CemCEVCSuite) Test_EnergySingleDemand() {
 	demand, err := s.sut.EnergyDemand(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, demand.MinDemand)

--- a/usecases/cem/cevc/public_scen2_test.go
+++ b/usecases/cem/cevc/public_scen2_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *CEVCSuite) Test_TimeSlotConstraints() {
+func (s *CemCEVCSuite) Test_TimeSlotConstraints() {
 	constraints, err := s.sut.TimeSlotConstraints(s.mockRemoteEntity)
 	assert.Equal(s.T(), uint(0), constraints.MinSlots)
 	assert.Equal(s.T(), uint(0), constraints.MaxSlots)
@@ -53,7 +53,7 @@ func (s *CEVCSuite) Test_TimeSlotConstraints() {
 	assert.Equal(s.T(), err, nil)
 }
 
-func (s *CEVCSuite) Test_WritePowerLimits() {
+func (s *CemCEVCSuite) Test_WritePowerLimits() {
 	data := []ucapi.DurationSlotValue{}
 
 	err := s.sut.WritePowerLimits(s.mockRemoteEntity, data)

--- a/usecases/cem/cevc/public_scen3_test.go
+++ b/usecases/cem/cevc/public_scen3_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *CEVCSuite) Test_IncentiveConstraints() {
+func (s *CemCEVCSuite) Test_IncentiveConstraints() {
 	constraints, err := s.sut.IncentiveConstraints(s.mockRemoteEntity)
 	assert.Equal(s.T(), uint(0), constraints.MinSlots)
 	assert.Equal(s.T(), uint(0), constraints.MaxSlots)
@@ -60,7 +60,7 @@ func (s *CEVCSuite) Test_IncentiveConstraints() {
 	assert.Equal(s.T(), err, nil)
 }
 
-func (s *CEVCSuite) Test_WriteIncentiveTableDescriptions() {
+func (s *CemCEVCSuite) Test_WriteIncentiveTableDescriptions() {
 	data := []ucapi.IncentiveTariffDescription{}
 
 	err := s.sut.WriteIncentiveTableDescriptions(s.mockRemoteEntity, data)
@@ -116,7 +116,7 @@ func (s *CEVCSuite) Test_WriteIncentiveTableDescriptions() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *CEVCSuite) Test_WriteIncentives() {
+func (s *CemCEVCSuite) Test_WriteIncentives() {
 	data := []ucapi.DurationSlotValue{}
 
 	err := s.sut.WriteIncentives(s.mockRemoteEntity, data)

--- a/usecases/cem/cevc/public_scen4_test.go
+++ b/usecases/cem/cevc/public_scen4_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *CEVCSuite) Test_ChargePlanConstaints() {
+func (s *CemCEVCSuite) Test_ChargePlanConstaints() {
 	_, err := s.sut.ChargePlanConstraints(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 
@@ -79,7 +79,7 @@ func (s *CEVCSuite) Test_ChargePlanConstaints() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *CEVCSuite) Test_ChargePlan() {
+func (s *CemCEVCSuite) Test_ChargePlan() {
 	_, err := s.sut.ChargePlan(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 

--- a/usecases/cem/cevc/public_test.go
+++ b/usecases/cem/cevc/public_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *CEVCSuite) Test_CoordinatedChargingScenarios() {
+func (s *CemCEVCSuite) Test_CoordinatedChargingScenarios() {
 	timeConst := &model.TimeSeriesConstraintsListDataType{
 		TimeSeriesConstraintsData: []model.TimeSeriesConstraintsDataType{
 			{

--- a/usecases/cem/cevc/testhelper_test.go
+++ b/usecases/cem/cevc/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestCEVCSuite(t *testing.T) {
-	suite.Run(t, new(CEVCSuite))
+func TestCemCEVCSuite(t *testing.T) {
+	suite.Run(t, new(CemCEVCSuite))
 }
 
-type CEVCSuite struct {
+type CemCEVCSuite struct {
 	suite.Suite
 
 	sut *CemCEVC
@@ -37,11 +37,11 @@ type CEVCSuite struct {
 	eventCalled bool
 }
 
-func (s *CEVCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemCEVCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *CEVCSuite) BeforeTest(suiteName, testName string) {
+func (s *CemCEVCSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/cevc/usecase_test.go
+++ b/usecases/cem/cevc/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *CEVCSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemCEVCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *CEVCSuite) Test_IsUseCaseSupported() {
+func (s *CemCEVCSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/evcc/events_test.go
+++ b/usecases/cem/evcc/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVCCSuite) Test_Events() {
+func (s *CemEVCCSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -57,7 +57,7 @@ func (s *EVCCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *EVCCSuite) Test_Failures() {
+func (s *CemEVCCSuite) Test_Failures() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -68,7 +68,7 @@ func (s *EVCCSuite) Test_Failures() {
 	s.sut.evElectricalParamerDescriptionUpdate(s.mockRemoteEntity)
 }
 
-func (s *EVCCSuite) Test_evConfigurationDataUpdate() {
+func (s *CemEVCCSuite) Test_evConfigurationDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -137,7 +137,7 @@ func (s *EVCCSuite) Test_evConfigurationDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *EVCCSuite) Test_evOperatingStateDataUpdate() {
+func (s *CemEVCCSuite) Test_evOperatingStateDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -162,7 +162,7 @@ func (s *EVCCSuite) Test_evOperatingStateDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *EVCCSuite) Test_evIdentificationDataUpdate() {
+func (s *CemEVCCSuite) Test_evIdentificationDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -194,7 +194,7 @@ func (s *EVCCSuite) Test_evIdentificationDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *EVCCSuite) Test_evManufacturerDataUpdate() {
+func (s *CemEVCCSuite) Test_evManufacturerDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -219,7 +219,7 @@ func (s *EVCCSuite) Test_evManufacturerDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *EVCCSuite) Test_evElectricalPermittedValuesUpdate() {
+func (s *CemEVCCSuite) Test_evElectricalPermittedValuesUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/evcc/public_test.go
+++ b/usecases/cem/evcc/public_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVCCSuite) Test_ChargeState() {
+func (s *CemEVCCSuite) Test_ChargeState() {
 	data, err := s.sut.ChargeState(s.mockRemoteEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), ucapi.EVChargeStateTypeUnplugged, data)
@@ -75,7 +75,7 @@ func (s *EVCCSuite) Test_ChargeState() {
 	assert.Equal(s.T(), ucapi.EVChargeStateTypeUnknown, data)
 }
 
-func (s *EVCCSuite) Test_EVConnected() {
+func (s *CemEVCCSuite) Test_EVConnected() {
 	data := s.sut.EVConnected(nil)
 	assert.Equal(s.T(), false, data)
 
@@ -97,7 +97,7 @@ func (s *EVCCSuite) Test_EVConnected() {
 	assert.Equal(s.T(), true, data)
 }
 
-func (s *EVCCSuite) Test_EVCommunicationStandard() {
+func (s *CemEVCCSuite) Test_EVCommunicationStandard() {
 	data, err := s.sut.CommunicationStandard(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), UCEVCCCommunicationStandardUnknown, data)
@@ -159,7 +159,7 @@ func (s *EVCCSuite) Test_EVCommunicationStandard() {
 	assert.Equal(s.T(), model.DeviceConfigurationKeyValueStringTypeISO151182ED2, data)
 }
 
-func (s *EVCCSuite) Test_EVAsymmetricChargingSupport() {
+func (s *CemEVCCSuite) Test_EVAsymmetricChargingSupport() {
 	data, err := s.sut.AsymmetricChargingSupport(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)
@@ -221,7 +221,7 @@ func (s *EVCCSuite) Test_EVAsymmetricChargingSupport() {
 	assert.True(s.T(), data)
 }
 
-func (s *EVCCSuite) Test_EVIdentification() {
+func (s *CemEVCCSuite) Test_EVIdentification() {
 	data, err := s.sut.Identifications(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), []ucapi.IdentificationItem(nil), data)
@@ -254,7 +254,7 @@ func (s *EVCCSuite) Test_EVIdentification() {
 	assert.Equal(s.T(), resultData, data)
 }
 
-func (s *EVCCSuite) Test_EVManufacturerData() {
+func (s *CemEVCCSuite) Test_EVManufacturerData() {
 	_, err := s.sut.ManufacturerData(nil)
 	assert.NotNil(s.T(), err)
 
@@ -292,7 +292,7 @@ func (s *EVCCSuite) Test_EVManufacturerData() {
 	assert.Equal(s.T(), "", data.BrandName)
 }
 
-func (s *EVCCSuite) Test_EVChargingPowerLimits() {
+func (s *CemEVCCSuite) Test_EVChargingPowerLimits() {
 	minData, maxData, standByData, err := s.sut.ChargingPowerLimits(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, minData)
@@ -389,7 +389,7 @@ func (s *EVCCSuite) Test_EVChargingPowerLimits() {
 	}
 }
 
-func (s *EVCCSuite) Test_EVInSleepMode() {
+func (s *CemEVCCSuite) Test_EVInSleepMode() {
 	data, err := s.sut.IsInSleepMode(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/evcc/results_test.go
+++ b/usecases/cem/evcc/results_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/enbility/spine-go/util"
 )
 
-func (s *EVCCSuite) Test_Results() {
+func (s *CemEVCCSuite) Test_Results() {
 	localDevice := s.service.LocalDevice()
 	localEntity := localDevice.EntityForType(model.EntityTypeTypeCEM)
 	localFeature := localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)

--- a/usecases/cem/evcc/testhelper_test.go
+++ b/usecases/cem/evcc/testhelper_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestEVCCSuite(t *testing.T) {
-	suite.Run(t, new(EVCCSuite))
+func TestCemEVCCSuite(t *testing.T) {
+	suite.Run(t, new(CemEVCCSuite))
 }
 
-type EVCCSuite struct {
+type CemEVCCSuite struct {
 	suite.Suite
 
 	sut *CemEVCC
@@ -37,11 +37,11 @@ type EVCCSuite struct {
 	eventCalled bool
 }
 
-func (s *EVCCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemEVCCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *EVCCSuite) BeforeTest(suiteName, testName string) {
+func (s *CemEVCCSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/evcc/usecase_test.go
+++ b/usecases/cem/evcc/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVCCSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemEVCCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *EVCCSuite) Test_IsUseCaseSupported() {
+func (s *CemEVCCSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/evcem/events_test.go
+++ b/usecases/cem/evcem/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVCEMSuite) Test_Events() {
+func (s *CemEVCEMSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -36,13 +36,13 @@ func (s *EVCEMSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *EVCEMSuite) Test_Failures() {
+func (s *CemEVCEMSuite) Test_Failures() {
 	s.sut.evConnected(s.mockRemoteEntity)
 
 	s.sut.evMeasurementDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *EVCEMSuite) Test_evElectricalConnectionDescriptionDataUpdate() {
+func (s *CemEVCEMSuite) Test_evElectricalConnectionDescriptionDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -79,7 +79,7 @@ func (s *EVCEMSuite) Test_evElectricalConnectionDescriptionDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *EVCEMSuite) Test_evMeasurementDataUpdate() {
+func (s *CemEVCEMSuite) Test_evMeasurementDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/evcem/public_test.go
+++ b/usecases/cem/evcem/public_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVCEMSuite) Test_EVConnectedPhases() {
+func (s *CemEVCEMSuite) Test_EVConnectedPhases() {
 	data, err := s.sut.PhasesConnected(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), uint(0), data)
@@ -48,7 +48,7 @@ func (s *EVCEMSuite) Test_EVConnectedPhases() {
 	assert.Equal(s.T(), uint(1), data)
 }
 
-func (s *EVCEMSuite) Test_EVCurrentPerPhase() {
+func (s *CemEVCEMSuite) Test_EVCurrentPerPhase() {
 	data, err := s.sut.CurrentPerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -113,7 +113,7 @@ func (s *EVCEMSuite) Test_EVCurrentPerPhase() {
 	assert.Equal(s.T(), 10.0, data[0])
 }
 
-func (s *EVCEMSuite) Test_EVPowerPerPhase_Power() {
+func (s *CemEVCEMSuite) Test_EVPowerPerPhase_Power() {
 	data, err := s.sut.PowerPerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -178,7 +178,7 @@ func (s *EVCEMSuite) Test_EVPowerPerPhase_Power() {
 	assert.Equal(s.T(), 80.0, data[0])
 }
 
-func (s *EVCEMSuite) Test_EVPowerPerPhase_Current() {
+func (s *CemEVCEMSuite) Test_EVPowerPerPhase_Current() {
 	data, err := s.sut.PowerPerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -243,7 +243,7 @@ func (s *EVCEMSuite) Test_EVPowerPerPhase_Current() {
 	assert.Equal(s.T(), 2300.0, data[0])
 }
 
-func (s *EVCEMSuite) Test_EVChargedEnergy() {
+func (s *CemEVCEMSuite) Test_EVChargedEnergy() {
 	data, err := s.sut.EnergyCharged(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/cem/evcem/testhelper_test.go
+++ b/usecases/cem/evcem/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestEVCEMSuite(t *testing.T) {
-	suite.Run(t, new(EVCEMSuite))
+func TestCemEVCEMSuite(t *testing.T) {
+	suite.Run(t, new(CemEVCEMSuite))
 }
 
-type EVCEMSuite struct {
+type CemEVCEMSuite struct {
 	suite.Suite
 
 	sut *CemEVCEM
@@ -37,11 +37,11 @@ type EVCEMSuite struct {
 	eventCalled bool
 }
 
-func (s *EVCEMSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemEVCEMSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *EVCEMSuite) BeforeTest(suiteName, testName string) {
+func (s *CemEVCEMSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/evcem/usecase_test.go
+++ b/usecases/cem/evcem/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVCEMSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemEVCEMSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *EVCEMSuite) Test_IsUseCaseSupported() {
+func (s *CemEVCEMSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/evsecc/events_test.go
+++ b/usecases/cem/evsecc/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVSECCSuite) Test_Events() {
+func (s *CemEVSECCSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -41,7 +41,7 @@ func (s *EVSECCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *EVSECCSuite) Test_evseManufacturerDataUpdate() {
+func (s *CemEVSECCSuite) Test_evseManufacturerDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -66,7 +66,7 @@ func (s *EVSECCSuite) Test_evseManufacturerDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *EVSECCSuite) Test_evseStateUpdate() {
+func (s *CemEVSECCSuite) Test_evseStateUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/evsecc/public_test.go
+++ b/usecases/cem/evsecc/public_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVSECCSuite) Test_EVSEManufacturerData() {
+func (s *CemEVSECCSuite) Test_EVSEManufacturerData() {
 	_, err := s.sut.ManufacturerData(nil)
 	assert.NotNil(s.T(), err)
 
@@ -44,7 +44,7 @@ func (s *EVSECCSuite) Test_EVSEManufacturerData() {
 	assert.Equal(s.T(), "", data.BrandName)
 }
 
-func (s *EVSECCSuite) Test_EVSEOperatingState() {
+func (s *CemEVSECCSuite) Test_EVSEOperatingState() {
 	data, errCode, err := s.sut.OperatingState(nil)
 	assert.Equal(s.T(), model.DeviceDiagnosisOperatingStateTypeNormalOperation, data)
 	assert.Equal(s.T(), "", errCode)

--- a/usecases/cem/evsecc/testhelper_test.go
+++ b/usecases/cem/evsecc/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestEVSECCSuite(t *testing.T) {
-	suite.Run(t, new(EVSECCSuite))
+func TestCemEVSECCSuite(t *testing.T) {
+	suite.Run(t, new(CemEVSECCSuite))
 }
 
-type EVSECCSuite struct {
+type CemEVSECCSuite struct {
 	suite.Suite
 
 	sut *CemEVSECC
@@ -37,11 +37,11 @@ type EVSECCSuite struct {
 	eventCalled bool
 }
 
-func (s *EVSECCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemEVSECCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *EVSECCSuite) BeforeTest(suiteName, testName string) {
+func (s *CemEVSECCSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/evsecc/usecase_test.go
+++ b/usecases/cem/evsecc/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVSECCSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemEVSECCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *EVSECCSuite) Test_IsUseCaseSupported() {
+func (s *CemEVSECCSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/evsoc/events_test.go
+++ b/usecases/cem/evsoc/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVSOCSuite) Test_Events() {
+func (s *CemEVSOCSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -30,11 +30,11 @@ func (s *EVSOCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *EVSOCSuite) Test_Failures() {
+func (s *CemEVSOCSuite) Test_Failures() {
 	s.sut.evConnected(s.mockRemoteEntity)
 }
 
-func (s *EVSOCSuite) Test_evMeasurementDataUpdate() {
+func (s *CemEVSOCSuite) Test_evMeasurementDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/evsoc/public_test.go
+++ b/usecases/cem/evsoc/public_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVSOCSuite) Test_StateOfCharge() {
+func (s *CemEVSOCSuite) Test_StateOfCharge() {
 	data, err := s.sut.StateOfCharge(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/cem/evsoc/testhelper_test.go
+++ b/usecases/cem/evsoc/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestEVSOCSuite(t *testing.T) {
-	suite.Run(t, new(EVSOCSuite))
+func TestCemEVSOCSuite(t *testing.T) {
+	suite.Run(t, new(CemEVSOCSuite))
 }
 
-type EVSOCSuite struct {
+type CemEVSOCSuite struct {
 	suite.Suite
 
 	sut *CemEVSOC
@@ -37,11 +37,11 @@ type EVSOCSuite struct {
 	eventCalled bool
 }
 
-func (s *EVSOCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemEVSOCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *EVSOCSuite) BeforeTest(suiteName, testName string) {
+func (s *CemEVSOCSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/evsoc/usecase_test.go
+++ b/usecases/cem/evsoc/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *EVSOCSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemEVSOCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *EVSOCSuite) Test_IsUseCaseSupported() {
+func (s *CemEVSOCSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/opev/events_test.go
+++ b/usecases/cem/opev/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *OPEVSuite) Test_Events() {
+func (s *CemOPEVSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -36,13 +36,13 @@ func (s *OPEVSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *OPEVSuite) Test_Failures() {
+func (s *CemOPEVSuite) Test_Failures() {
 	s.sut.evConnected(s.mockRemoteEntity)
 
 	s.sut.evLoadControlLimitDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *OPEVSuite) Test_evElectricalPermittedValuesUpdate() {
+func (s *CemOPEVSuite) Test_evElectricalPermittedValuesUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -121,7 +121,7 @@ func (s *OPEVSuite) Test_evElectricalPermittedValuesUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *OPEVSuite) Test_evLoadControlLimitDataUpdate() {
+func (s *CemOPEVSuite) Test_evLoadControlLimitDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/opev/public_test.go
+++ b/usecases/cem/opev/public_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *OPEVSuite) Test_Public() {
+func (s *CemOPEVSuite) Test_Public() {
 	// The actual tests of the functionality is located in the util package
 
 	_, _, _, err := s.sut.CurrentLimits(s.mockRemoteEntity)

--- a/usecases/cem/opev/testhelper_test.go
+++ b/usecases/cem/opev/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestOPEVSuite(t *testing.T) {
-	suite.Run(t, new(OPEVSuite))
+func TestCemOPEVSuite(t *testing.T) {
+	suite.Run(t, new(CemOPEVSuite))
 }
 
-type OPEVSuite struct {
+type CemOPEVSuite struct {
 	suite.Suite
 
 	sut *CemOPEV
@@ -37,11 +37,11 @@ type OPEVSuite struct {
 	eventCalled bool
 }
 
-func (s *OPEVSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemOPEVSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *OPEVSuite) BeforeTest(suiteName, testName string) {
+func (s *CemOPEVSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/opev/usecase_test.go
+++ b/usecases/cem/opev/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *OPEVSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemOPEVSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *OPEVSuite) Test_IsUseCaseSupported() {
+func (s *CemOPEVSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/oscev/events_test.go
+++ b/usecases/cem/oscev/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *OSCEVSuite) Test_Events() {
+func (s *CemOSCEVSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -33,7 +33,7 @@ func (s *OSCEVSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *OSCEVSuite) Test_evElectricalPermittedValuesUpdate() {
+func (s *CemOSCEVSuite) Test_evElectricalPermittedValuesUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -112,7 +112,7 @@ func (s *OSCEVSuite) Test_evElectricalPermittedValuesUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *OSCEVSuite) Test_evLoadControlLimitDataUpdate() {
+func (s *CemOSCEVSuite) Test_evLoadControlLimitDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/oscev/public_test.go
+++ b/usecases/cem/oscev/public_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *OSCEVSuite) Test_Public() {
+func (s *CemOSCEVSuite) Test_Public() {
 	// The actual tests of the functionality is located in the util package
 
 	_, _, _, err := s.sut.CurrentLimits(s.mockRemoteEntity)

--- a/usecases/cem/oscev/testhelper_test.go
+++ b/usecases/cem/oscev/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestOSCEVSuite(t *testing.T) {
-	suite.Run(t, new(OSCEVSuite))
+func TestCemOSCEVSuite(t *testing.T) {
+	suite.Run(t, new(CemOSCEVSuite))
 }
 
-type OSCEVSuite struct {
+type CemOSCEVSuite struct {
 	suite.Suite
 
 	sut *CemOSCEV
@@ -36,11 +36,11 @@ type OSCEVSuite struct {
 	eventCalled      bool
 }
 
-func (s *OSCEVSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemOSCEVSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *OSCEVSuite) BeforeTest(suiteName, testName string) {
+func (s *CemOSCEVSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/oscev/usecase_test.go
+++ b/usecases/cem/oscev/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *OSCEVSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemOSCEVSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *OSCEVSuite) Test_IsUseCaseSupported() {
+func (s *CemOSCEVSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/vabd/events_test.go
+++ b/usecases/cem/vabd/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *VABDSuite) Test_Events() {
+func (s *CemVABDSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -39,13 +39,13 @@ func (s *VABDSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *VABDSuite) Test_Failures() {
+func (s *CemVABDSuite) Test_Failures() {
 	s.sut.inverterConnected(s.mockRemoteEntity)
 
 	s.sut.inverterMeasurementDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *VABDSuite) Test_inverterMeasurementDataUpdate() {
+func (s *CemVABDSuite) Test_inverterMeasurementDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/vabd/public_test.go
+++ b/usecases/cem/vabd/public_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *VABDSuite) Test_CurrentChargePower() {
+func (s *CemVABDSuite) Test_CurrentChargePower() {
 	data, err := s.sut.Power(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -51,7 +51,7 @@ func (s *VABDSuite) Test_CurrentChargePower() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *VABDSuite) Test_TotalChargeEnergy() {
+func (s *CemVABDSuite) Test_TotalChargeEnergy() {
 	data, err := s.sut.EnergyCharged(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -96,7 +96,7 @@ func (s *VABDSuite) Test_TotalChargeEnergy() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *VABDSuite) Test_TotalDischargeEnergy() {
+func (s *CemVABDSuite) Test_TotalDischargeEnergy() {
 	data, err := s.sut.EnergyDischarged(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -141,7 +141,7 @@ func (s *VABDSuite) Test_TotalDischargeEnergy() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *VABDSuite) Test_CurrentStateOfCharge() {
+func (s *CemVABDSuite) Test_CurrentStateOfCharge() {
 	data, err := s.sut.StateOfCharge(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/cem/vabd/testhelper_test.go
+++ b/usecases/cem/vabd/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestVABDSuite(t *testing.T) {
-	suite.Run(t, new(VABDSuite))
+func TestCemVABDSuite(t *testing.T) {
+	suite.Run(t, new(CemVABDSuite))
 }
 
-type VABDSuite struct {
+type CemVABDSuite struct {
 	suite.Suite
 
 	sut *CemVABD
@@ -37,11 +37,11 @@ type VABDSuite struct {
 	eventCalled bool
 }
 
-func (s *VABDSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemVABDSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *VABDSuite) BeforeTest(suiteName, testName string) {
+func (s *CemVABDSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/vabd/usecase_test.go
+++ b/usecases/cem/vabd/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *VABDSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemVABDSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *VABDSuite) Test_IsUseCaseSupported() {
+func (s *CemVABDSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cem/vapd/events_test.go
+++ b/usecases/cem/vapd/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *VAPDSuite) Test_Events() {
+func (s *CemVAPDSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -39,7 +39,7 @@ func (s *VAPDSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *VAPDSuite) Test_Failures() {
+func (s *CemVAPDSuite) Test_Failures() {
 	s.sut.inverterConnected(s.mockRemoteEntity)
 
 	s.sut.inverterConfigurationDescriptionDataUpdate(s.mockRemoteEntity)
@@ -47,7 +47,7 @@ func (s *VAPDSuite) Test_Failures() {
 	s.sut.inverterMeasurementDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *VAPDSuite) Test_inverterConfigurationDataUpdate() {
+func (s *CemVAPDSuite) Test_inverterConfigurationDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -90,7 +90,7 @@ func (s *VAPDSuite) Test_inverterConfigurationDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *VAPDSuite) Test_inverterMeasurementDataUpdate() {
+func (s *CemVAPDSuite) Test_inverterMeasurementDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/cem/vapd/public_test.go
+++ b/usecases/cem/vapd/public_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *VAPDSuite) Test_CurrentProductionPower() {
+func (s *CemVAPDSuite) Test_CurrentProductionPower() {
 	data, err := s.sut.Power(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -51,7 +51,7 @@ func (s *VAPDSuite) Test_CurrentProductionPower() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *VAPDSuite) Test_NominalPeakPower() {
+func (s *CemVAPDSuite) Test_NominalPeakPower() {
 	data, err := s.sut.PowerNominalPeak(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -92,7 +92,7 @@ func (s *VAPDSuite) Test_NominalPeakPower() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *VAPDSuite) Test_TotalPVYield() {
+func (s *CemVAPDSuite) Test_TotalPVYield() {
 	data, err := s.sut.PVYieldTotal(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/cem/vapd/testhelper_test.go
+++ b/usecases/cem/vapd/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestVAPDSuite(t *testing.T) {
-	suite.Run(t, new(VAPDSuite))
+func TestCemVAPDSuite(t *testing.T) {
+	suite.Run(t, new(CemVAPDSuite))
 }
 
-type VAPDSuite struct {
+type CemVAPDSuite struct {
 	suite.Suite
 
 	sut *CemVAPD
@@ -37,11 +37,11 @@ type VAPDSuite struct {
 	eventCalled bool
 }
 
-func (s *VAPDSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CemVAPDSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *VAPDSuite) BeforeTest(suiteName, testName string) {
+func (s *CemVAPDSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cem/vapd/usecase_test.go
+++ b/usecases/cem/vapd/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *VAPDSuite) Test_UpdateUseCaseAvailability() {
+func (s *CemVAPDSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *VAPDSuite) Test_IsUseCaseSupported() {
+func (s *CemVAPDSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cs/lpc/events_test.go
+++ b/usecases/cs/lpc/events_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPCSuite) Test_Events() {
+func (s *CsLPCSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity:    s.mockRemoteEntity,
 		EventType: spineapi.EventTypeSubscriptionChange,
@@ -64,7 +64,7 @@ func (s *LPCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *LPCSuite) Test_deviceConnected() {
+func (s *CsLPCSuite) Test_deviceConnected() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -84,7 +84,7 @@ func (s *LPCSuite) Test_deviceConnected() {
 	s.sut.subscribeHeartbeatWorkaround(payload)
 }
 
-func (s *LPCSuite) Test_multipleDeviceDiagServer() {
+func (s *CsLPCSuite) Test_multipleDeviceDiagServer() {
 	// multiple entities each with DeviceDiagnosis server
 
 	payload := spineapi.EventPayload{
@@ -213,7 +213,7 @@ func (s *LPCSuite) Test_multipleDeviceDiagServer() {
 	s.sut.subscribeHeartbeatWorkaround(payload)
 }
 
-func (s *LPCSuite) Test_loadControlLimitDataUpdate() {
+func (s *CsLPCSuite) Test_loadControlLimitDataUpdate() {
 	localDevice := s.service.LocalDevice()
 	localEntity := localDevice.EntityForType(model.EntityTypeTypeCEM)
 
@@ -267,7 +267,7 @@ func (s *LPCSuite) Test_loadControlLimitDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *LPCSuite) Test_configurationDataUpdate() {
+func (s *CsLPCSuite) Test_configurationDataUpdate() {
 	localDevice := s.service.LocalDevice()
 	localEntity := localDevice.EntityForType(model.EntityTypeTypeCEM)
 	lFeature := localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -44,7 +44,7 @@ func (e *CsLPC) ConsumptionLimit() (limit ucapi.LoadLimit, resultErr error) {
 	limit.IsChangeable = (value.IsLimitChangeable != nil && *value.IsLimitChangeable)
 	limit.IsActive = (value.IsLimitActive != nil && *value.IsLimitActive)
 	if value.TimePeriod != nil && value.TimePeriod.EndTime != nil {
-		if duration, err := value.TimePeriod.EndTime.GetTimeDuration(); err == nil {
+		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
 		}
 	}

--- a/usecases/cs/lpc/public_test.go
+++ b/usecases/cs/lpc/public_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPCSuite) Test_ConsumptionLimit() {
+func (s *CsLPCSuite) Test_ConsumptionLimit() {
 	limit, err := s.sut.ConsumptionLimit()
 	assert.Equal(s.T(), 0.0, limit.Value)
-	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), err)
 
 	newLimit := ucapi.LoadLimit{
 		Duration:     time.Duration(time.Hour * 2),
@@ -30,7 +30,7 @@ func (s *LPCSuite) Test_ConsumptionLimit() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPCSuite) Test_PendingConsumptionLimits() {
+func (s *CsLPCSuite) Test_PendingConsumptionLimits() {
 	data := s.sut.PendingConsumptionLimits()
 	assert.Equal(s.T(), 0, len(data))
 
@@ -66,7 +66,7 @@ func (s *LPCSuite) Test_PendingConsumptionLimits() {
 	s.sut.ApproveOrDenyConsumptionLimit(msgCounter, false, "leave me alone")
 }
 
-func (s *LPCSuite) Test_Failsafe() {
+func (s *CsLPCSuite) Test_Failsafe() {
 	limit, changeable, err := s.sut.FailsafeConsumptionActivePowerLimit()
 	assert.Equal(s.T(), 0.0, limit)
 	assert.Equal(s.T(), false, changeable)
@@ -103,7 +103,7 @@ func (s *LPCSuite) Test_Failsafe() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPCSuite) Test_IsHeartbeatWithinDuration() {
+func (s *CsLPCSuite) Test_IsHeartbeatWithinDuration() {
 	assert.Nil(s.T(), s.sut.heartbeatDiag)
 
 	value := s.sut.IsHeartbeatWithinDuration()
@@ -140,7 +140,7 @@ func (s *LPCSuite) Test_IsHeartbeatWithinDuration() {
 	assert.True(s.T(), value)
 }
 
-func (s *LPCSuite) Test_ContractualConsumptionNominalMax() {
+func (s *CsLPCSuite) Test_ContractualConsumptionNominalMax() {
 	value, err := s.sut.ContractualConsumptionNominalMax()
 	assert.Equal(s.T(), 0.0, value)
 	assert.NotNil(s.T(), err)

--- a/usecases/cs/lpc/testhelper_test.go
+++ b/usecases/cs/lpc/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestLPCSuite(t *testing.T) {
-	suite.Run(t, new(LPCSuite))
+func TestCsLPCSuite(t *testing.T) {
+	suite.Run(t, new(CsLPCSuite))
 }
 
-type LPCSuite struct {
+type CsLPCSuite struct {
 	suite.Suite
 
 	sut *CsLPC
@@ -40,11 +40,11 @@ type LPCSuite struct {
 	eventCalled bool
 }
 
-func (s *LPCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CsLPCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *LPCSuite) BeforeTest(suiteName, testName string) {
+func (s *CsLPCSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cs/lpc/usecase_test.go
+++ b/usecases/cs/lpc/usecase_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPCSuite) Test_loadControlServerAndLimitId() {
+func (s *CsLPCSuite) Test_loadControlServerAndLimitId() {
 	lc, _, err := s.sut.loadControlServerAndLimitId()
 	assert.NotNil(s.T(), lc)
 	assert.Nil(s.T(), err)
@@ -26,7 +26,7 @@ func (s *LPCSuite) Test_loadControlServerAndLimitId() {
 	assert.NotNil(s.T(), err)
 }
 
-func (s *LPCSuite) Test_loadControlWriteCB() {
+func (s *CsLPCSuite) Test_loadControlWriteCB() {
 	msg := &spineapi.Message{}
 
 	s.sut.loadControlWriteCB(msg)
@@ -78,11 +78,11 @@ func (s *LPCSuite) Test_loadControlWriteCB() {
 	s.sut.loadControlWriteCB(msg)
 }
 
-func (s *LPCSuite) Test_UpdateUseCaseAvailability() {
+func (s *CsLPCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *LPCSuite) Test_IsUseCaseSupported() {
+func (s *CsLPCSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/cs/lpp/events_test.go
+++ b/usecases/cs/lpp/events_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPPSuite) Test_Events() {
+func (s *CsLPPSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity:    s.mockRemoteEntity,
 		EventType: spineapi.EventTypeSubscriptionChange,
@@ -64,7 +64,7 @@ func (s *LPPSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *LPPSuite) Test_deviceConnected() {
+func (s *CsLPPSuite) Test_deviceConnected() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -84,7 +84,7 @@ func (s *LPPSuite) Test_deviceConnected() {
 	s.sut.subscribeHeartbeatWorkaround(payload)
 }
 
-func (s *LPPSuite) Test_multipleDeviceDiagServer() {
+func (s *CsLPPSuite) Test_multipleDeviceDiagServer() {
 	// multiple entities each with DeviceDiagnosis server
 
 	payload := spineapi.EventPayload{
@@ -213,7 +213,7 @@ func (s *LPPSuite) Test_multipleDeviceDiagServer() {
 	s.sut.subscribeHeartbeatWorkaround(payload)
 }
 
-func (s *LPPSuite) Test_loadControlLimitDataUpdate() {
+func (s *CsLPPSuite) Test_loadControlLimitDataUpdate() {
 	localDevice := s.service.LocalDevice()
 	localEntity := localDevice.EntityForType(model.EntityTypeTypeCEM)
 
@@ -267,7 +267,7 @@ func (s *LPPSuite) Test_loadControlLimitDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *LPPSuite) Test_configurationDataUpdate() {
+func (s *CsLPPSuite) Test_configurationDataUpdate() {
 	localDevice := s.service.LocalDevice()
 	localEntity := localDevice.EntityForType(model.EntityTypeTypeCEM)
 	lFeature := localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -44,7 +44,7 @@ func (e *CsLPP) ProductionLimit() (limit ucapi.LoadLimit, resultErr error) {
 	limit.IsChangeable = (value.IsLimitChangeable != nil && *value.IsLimitChangeable)
 	limit.IsActive = (value.IsLimitActive != nil && *value.IsLimitActive)
 	if value.TimePeriod != nil && value.TimePeriod.EndTime != nil {
-		if duration, err := value.TimePeriod.EndTime.GetTimeDuration(); err == nil {
+		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
 		}
 	}

--- a/usecases/cs/lpp/public_test.go
+++ b/usecases/cs/lpp/public_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPPSuite) Test_LoadControlLimit() {
+func (s *CsLPPSuite) Test_LoadControlLimit() {
 	limit, err := s.sut.ProductionLimit()
 	assert.Equal(s.T(), 0.0, limit.Value)
-	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), err)
 
 	newLimit := ucapi.LoadLimit{
 		Duration:     time.Duration(time.Hour * 2),
@@ -30,7 +30,7 @@ func (s *LPPSuite) Test_LoadControlLimit() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPPSuite) Test_PendingProductionLimits() {
+func (s *CsLPPSuite) Test_PendingProductionLimits() {
 	data := s.sut.PendingProductionLimits()
 	assert.Equal(s.T(), 0, len(data))
 
@@ -66,7 +66,7 @@ func (s *LPPSuite) Test_PendingProductionLimits() {
 	s.sut.ApproveOrDenyProductionLimit(msgCounter, false, "leave me alone")
 }
 
-func (s *LPPSuite) Test_Failsafe() {
+func (s *CsLPPSuite) Test_Failsafe() {
 	limit, changeable, err := s.sut.FailsafeProductionActivePowerLimit()
 	assert.Equal(s.T(), 0.0, limit)
 	assert.Equal(s.T(), false, changeable)
@@ -103,7 +103,7 @@ func (s *LPPSuite) Test_Failsafe() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPPSuite) Test_IsHeartbeatWithinDuration() {
+func (s *CsLPPSuite) Test_IsHeartbeatWithinDuration() {
 	assert.Nil(s.T(), s.sut.heartbeatDiag)
 
 	value := s.sut.IsHeartbeatWithinDuration()
@@ -140,7 +140,7 @@ func (s *LPPSuite) Test_IsHeartbeatWithinDuration() {
 	assert.True(s.T(), value)
 }
 
-func (s *LPPSuite) Test_ContractualProductionNominalMax() {
+func (s *CsLPPSuite) Test_ContractualProductionNominalMax() {
 	value, err := s.sut.ContractualProductionNominalMax()
 	assert.Equal(s.T(), 0.0, value)
 	assert.NotNil(s.T(), err)

--- a/usecases/cs/lpp/testhelper_test.go
+++ b/usecases/cs/lpp/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestLPPSuite(t *testing.T) {
-	suite.Run(t, new(LPPSuite))
+func TestCsLPPSuite(t *testing.T) {
+	suite.Run(t, new(CsLPPSuite))
 }
 
-type LPPSuite struct {
+type CsLPPSuite struct {
 	suite.Suite
 
 	sut *CsLPP
@@ -40,11 +40,11 @@ type LPPSuite struct {
 	eventCalled bool
 }
 
-func (s *LPPSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *CsLPPSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *LPPSuite) BeforeTest(suiteName, testName string) {
+func (s *CsLPPSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -87,9 +87,6 @@ func (e *CsLPP) loadControlServerAndLimitId() (lc *server.LoadControl, limitid m
 // the implementation only considers write messages for this use case and
 // approves all others
 func (e *CsLPP) loadControlWriteCB(msg *spineapi.Message) {
-	e.pendingMux.Lock()
-	defer e.pendingMux.Unlock()
-
 	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
 		msg.Cmd.LoadControlLimitListData == nil {
 		return
@@ -108,6 +105,8 @@ func (e *CsLPP) loadControlWriteCB(msg *spineapi.Message) {
 		return
 	}
 
+	e.pendingMux.Lock()
+
 	// check if there is a matching limitId in the data
 	for _, item := range data.LoadControlLimitData {
 		if item.LimitId == nil ||
@@ -117,10 +116,13 @@ func (e *CsLPP) loadControlWriteCB(msg *spineapi.Message) {
 
 		if _, ok := e.pendingLimits[*msg.RequestHeader.MsgCounter]; !ok {
 			e.pendingLimits[*msg.RequestHeader.MsgCounter] = msg
+			e.pendingMux.Unlock()
 			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
 			return
 		}
 	}
+
+	e.pendingMux.Unlock()
 
 	// approve, because this is no request for this usecase
 	go e.ApproveOrDenyProductionLimit(*msg.RequestHeader.MsgCounter, true, "")
@@ -145,7 +147,14 @@ func (e *CsLPP) AddFeatures() {
 		ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 	}
 	if lc, err := server.NewLoadControl(e.LocalEntity); err == nil {
-		lc.AddLimitDescription(newLimitDesc)
+		limitId := lc.AddLimitDescription(newLimitDesc)
+
+		newLimiData := model.LoadControlLimitDataType{
+			Value:             model.NewScaledNumberType(0),
+			IsLimitChangeable: util.Ptr(true),
+			IsLimitActive:     util.Ptr(false),
+		}
+		_ = lc.UpdateLimitDataForId(newLimiData, nil, *limitId)
 	}
 
 	f = e.LocalEntity.GetOrAddFeature(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)

--- a/usecases/cs/lpp/usecase_test.go
+++ b/usecases/cs/lpp/usecase_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPPSuite) Test_loadControlServerAndLimitId() {
+func (s *CsLPPSuite) Test_loadControlServerAndLimitId() {
 	lc, _, err := s.sut.loadControlServerAndLimitId()
 	assert.NotNil(s.T(), lc)
 	assert.Nil(s.T(), err)
@@ -26,7 +26,7 @@ func (s *LPPSuite) Test_loadControlServerAndLimitId() {
 	assert.NotNil(s.T(), err)
 }
 
-func (s *LPPSuite) Test_loadControlWriteCB() {
+func (s *CsLPPSuite) Test_loadControlWriteCB() {
 	msg := &spineapi.Message{}
 
 	s.sut.loadControlWriteCB(msg)
@@ -78,11 +78,11 @@ func (s *LPPSuite) Test_loadControlWriteCB() {
 	s.sut.loadControlWriteCB(msg)
 }
 
-func (s *LPPSuite) Test_UpdateUseCaseAvailability() {
+func (s *CsLPPSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *LPPSuite) Test_IsUseCaseSupported() {
+func (s *CsLPPSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/eg/lpc/events.go
+++ b/usecases/eg/lpc/events.go
@@ -45,6 +45,10 @@ func (e *EgLPC) connected(entity spineapi.EntityRemoteInterface) {
 			logging.Log().Debug(err)
 		}
 
+		if _, err := loadControl.Bind(); err != nil {
+			logging.Log().Debug(err)
+		}
+
 		// get descriptions
 		if _, err := loadControl.RequestLimitDescriptions(); err != nil {
 			logging.Log().Debug(err)

--- a/usecases/eg/lpc/events_test.go
+++ b/usecases/eg/lpc/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPCSuite) Test_Events() {
+func (s *EgLPCSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -39,13 +39,13 @@ func (s *LPCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *LPCSuite) Test_Failures() {
+func (s *EgLPCSuite) Test_Failures() {
 	s.sut.connected(s.mockRemoteEntity)
 
 	s.sut.configurationDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *LPCSuite) Test_loadControlLimitDataUpdate() {
+func (s *EgLPCSuite) Test_loadControlLimitDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -97,7 +97,7 @@ func (s *LPCSuite) Test_loadControlLimitDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *LPCSuite) Test_configurationDataUpdate() {
+func (s *EgLPCSuite) Test_configurationDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/eg/lpc/public.go
+++ b/usecases/eg/lpc/public.go
@@ -64,7 +64,7 @@ func (e *EgLPC) ConsumptionLimit(entity spineapi.EntityRemoteInterface) (
 	limit.IsChangeable = (value.IsLimitChangeable != nil && *value.IsLimitChangeable)
 	limit.IsActive = (value.IsLimitActive != nil && *value.IsLimitActive)
 	if value.TimePeriod != nil && value.TimePeriod.EndTime != nil {
-		if duration, err := value.TimePeriod.EndTime.GetTimeDuration(); err == nil {
+		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
 		}
 	}
@@ -116,7 +116,7 @@ func (e *EgLPC) WriteConsumptionLimit(
 		return nil, api.ErrDataNotAvailable
 	}
 
-	for index, item := range currentLimits {
+	for _, item := range currentLimits {
 		if item.LimitId == nil ||
 			*item.LimitId != *limitDesc.LimitId {
 			continue
@@ -139,11 +139,18 @@ func (e *EgLPC) WriteConsumptionLimit(
 			}
 		}
 
-		currentLimits[index] = newLimit
+		limitData = append(limitData, newLimit)
 		break
 	}
 
-	msgCounter, err := loadControl.WriteLimitData(limitData)
+	deleteSelectors := &model.LoadControlLimitListDataSelectorsType{
+		LimitId: limitDesc.LimitId,
+	}
+	deleteElements := &model.LoadControlLimitDataElementsType{
+		TimePeriod: &model.TimePeriodElementsType{},
+	}
+
+	msgCounter, err := loadControl.WriteLimitData(limitData, deleteSelectors, deleteElements)
 
 	return msgCounter, err
 }

--- a/usecases/eg/lpc/public_test.go
+++ b/usecases/eg/lpc/public_test.go
@@ -120,11 +120,11 @@ func (s *LPCSuite) Test_WriteLoadControlLimit() {
 	assert.Nil(s.T(), fErr)
 
 	_, err = s.sut.WriteConsumptionLimit(s.monitoredEntity, limit)
-	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), err)
 
 	limit.Duration = time.Duration(time.Hour * 2)
 	_, err = s.sut.WriteConsumptionLimit(s.monitoredEntity, limit)
-	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), err)
 }
 
 func (s *LPCSuite) Test_FailsafeConsumptionActivePowerLimit() {

--- a/usecases/eg/lpc/public_test.go
+++ b/usecases/eg/lpc/public_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPCSuite) Test_ConsumptionLimit() {
+func (s *EgLPCSuite) Test_ConsumptionLimit() {
 	data, err := s.sut.ConsumptionLimit(nil)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data.Value)
@@ -74,7 +74,7 @@ func (s *LPCSuite) Test_ConsumptionLimit() {
 	assert.Equal(s.T(), false, data.IsActive)
 }
 
-func (s *LPCSuite) Test_WriteLoadControlLimit() {
+func (s *EgLPCSuite) Test_WriteLoadControlLimit() {
 	limit := ucapi.LoadLimit{
 		Value:    6000,
 		IsActive: true,
@@ -127,7 +127,7 @@ func (s *LPCSuite) Test_WriteLoadControlLimit() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPCSuite) Test_FailsafeConsumptionActivePowerLimit() {
+func (s *EgLPCSuite) Test_FailsafeConsumptionActivePowerLimit() {
 	data, err := s.sut.FailsafeConsumptionActivePowerLimit(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -189,7 +189,7 @@ func (s *LPCSuite) Test_FailsafeConsumptionActivePowerLimit() {
 	assert.Equal(s.T(), 4000.0, data)
 }
 
-func (s *LPCSuite) Test_WriteFailsafeConsumptionActivePowerLimit() {
+func (s *EgLPCSuite) Test_WriteFailsafeConsumptionActivePowerLimit() {
 	_, err := s.sut.WriteFailsafeConsumptionActivePowerLimit(s.mockRemoteEntity, 6000)
 	assert.NotNil(s.T(), err)
 
@@ -228,7 +228,7 @@ func (s *LPCSuite) Test_WriteFailsafeConsumptionActivePowerLimit() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPCSuite) Test_FailsafeDurationMinimum() {
+func (s *EgLPCSuite) Test_FailsafeDurationMinimum() {
 	data, err := s.sut.FailsafeDurationMinimum(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), time.Duration(0), data)
@@ -290,7 +290,7 @@ func (s *LPCSuite) Test_FailsafeDurationMinimum() {
 	assert.Equal(s.T(), time.Duration(time.Hour*2), data)
 }
 
-func (s *LPCSuite) Test_WriteFailsafeDurationMinimum() {
+func (s *EgLPCSuite) Test_WriteFailsafeDurationMinimum() {
 	_, err := s.sut.WriteFailsafeDurationMinimum(s.mockRemoteEntity, time.Duration(time.Hour*2))
 	assert.NotNil(s.T(), err)
 
@@ -332,7 +332,7 @@ func (s *LPCSuite) Test_WriteFailsafeDurationMinimum() {
 	assert.NotNil(s.T(), err)
 }
 
-func (s *LPCSuite) Test_PowerConsumptionNominalMax() {
+func (s *EgLPCSuite) Test_PowerConsumptionNominalMax() {
 	data, err := s.sut.PowerConsumptionNominalMax(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/eg/lpc/testhelper_test.go
+++ b/usecases/eg/lpc/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestLPCSuite(t *testing.T) {
-	suite.Run(t, new(LPCSuite))
+func TestEgLPCSuite(t *testing.T) {
+	suite.Run(t, new(EgLPCSuite))
 }
 
-type LPCSuite struct {
+type EgLPCSuite struct {
 	suite.Suite
 
 	sut *EgLPC
@@ -37,11 +37,11 @@ type LPCSuite struct {
 	eventCalled bool
 }
 
-func (s *LPCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *EgLPCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *LPCSuite) BeforeTest(suiteName, testName string) {
+func (s *EgLPCSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/eg/lpc/usecase.go
+++ b/usecases/eg/lpc/usecase.go
@@ -75,7 +75,7 @@ func (e *EgLPC) IsUseCaseSupported(entity spineapi.EntityRemoteInterface) (bool,
 	// check if the usecase and mandatory scenarios are supported and
 	// if the required server features are available
 	if !entity.Device().VerifyUseCaseScenariosAndFeaturesSupport(
-		model.UseCaseActorTypeEnergyGuard,
+		model.UseCaseActorTypeControllableSystem,
 		e.UseCaseName,
 		[]model.UseCaseScenarioSupportType{1, 2, 3, 4},
 		[]model.FeatureTypeType{

--- a/usecases/eg/lpc/usecase_test.go
+++ b/usecases/eg/lpc/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPCSuite) Test_UpdateUseCaseAvailability() {
+func (s *EgLPCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *LPCSuite) Test_IsUseCaseSupported() {
+func (s *EgLPCSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)
@@ -22,7 +22,7 @@ func (s *LPCSuite) Test_IsUseCaseSupported() {
 	ucData := &model.NodeManagementUseCaseDataType{
 		UseCaseInformation: []model.UseCaseInformationDataType{
 			{
-				Actor: util.Ptr(model.UseCaseActorTypeEnergyGuard),
+				Actor: util.Ptr(model.UseCaseActorTypeControllableSystem),
 				UseCaseSupport: []model.UseCaseSupportType{
 					{
 						UseCaseName:      util.Ptr(model.UseCaseNameTypeLimitationOfPowerConsumption),

--- a/usecases/eg/lpp/events.go
+++ b/usecases/eg/lpp/events.go
@@ -45,6 +45,10 @@ func (e *EgLPP) connected(entity spineapi.EntityRemoteInterface) {
 			logging.Log().Debug(err)
 		}
 
+		if _, err := loadControl.Bind(); err != nil {
+			logging.Log().Debug(err)
+		}
+
 		// get descriptions
 		if _, err := loadControl.RequestLimitDescriptions(); err != nil {
 			logging.Log().Debug(err)

--- a/usecases/eg/lpp/events_test.go
+++ b/usecases/eg/lpp/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPPSuite) Test_Events() {
+func (s *EgLPPSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -39,13 +39,13 @@ func (s *LPPSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *LPPSuite) Test_Failures() {
+func (s *EgLPPSuite) Test_Failures() {
 	s.sut.connected(s.mockRemoteEntity)
 
 	s.sut.configurationDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *LPPSuite) Test_loadControlLimitDataUpdate() {
+func (s *EgLPPSuite) Test_loadControlLimitDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -97,7 +97,7 @@ func (s *LPPSuite) Test_loadControlLimitDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *LPPSuite) Test_configurationDataUpdate() {
+func (s *EgLPPSuite) Test_configurationDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/eg/lpp/public.go
+++ b/usecases/eg/lpp/public.go
@@ -64,7 +64,7 @@ func (e *EgLPP) ProductionLimit(entity spineapi.EntityRemoteInterface) (
 	limit.IsChangeable = (value.IsLimitChangeable != nil && *value.IsLimitChangeable)
 	limit.IsActive = (value.IsLimitActive != nil && *value.IsLimitActive)
 	if value.TimePeriod != nil && value.TimePeriod.EndTime != nil {
-		if duration, err := value.TimePeriod.EndTime.GetTimeDuration(); err == nil {
+		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
 		}
 	}
@@ -116,7 +116,7 @@ func (e *EgLPP) WriteProductionLimit(
 		return nil, api.ErrDataNotAvailable
 	}
 
-	for index, item := range currentLimits {
+	for _, item := range currentLimits {
 		if item.LimitId == nil ||
 			*item.LimitId != *limitDesc.LimitId {
 			continue
@@ -139,11 +139,18 @@ func (e *EgLPP) WriteProductionLimit(
 			}
 		}
 
-		currentLimits[index] = newLimit
+		limitData = append(limitData, newLimit)
 		break
 	}
 
-	msgCounter, err := loadControl.WriteLimitData(limitData)
+	deleteSelectors := &model.LoadControlLimitListDataSelectorsType{
+		LimitId: limitDesc.LimitId,
+	}
+	deleteElements := &model.LoadControlLimitDataElementsType{
+		TimePeriod: &model.TimePeriodElementsType{},
+	}
+
+	msgCounter, err := loadControl.WriteLimitData(limitData, deleteSelectors, deleteElements)
 
 	return msgCounter, err
 }

--- a/usecases/eg/lpp/public_test.go
+++ b/usecases/eg/lpp/public_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPPSuite) Test_LoadControlLimit() {
+func (s *EgLPPSuite) Test_LoadControlLimit() {
 	data, err := s.sut.ProductionLimit(nil)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data.Value)
@@ -68,7 +68,7 @@ func (s *LPPSuite) Test_LoadControlLimit() {
 	assert.Equal(s.T(), false, data.IsActive)
 }
 
-func (s *LPPSuite) Test_WriteLoadControlLimit() {
+func (s *EgLPPSuite) Test_WriteLoadControlLimit() {
 	limit := ucapi.LoadLimit{
 		Value:    6000,
 		IsActive: true,
@@ -121,7 +121,7 @@ func (s *LPPSuite) Test_WriteLoadControlLimit() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPPSuite) Test_FailsafeProductionActivePowerLimit() {
+func (s *EgLPPSuite) Test_FailsafeProductionActivePowerLimit() {
 	data, err := s.sut.FailsafeProductionActivePowerLimit(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -183,7 +183,7 @@ func (s *LPPSuite) Test_FailsafeProductionActivePowerLimit() {
 	assert.Equal(s.T(), 4000.0, data)
 }
 
-func (s *LPPSuite) Test_WriteFailsafeProductionActivePowerLimit() {
+func (s *EgLPPSuite) Test_WriteFailsafeProductionActivePowerLimit() {
 	_, err := s.sut.WriteFailsafeProductionActivePowerLimit(s.mockRemoteEntity, 6000)
 	assert.NotNil(s.T(), err)
 
@@ -222,7 +222,7 @@ func (s *LPPSuite) Test_WriteFailsafeProductionActivePowerLimit() {
 	assert.Nil(s.T(), err)
 }
 
-func (s *LPPSuite) Test_FailsafeDurationMinimum() {
+func (s *EgLPPSuite) Test_FailsafeDurationMinimum() {
 	data, err := s.sut.FailsafeDurationMinimum(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), time.Duration(0), data)
@@ -284,7 +284,7 @@ func (s *LPPSuite) Test_FailsafeDurationMinimum() {
 	assert.Equal(s.T(), time.Duration(time.Hour*2), data)
 }
 
-func (s *LPPSuite) Test_WriteFailsafeDurationMinimum() {
+func (s *EgLPPSuite) Test_WriteFailsafeDurationMinimum() {
 	_, err := s.sut.WriteFailsafeDurationMinimum(s.mockRemoteEntity, time.Duration(time.Hour*2))
 	assert.NotNil(s.T(), err)
 
@@ -326,7 +326,7 @@ func (s *LPPSuite) Test_WriteFailsafeDurationMinimum() {
 	assert.NotNil(s.T(), err)
 }
 
-func (s *LPPSuite) Test_PowerProductionNominalMax() {
+func (s *EgLPPSuite) Test_PowerProductionNominalMax() {
 	data, err := s.sut.PowerProductionNominalMax(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/eg/lpp/public_test.go
+++ b/usecases/eg/lpp/public_test.go
@@ -114,11 +114,11 @@ func (s *LPPSuite) Test_WriteLoadControlLimit() {
 	assert.Nil(s.T(), fErr)
 
 	_, err = s.sut.WriteProductionLimit(s.monitoredEntity, limit)
-	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), err)
 
 	limit.Duration = time.Duration(time.Hour * 2)
 	_, err = s.sut.WriteProductionLimit(s.monitoredEntity, limit)
-	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), err)
 }
 
 func (s *LPPSuite) Test_FailsafeProductionActivePowerLimit() {

--- a/usecases/eg/lpp/testhelper_test.go
+++ b/usecases/eg/lpp/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestLPPSuite(t *testing.T) {
-	suite.Run(t, new(LPPSuite))
+func TestEgLPPSuite(t *testing.T) {
+	suite.Run(t, new(EgLPPSuite))
 }
 
-type LPPSuite struct {
+type EgLPPSuite struct {
 	suite.Suite
 
 	sut *EgLPP
@@ -37,11 +37,11 @@ type LPPSuite struct {
 	eventCalled bool
 }
 
-func (s *LPPSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *EgLPPSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *LPPSuite) BeforeTest(suiteName, testName string) {
+func (s *EgLPPSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/eg/lpp/usecase.go
+++ b/usecases/eg/lpp/usecase.go
@@ -77,7 +77,7 @@ func (e *EgLPP) IsUseCaseSupported(entity spineapi.EntityRemoteInterface) (bool,
 	// check if the usecase and mandatory scenarios are supported and
 	// if the required server features are available
 	if !entity.Device().VerifyUseCaseScenariosAndFeaturesSupport(
-		model.UseCaseActorTypeEnergyGuard,
+		model.UseCaseActorTypeControllableSystem,
 		e.UseCaseName,
 		[]model.UseCaseScenarioSupportType{1, 2, 3, 4},
 		[]model.FeatureTypeType{

--- a/usecases/eg/lpp/usecase_test.go
+++ b/usecases/eg/lpp/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *LPPSuite) Test_UpdateUseCaseAvailability() {
+func (s *EgLPPSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *LPPSuite) Test_IsUseCaseSupported() {
+func (s *EgLPPSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)
@@ -22,7 +22,7 @@ func (s *LPPSuite) Test_IsUseCaseSupported() {
 	ucData := &model.NodeManagementUseCaseDataType{
 		UseCaseInformation: []model.UseCaseInformationDataType{
 			{
-				Actor: util.Ptr(model.UseCaseActorTypeEnergyGuard),
+				Actor: util.Ptr(model.UseCaseActorTypeControllableSystem),
 				UseCaseSupport: []model.UseCaseSupportType{
 					{
 						UseCaseName:      util.Ptr(model.UseCaseNameTypeLimitationOfPowerProduction),

--- a/usecases/gcp/mgcp/events_test.go
+++ b/usecases/gcp/mgcp/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *MGCPSuite) Test_Events() {
+func (s *GcpMGCPSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -36,7 +36,7 @@ func (s *MGCPSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *MGCPSuite) Test_Failures() {
+func (s *GcpMGCPSuite) Test_Failures() {
 	s.sut.gridConnected(s.mockRemoteEntity)
 
 	s.sut.gridConfigurationDescriptionDataUpdate(s.mockRemoteEntity)
@@ -44,7 +44,7 @@ func (s *MGCPSuite) Test_Failures() {
 	s.sut.gridMeasurementDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *MGCPSuite) Test_gridConfigurationDataUpdate() {
+func (s *GcpMGCPSuite) Test_gridConfigurationDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,
@@ -87,7 +87,7 @@ func (s *MGCPSuite) Test_gridConfigurationDataUpdate() {
 	assert.True(s.T(), s.eventCalled)
 }
 
-func (s *MGCPSuite) Test_gridMeasurementDataUpdate() {
+func (s *GcpMGCPSuite) Test_gridMeasurementDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/gcp/mgcp/public_test.go
+++ b/usecases/gcp/mgcp/public_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *MGCPSuite) Test_PowerLimitationFactor() {
+func (s *GcpMGCPSuite) Test_PowerLimitationFactor() {
 	data, err := s.sut.PowerLimitationFactor(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -52,7 +52,7 @@ func (s *MGCPSuite) Test_PowerLimitationFactor() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *MGCPSuite) Test_Power() {
+func (s *GcpMGCPSuite) Test_Power() {
 	data, err := s.sut.Power(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -130,7 +130,7 @@ func (s *MGCPSuite) Test_Power() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *MGCPSuite) Test_EnergyFeedIn() {
+func (s *GcpMGCPSuite) Test_EnergyFeedIn() {
 	data, err := s.sut.EnergyFeedIn(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -175,7 +175,7 @@ func (s *MGCPSuite) Test_EnergyFeedIn() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *MGCPSuite) Test_EnergyConsumed() {
+func (s *GcpMGCPSuite) Test_EnergyConsumed() {
 	data, err := s.sut.EnergyConsumed(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -220,7 +220,7 @@ func (s *MGCPSuite) Test_EnergyConsumed() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *MGCPSuite) Test_CurrentPerPhase() {
+func (s *GcpMGCPSuite) Test_CurrentPerPhase() {
 	data, err := s.sut.CurrentPerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -325,7 +325,7 @@ func (s *MGCPSuite) Test_CurrentPerPhase() {
 	assert.Equal(s.T(), []float64{10, 10, 10}, data)
 }
 
-func (s *MGCPSuite) Test_VoltagePerPhase() {
+func (s *GcpMGCPSuite) Test_VoltagePerPhase() {
 	data, err := s.sut.VoltagePerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -418,7 +418,7 @@ func (s *MGCPSuite) Test_VoltagePerPhase() {
 	assert.Equal(s.T(), []float64{230, 230, 230}, data)
 }
 
-func (s *MGCPSuite) Test_Frequency() {
+func (s *GcpMGCPSuite) Test_Frequency() {
 	data, err := s.sut.Frequency(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/gcp/mgcp/testhelper_test.go
+++ b/usecases/gcp/mgcp/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestMGCPSuite(t *testing.T) {
-	suite.Run(t, new(MGCPSuite))
+func TestGcpMGCPSuite(t *testing.T) {
+	suite.Run(t, new(GcpMGCPSuite))
 }
 
-type MGCPSuite struct {
+type GcpMGCPSuite struct {
 	suite.Suite
 
 	sut *GcpMGCP
@@ -37,11 +37,11 @@ type MGCPSuite struct {
 	eventCalled bool
 }
 
-func (s *MGCPSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *GcpMGCPSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *MGCPSuite) BeforeTest(suiteName, testName string) {
+func (s *GcpMGCPSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/gcp/mgcp/usecase_test.go
+++ b/usecases/gcp/mgcp/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *MGCPSuite) Test_UpdateUseCaseAvailability() {
+func (s *GcpMGCPSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *MGCPSuite) Test_IsUseCaseSupported() {
+func (s *GcpMGCPSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)

--- a/usecases/internal/loadcontrol.go
+++ b/usecases/internal/loadcontrol.go
@@ -198,7 +198,7 @@ func WriteLoadControlLimits(
 		limitData = append(limitData, newLimit)
 	}
 
-	msgCounter, err := loadControl.WriteLimitData(limitData)
+	msgCounter, err := loadControl.WriteLimitData(limitData, nil, nil)
 
 	return msgCounter, err
 }

--- a/usecases/ma/mpc/events_test.go
+++ b/usecases/ma/mpc/events_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *MPCSuite) Test_Events() {
+func (s *MaMPCSuite) Test_Events() {
 	payload := spineapi.EventPayload{
 		Entity: s.mockRemoteEntity,
 	}
@@ -33,13 +33,13 @@ func (s *MPCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *MPCSuite) Test_Failures() {
+func (s *MaMPCSuite) Test_Failures() {
 	s.sut.deviceConnected(s.mockRemoteEntity)
 
 	s.sut.deviceMeasurementDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
-func (s *MPCSuite) Test_deviceMeasurementDataUpdate() {
+func (s *MaMPCSuite) Test_deviceMeasurementDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,
 		Device: s.remoteDevice,

--- a/usecases/ma/mpc/public_test.go
+++ b/usecases/ma/mpc/public_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *MPCSuite) Test_Power() {
+func (s *MaMPCSuite) Test_Power() {
 	data, err := s.sut.Power(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -84,7 +84,7 @@ func (s *MPCSuite) Test_Power() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *MPCSuite) Test_PowerPerPhase() {
+func (s *MaMPCSuite) Test_PowerPerPhase() {
 	data, err := s.sut.PowerPerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -189,7 +189,7 @@ func (s *MPCSuite) Test_PowerPerPhase() {
 	assert.Equal(s.T(), []float64{10, 10, 10}, data)
 }
 
-func (s *MPCSuite) Test_EnergyConsumed() {
+func (s *MaMPCSuite) Test_EnergyConsumed() {
 	data, err := s.sut.EnergyConsumed(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -234,7 +234,7 @@ func (s *MPCSuite) Test_EnergyConsumed() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *MPCSuite) Test_EnergyProduced() {
+func (s *MaMPCSuite) Test_EnergyProduced() {
 	data, err := s.sut.EnergyProduced(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
@@ -279,7 +279,7 @@ func (s *MPCSuite) Test_EnergyProduced() {
 	assert.Equal(s.T(), 10.0, data)
 }
 
-func (s *MPCSuite) Test_CurrentPerPhase() {
+func (s *MaMPCSuite) Test_CurrentPerPhase() {
 	data, err := s.sut.CurrentPerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -384,7 +384,7 @@ func (s *MPCSuite) Test_CurrentPerPhase() {
 	assert.Equal(s.T(), []float64{10, 10, 10}, data)
 }
 
-func (s *MPCSuite) Test_VoltagePerPhase() {
+func (s *MaMPCSuite) Test_VoltagePerPhase() {
 	data, err := s.sut.VoltagePerPhase(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
@@ -477,7 +477,7 @@ func (s *MPCSuite) Test_VoltagePerPhase() {
 	assert.Equal(s.T(), []float64{230, 230, 230}, data)
 }
 
-func (s *MPCSuite) Test_Frequency() {
+func (s *MaMPCSuite) Test_Frequency() {
 	data, err := s.sut.Frequency(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)

--- a/usecases/ma/mpc/testhelper_test.go
+++ b/usecases/ma/mpc/testhelper_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestMPCSuite(t *testing.T) {
-	suite.Run(t, new(MPCSuite))
+func TestMaMPCSuite(t *testing.T) {
+	suite.Run(t, new(MaMPCSuite))
 }
 
-type MPCSuite struct {
+type MaMPCSuite struct {
 	suite.Suite
 
 	sut *MaMPC
@@ -37,11 +37,11 @@ type MPCSuite struct {
 	eventCalled bool
 }
 
-func (s *MPCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+func (s *MaMPCSuite) Event(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	s.eventCalled = true
 }
 
-func (s *MPCSuite) BeforeTest(suiteName, testName string) {
+func (s *MaMPCSuite) BeforeTest(suiteName, testName string) {
 	s.eventCalled = false
 	cert, _ := cert.CreateCertificate("test", "test", "DE", "test")
 	configuration, _ := api.NewConfiguration(

--- a/usecases/ma/mpc/usecase_test.go
+++ b/usecases/ma/mpc/usecase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *MPCSuite) Test_UpdateUseCaseAvailability() {
+func (s *MaMPCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }
 
-func (s *MPCSuite) Test_IsUseCaseSupported() {
+func (s *MaMPCSuite) Test_IsUseCaseSupported() {
 	data, err := s.sut.IsUseCaseSupported(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), false, data)


### PR DESCRIPTION
- Fix issues in LPC and LPP implementation
- Add support for writing partial deletes in LoadControlLimit client feature
- Add simple cmd control box demo which will send a limit 5s after connecting to a compatible device
- Update cmd EVSE demo to support LPC as a consumable system