### PR TITLE
Add partial read support

### DIFF
--- a/api/featuresclient.go
+++ b/api/featuresclient.go
@@ -10,11 +10,17 @@ type DeviceClassificationClientInterface interface {
 type DeviceConfigurationClientInterface interface {
 	DeviceConfigurationCommonInterface
 
-	// request DeviceConfigurationDescriptionListData from a remote entity
-	RequestDescriptions() (*model.MsgCounterType, error)
+	// request DeviceConfigurationKeyValueDescriptionDataType from a remote entity
+	RequestKeyValueDescriptions(
+		selector *model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType,
+		elements *model.DeviceConfigurationKeyValueDescriptionDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request DeviceConfigurationKeyValueListData from a remote entity
-	RequestKeyValues() (*model.MsgCounterType, error)
+	RequestKeyValues(
+		selector *model.DeviceConfigurationKeyValueListDataSelectorsType,
+		elements *model.DeviceConfigurationKeyValueDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// write key values
 	// returns an error if this failed
@@ -31,16 +37,28 @@ type DeviceDiagnosisClientInterface interface {
 
 type ElectricalConnectionClientInterface interface {
 	// request ElectricalConnectionDescriptionListDataType from a remote entity
-	RequestDescriptions() (*model.MsgCounterType, error)
+	RequestDescriptions(
+		selector *model.ElectricalConnectionDescriptionListDataSelectorsType,
+		elements *model.ElectricalConnectionDescriptionDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeElectricalConnectionParameterDescriptionListData from a remote entity
-	RequestParameterDescriptions() (*model.MsgCounterType, error)
+	RequestParameterDescriptions(
+		selector *model.ElectricalConnectionParameterDescriptionListDataSelectorsType,
+		elements *model.ElectricalConnectionParameterDescriptionDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeElectricalConnectionPermittedValueSetListData from a remote entity
-	RequestPermittedValueSets() (*model.MsgCounterType, error)
+	RequestPermittedValueSets(
+		selector *model.ElectricalConnectionPermittedValueSetListDataSelectorsType,
+		elements *model.ElectricalConnectionPermittedValueSetDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeElectricalConnectionCharacteristicListData from a remote entity
-	RequestCharacteristics() (*model.MsgCounterType, error)
+	RequestCharacteristics(
+		selector *model.ElectricalConnectionCharacteristicListDataSelectorsType,
+		elements *model.ElectricalConnectionCharacteristicDataElementsType,
+	) (*model.MsgCounterType, error)
 }
 
 type IdentificationClientInterface interface {
@@ -69,13 +87,22 @@ type IncentiveTableClientInterface interface {
 
 type LoadControlClientInterface interface {
 	// request FunctionTypeLoadControlLimitDescriptionListData from a remote device
-	RequestLimitDescriptions() (*model.MsgCounterType, error)
+	RequestLimitDescriptions(
+		selector *model.LoadControlLimitDescriptionListDataSelectorsType,
+		elements *model.LoadControlLimitDescriptionDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeLoadControlLimitConstraintsListData from a remote device
-	RequestLimitConstraints() (*model.MsgCounterType, error)
+	RequestLimitConstraints(
+		selector *model.LoadControlLimitConstraintsListDataSelectorsType,
+		elements *model.LoadControlLimitConstraintsDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeLoadControlLimitListData from a remote device
-	RequestLimitData() (*model.MsgCounterType, error)
+	RequestLimitData(
+		selector *model.LoadControlLimitListDataSelectorsType,
+		elements *model.LoadControlLimitDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// write load control limits
 	// returns an error if this failed
@@ -88,13 +115,22 @@ type LoadControlClientInterface interface {
 
 type MeasurementClientInterface interface {
 	// request FunctionTypeMeasurementDescriptionListData from a remote device
-	RequestDescriptions() (*model.MsgCounterType, error)
+	RequestDescriptions(
+		selector *model.MeasurementDescriptionListDataSelectorsType,
+		elements *model.MeasurementDescriptionDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeMeasurementConstraintsListData from a remote entity
-	RequestConstraints() (*model.MsgCounterType, error)
+	RequestConstraints(
+		selector *model.MeasurementConstraintsListDataSelectorsType,
+		elements *model.MeasurementConstraintsDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeMeasurementListData from a remote entity
-	RequestData() (*model.MsgCounterType, error)
+	RequestData(
+		selector *model.MeasurementListDataSelectorsType,
+		elements *model.MeasurementDataElementsType,
+	) (*model.MsgCounterType, error)
 }
 
 type SmartEnergyManagementPsClientInterface interface {
@@ -108,13 +144,22 @@ type SmartEnergyManagementPsClientInterface interface {
 
 type TimeSeriesClientInterface interface {
 	// request FunctionTypeTimeSeriesDescriptionListData from a remote entity
-	RequestDescriptions() (*model.MsgCounterType, error)
+	RequestDescriptions(
+		selector *model.TimeSeriesDescriptionListDataSelectorsType,
+		elements *model.TimeSeriesDescriptionDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeTimeSeriesConstraintsListData from a remote entity
-	RequestConstraints() (*model.MsgCounterType, error)
+	RequestConstraints(
+		selector *model.TimeSeriesConstraintsListDataSelectorsType,
+		elements *model.TimeSeriesConstraintsDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// request FunctionTypeTimeSeriesListData from a remote device
-	RequestData() (*model.MsgCounterType, error)
+	RequestData(
+		selector *model.TimeSeriesListDataSelectorsType,
+		elements *model.TimeSeriesDataElementsType,
+	) (*model.MsgCounterType, error)
 
 	// write Time Series values
 	// returns an error if this failed

--- a/features/client/deviceclassification_test.go
+++ b/features/client/deviceclassification_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -21,7 +20,7 @@ type DeviceClassificationSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	deviceClassification *features.DeviceClassification
+	deviceClassification *DeviceClassification
 	sentMessage          []byte
 }
 
@@ -46,11 +45,11 @@ func (s *DeviceClassificationSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.deviceClassification, err = features.NewDeviceClassification(s.localEntity, nil)
+	s.deviceClassification, err = NewDeviceClassification(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.deviceClassification)
 
-	s.deviceClassification, err = features.NewDeviceClassification(s.localEntity, s.remoteEntity)
+	s.deviceClassification, err = NewDeviceClassification(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.deviceClassification)
 }

--- a/features/client/deviceconfiguration.go
+++ b/features/client/deviceconfiguration.go
@@ -36,14 +36,20 @@ func NewDeviceConfiguration(
 
 var _ api.DeviceConfigurationClientInterface = (*DeviceConfiguration)(nil)
 
-// request DeviceConfiguration data from a remote entity
-func (d *DeviceConfiguration) RequestDescriptions() (*model.MsgCounterType, error) {
-	return d.requestData(model.FunctionTypeDeviceConfigurationKeyValueDescriptionListData, nil, nil)
+// request DeviceConfigurationKeyValueDescriptionDataType from a remote entity
+func (d *DeviceConfiguration) RequestKeyValueDescriptions(
+	selector *model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType,
+	elements *model.DeviceConfigurationKeyValueDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return d.requestData(model.FunctionTypeDeviceConfigurationKeyValueDescriptionListData, selector, elements)
 }
 
-// request DeviceConfigurationKeyValueListDataType from a remote entity
-func (d *DeviceConfiguration) RequestKeyValues() (*model.MsgCounterType, error) {
-	return d.requestData(model.FunctionTypeDeviceConfigurationKeyValueListData, nil, nil)
+// request DeviceConfigurationKeyValueListData from a remote entity
+func (d *DeviceConfiguration) RequestKeyValues(
+	selector *model.DeviceConfigurationKeyValueListDataSelectorsType,
+	elements *model.DeviceConfigurationKeyValueDataElementsType,
+) (*model.MsgCounterType, error) {
+	return d.requestData(model.FunctionTypeDeviceConfigurationKeyValueListData, selector, elements)
 }
 
 // write key values

--- a/features/client/deviceconfiguration_test.go
+++ b/features/client/deviceconfiguration_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipmocks "github.com/enbility/ship-go/mocks"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/mocks"
@@ -25,7 +24,7 @@ type DeviceConfigurationSuite struct {
 	remoteEntity     spineapi.EntityRemoteInterface
 	mockRemoteEntity *mocks.EntityRemoteInterface
 
-	deviceConfiguration *features.DeviceConfiguration
+	deviceConfiguration *DeviceConfiguration
 }
 
 const remoteSki string = "testremoteski"
@@ -60,23 +59,37 @@ func (s *DeviceConfigurationSuite) BeforeTest(suiteName, testName string) {
 	mockRemoteFeature.EXPECT().DataCopy(mock.Anything).Return(mock.Anything).Maybe()
 
 	var err error
-	s.deviceConfiguration, err = features.NewDeviceConfiguration(s.localEntity, nil)
+	s.deviceConfiguration, err = NewDeviceConfiguration(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.deviceConfiguration)
 
-	s.deviceConfiguration, err = features.NewDeviceConfiguration(s.localEntity, s.remoteEntity)
+	s.deviceConfiguration, err = NewDeviceConfiguration(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.deviceConfiguration)
 }
 
-func (s *DeviceConfigurationSuite) Test_RequestDescriptions() {
-	counter, err := s.deviceConfiguration.RequestDescriptions()
+func (s *DeviceConfigurationSuite) Test_RequestKeyValueDescriptions() {
+	counter, err := s.deviceConfiguration.RequestKeyValueDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.deviceConfiguration.RequestKeyValueDescriptions(
+		&model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType{},
+		&model.DeviceConfigurationKeyValueDescriptionDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }
 
 func (s *DeviceConfigurationSuite) Test_RequestKeyValueList() {
-	counter, err := s.deviceConfiguration.RequestKeyValues()
+	counter, err := s.deviceConfiguration.RequestKeyValues(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.deviceConfiguration.RequestKeyValues(
+		&model.DeviceConfigurationKeyValueListDataSelectorsType{},
+		&model.DeviceConfigurationKeyValueDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }

--- a/features/client/devicediagnosis_test.go
+++ b/features/client/devicediagnosis_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -21,7 +20,7 @@ type DeviceDiagnosisSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	deviceDiagnosis *features.DeviceDiagnosis
+	deviceDiagnosis *DeviceDiagnosis
 	sentMessage     []byte
 }
 
@@ -47,11 +46,11 @@ func (s *DeviceDiagnosisSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.deviceDiagnosis, err = features.NewDeviceDiagnosis(s.localEntity, nil)
+	s.deviceDiagnosis, err = NewDeviceDiagnosis(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.deviceDiagnosis)
 
-	s.deviceDiagnosis, err = features.NewDeviceDiagnosis(s.localEntity, s.remoteEntity)
+	s.deviceDiagnosis, err = NewDeviceDiagnosis(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.deviceDiagnosis)
 }

--- a/features/client/electricalconnection.go
+++ b/features/client/electricalconnection.go
@@ -36,21 +36,33 @@ func NewElectricalConnection(
 var _ api.ElectricalConnectionClientInterface = (*ElectricalConnection)(nil)
 
 // request ElectricalConnectionDescriptionListDataType from a remote entity
-func (e *ElectricalConnection) RequestDescriptions() (*model.MsgCounterType, error) {
-	return e.requestData(model.FunctionTypeElectricalConnectionDescriptionListData, nil, nil)
+func (e *ElectricalConnection) RequestDescriptions(
+	selector *model.ElectricalConnectionDescriptionListDataSelectorsType,
+	elements *model.ElectricalConnectionDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return e.requestData(model.FunctionTypeElectricalConnectionDescriptionListData, selector, elements)
 }
 
 // request FunctionTypeElectricalConnectionParameterDescriptionListData from a remote entity
-func (e *ElectricalConnection) RequestParameterDescriptions() (*model.MsgCounterType, error) {
-	return e.requestData(model.FunctionTypeElectricalConnectionParameterDescriptionListData, nil, nil)
+func (e *ElectricalConnection) RequestParameterDescriptions(
+	selector *model.ElectricalConnectionParameterDescriptionListDataSelectorsType,
+	elements *model.ElectricalConnectionParameterDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return e.requestData(model.FunctionTypeElectricalConnectionParameterDescriptionListData, selector, elements)
 }
 
 // request FunctionTypeElectricalConnectionPermittedValueSetListData from a remote entity
-func (e *ElectricalConnection) RequestPermittedValueSets() (*model.MsgCounterType, error) {
-	return e.requestData(model.FunctionTypeElectricalConnectionPermittedValueSetListData, nil, nil)
+func (e *ElectricalConnection) RequestPermittedValueSets(
+	selector *model.ElectricalConnectionPermittedValueSetListDataSelectorsType,
+	elements *model.ElectricalConnectionPermittedValueSetDataElementsType,
+) (*model.MsgCounterType, error) {
+	return e.requestData(model.FunctionTypeElectricalConnectionPermittedValueSetListData, selector, elements)
 }
 
 // request FunctionTypeElectricalConnectionCharacteristicListData from a remote entity
-func (e *ElectricalConnection) RequestCharacteristics() (*model.MsgCounterType, error) {
-	return e.requestData(model.FunctionTypeElectricalConnectionCharacteristicListData, nil, nil)
+func (e *ElectricalConnection) RequestCharacteristics(
+	selector *model.ElectricalConnectionCharacteristicListDataSelectorsType,
+	elements *model.ElectricalConnectionCharacteristicDataElementsType,
+) (*model.MsgCounterType, error) {
+	return e.requestData(model.FunctionTypeElectricalConnectionCharacteristicListData, selector, elements)
 }

--- a/features/client/electricalconnection_test.go
+++ b/features/client/electricalconnection_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -21,7 +20,7 @@ type ElectricalConnectionSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	electricalConnection *features.ElectricalConnection
+	electricalConnection *ElectricalConnection
 	sentMessage          []byte
 }
 
@@ -49,35 +48,63 @@ func (s *ElectricalConnectionSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.electricalConnection, err = features.NewElectricalConnection(s.localEntity, nil)
+	s.electricalConnection, err = NewElectricalConnection(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.electricalConnection)
 
-	s.electricalConnection, err = features.NewElectricalConnection(s.localEntity, s.remoteEntity)
+	s.electricalConnection, err = NewElectricalConnection(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.electricalConnection)
 }
 
 func (s *ElectricalConnectionSuite) Test_RequestDescriptions() {
-	counter, err := s.electricalConnection.RequestDescriptions()
+	counter, err := s.electricalConnection.RequestDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.electricalConnection.RequestDescriptions(
+		&model.ElectricalConnectionDescriptionListDataSelectorsType{},
+		&model.ElectricalConnectionDescriptionDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }
 
 func (s *ElectricalConnectionSuite) Test_RequestParameterDescriptions() {
-	counter, err := s.electricalConnection.RequestParameterDescriptions()
+	counter, err := s.electricalConnection.RequestParameterDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.electricalConnection.RequestParameterDescriptions(
+		&model.ElectricalConnectionParameterDescriptionListDataSelectorsType{},
+		&model.ElectricalConnectionParameterDescriptionDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }
 
 func (s *ElectricalConnectionSuite) Test_RequestPermittedValueSets() {
-	counter, err := s.electricalConnection.RequestPermittedValueSets()
+	counter, err := s.electricalConnection.RequestPermittedValueSets(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.electricalConnection.RequestPermittedValueSets(
+		&model.ElectricalConnectionPermittedValueSetListDataSelectorsType{},
+		&model.ElectricalConnectionPermittedValueSetDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }
 
 func (s *ElectricalConnectionSuite) Test_RequestCharacteristics() {
-	counter, err := s.electricalConnection.RequestCharacteristics()
+	counter, err := s.electricalConnection.RequestCharacteristics(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.electricalConnection.RequestCharacteristics(
+		&model.ElectricalConnectionCharacteristicListDataSelectorsType{},
+		&model.ElectricalConnectionCharacteristicDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }

--- a/features/client/helper_test.go
+++ b/features/client/helper_test.go
@@ -1,4 +1,4 @@
-package client_test
+package client
 
 import (
 	"encoding/json"
@@ -16,6 +16,7 @@ import (
 type featureFunctions struct {
 	featureType model.FeatureTypeType
 	functions   []model.FunctionType
+	partial     bool
 }
 
 type WriteMessageHandler struct {
@@ -150,11 +151,22 @@ func setupFeatures(
 		}
 		var supportedFcts []model.FunctionPropertyType
 		for _, function := range item.functions {
+			read := &model.PossibleOperationsReadType{}
+			write := &model.PossibleOperationsWriteType{}
+			if item.partial {
+				read = &model.PossibleOperationsReadType{
+					Partial: &model.ElementTagType{},
+				}
+				write = &model.PossibleOperationsWriteType{
+					Partial: &model.ElementTagType{},
+				}
+			}
+
 			supportedFct := model.FunctionPropertyType{
 				Function: util.Ptr(function),
 				PossibleOperations: &model.PossibleOperationsType{
-					Read:  &model.PossibleOperationsReadType{},
-					Write: &model.PossibleOperationsWriteType{},
+					Read:  read,
+					Write: write,
 				},
 			}
 

--- a/features/client/identification_test.go
+++ b/features/client/identification_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -21,7 +20,7 @@ type IdentificationSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	identification *features.Identification
+	identification *Identification
 	sentMessage    []byte
 }
 
@@ -46,11 +45,11 @@ func (s *IdentificationSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.identification, err = features.NewIdentification(s.localEntity, nil)
+	s.identification, err = NewIdentification(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.identification)
 
-	s.identification, err = features.NewIdentification(s.localEntity, s.remoteEntity)
+	s.identification, err = NewIdentification(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.identification)
 }

--- a/features/client/incentivetable_test.go
+++ b/features/client/incentivetable_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -22,7 +21,7 @@ type IncentiveTableSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	incentiveTable *features.IncentiveTable
+	incentiveTable *IncentiveTable
 	sentMessage    []byte
 }
 
@@ -49,11 +48,11 @@ func (s *IncentiveTableSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.incentiveTable, err = features.NewIncentiveTable(s.localEntity, nil)
+	s.incentiveTable, err = NewIncentiveTable(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.incentiveTable)
 
-	s.incentiveTable, err = features.NewIncentiveTable(s.localEntity, s.remoteEntity)
+	s.incentiveTable, err = NewIncentiveTable(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.incentiveTable)
 }

--- a/features/client/loadcontrol.go
+++ b/features/client/loadcontrol.go
@@ -37,18 +37,27 @@ func NewLoadControl(
 var _ api.LoadControlClientInterface = (*LoadControl)(nil)
 
 // request FunctionTypeLoadControlLimitDescriptionListData from a remote device
-func (l *LoadControl) RequestLimitDescriptions() (*model.MsgCounterType, error) {
-	return l.requestData(model.FunctionTypeLoadControlLimitDescriptionListData, nil, nil)
+func (l *LoadControl) RequestLimitDescriptions(
+	selector *model.LoadControlLimitDescriptionListDataSelectorsType,
+	elements *model.LoadControlLimitDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return l.requestData(model.FunctionTypeLoadControlLimitDescriptionListData, selector, elements)
 }
 
 // request FunctionTypeLoadControlLimitConstraintsListData from a remote device
-func (l *LoadControl) RequestLimitConstraints() (*model.MsgCounterType, error) {
-	return l.requestData(model.FunctionTypeLoadControlLimitConstraintsListData, nil, nil)
+func (l *LoadControl) RequestLimitConstraints(
+	selector *model.LoadControlLimitConstraintsListDataSelectorsType,
+	elements *model.LoadControlLimitConstraintsDataElementsType,
+) (*model.MsgCounterType, error) {
+	return l.requestData(model.FunctionTypeLoadControlLimitConstraintsListData, selector, elements)
 }
 
 // request FunctionTypeLoadControlLimitListData from a remote device
-func (l *LoadControl) RequestLimitData() (*model.MsgCounterType, error) {
-	return l.requestData(model.FunctionTypeLoadControlLimitListData, nil, nil)
+func (l *LoadControl) RequestLimitData(
+	selector *model.LoadControlLimitListDataSelectorsType,
+	elements *model.LoadControlLimitDataElementsType,
+) (*model.MsgCounterType, error) {
+	return l.requestData(model.FunctionTypeLoadControlLimitListData, selector, elements)
 }
 
 // write load control limits

--- a/features/client/loadcontrol_test.go
+++ b/features/client/loadcontrol_test.go
@@ -1,10 +1,9 @@
-package client_test
+package client
 
 import (
 	"testing"
 	"time"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -23,7 +22,7 @@ type LoadControlSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	loadControl *features.LoadControl
+	loadControl *LoadControl
 	sentMessage []byte
 }
 
@@ -50,29 +49,50 @@ func (s *LoadControlSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.loadControl, err = features.NewLoadControl(s.localEntity, nil)
+	s.loadControl, err = NewLoadControl(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.loadControl)
 
-	s.loadControl, err = features.NewLoadControl(s.localEntity, s.remoteEntity)
+	s.loadControl, err = NewLoadControl(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.loadControl)
 }
 
 func (s *LoadControlSuite) Test_RequestLimitDescription() {
-	counter, err := s.loadControl.RequestLimitDescriptions()
+	counter, err := s.loadControl.RequestLimitDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.loadControl.RequestLimitDescriptions(
+		&model.LoadControlLimitDescriptionListDataSelectorsType{},
+		&model.LoadControlLimitDescriptionDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }
 
 func (s *LoadControlSuite) Test_RequestLimitConstraints() {
-	counter, err := s.loadControl.RequestLimitConstraints()
+	counter, err := s.loadControl.RequestLimitConstraints(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.loadControl.RequestLimitConstraints(
+		&model.LoadControlLimitConstraintsListDataSelectorsType{},
+		&model.LoadControlLimitConstraintsDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }
 
 func (s *LoadControlSuite) Test_RequestLimits() {
-	counter, err := s.loadControl.RequestLimitData()
+	counter, err := s.loadControl.RequestLimitData(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.loadControl.RequestLimitData(
+		&model.LoadControlLimitListDataSelectorsType{},
+		&model.LoadControlLimitDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }

--- a/features/client/measurement.go
+++ b/features/client/measurement.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/enbility/eebus-go/api"
 	"github.com/enbility/eebus-go/features/internal"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -11,6 +12,8 @@ type Measurement struct {
 
 	*internal.MeasurementCommon
 }
+
+var _ api.MeasurementClientInterface = (*Measurement)(nil)
 
 // Get a new Measurement features helper
 //
@@ -33,16 +36,25 @@ func NewMeasurement(
 }
 
 // request FunctionTypeMeasurementDescriptionListData from a remote device
-func (m *Measurement) RequestDescriptions() (*model.MsgCounterType, error) {
-	return m.requestData(model.FunctionTypeMeasurementDescriptionListData, nil, nil)
+func (m *Measurement) RequestDescriptions(
+	selector *model.MeasurementDescriptionListDataSelectorsType,
+	elements *model.MeasurementDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return m.requestData(model.FunctionTypeMeasurementDescriptionListData, selector, elements)
 }
 
 // request FunctionTypeMeasurementConstraintsListData from a remote entity
-func (m *Measurement) RequestConstraints() (*model.MsgCounterType, error) {
-	return m.requestData(model.FunctionTypeMeasurementConstraintsListData, nil, nil)
+func (m *Measurement) RequestConstraints(
+	selector *model.MeasurementConstraintsListDataSelectorsType,
+	elements *model.MeasurementConstraintsDataElementsType,
+) (*model.MsgCounterType, error) {
+	return m.requestData(model.FunctionTypeMeasurementConstraintsListData, selector, elements)
 }
 
 // request FunctionTypeMeasurementListData from a remote entity
-func (m *Measurement) RequestData() (*model.MsgCounterType, error) {
-	return m.requestData(model.FunctionTypeMeasurementListData, nil, nil)
+func (m *Measurement) RequestData(
+	selector *model.MeasurementListDataSelectorsType,
+	elements *model.MeasurementDataElementsType,
+) (*model.MsgCounterType, error) {
+	return m.requestData(model.FunctionTypeMeasurementListData, selector, elements)
 }

--- a/features/client/measurement_test.go
+++ b/features/client/measurement_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -21,7 +20,7 @@ type MeasurementSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	measurement *features.Measurement
+	measurement *Measurement
 	sentMessage []byte
 }
 
@@ -56,29 +55,50 @@ func (s *MeasurementSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.measurement, err = features.NewMeasurement(s.localEntity, nil)
+	s.measurement, err = NewMeasurement(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.measurement)
 
-	s.measurement, err = features.NewMeasurement(s.localEntity, s.remoteEntity)
+	s.measurement, err = NewMeasurement(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.measurement)
 }
 
 func (s *MeasurementSuite) Test_RequestDescriptions() {
-	msgCounter, err := s.measurement.RequestDescriptions()
+	msgCounter, err := s.measurement.RequestDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter)
+
+	msgCounter, err = s.measurement.RequestDescriptions(
+		&model.MeasurementDescriptionListDataSelectorsType{},
+		&model.MeasurementDescriptionDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), msgCounter)
 }
 
 func (s *MeasurementSuite) Test_RequestConstraints() {
-	msgCounter, err := s.measurement.RequestConstraints()
+	msgCounter, err := s.measurement.RequestConstraints(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter)
+
+	msgCounter, err = s.measurement.RequestConstraints(
+		&model.MeasurementConstraintsListDataSelectorsType{},
+		&model.MeasurementConstraintsDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), msgCounter)
 }
 
 func (s *MeasurementSuite) Test_RequestData() {
-	counter, err := s.measurement.RequestData()
+	counter, err := s.measurement.RequestData(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.measurement.RequestData(
+		&model.MeasurementListDataSelectorsType{},
+		&model.MeasurementDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }

--- a/features/client/smartenergymanagementps_test.go
+++ b/features/client/smartenergymanagementps_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -21,7 +20,7 @@ type SmartEnergyManagementPsSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	smartenergymgmtps *features.SmartEnergyManagementPs
+	smartenergymgmtps *SmartEnergyManagementPs
 	sentMessage       []byte
 }
 
@@ -46,11 +45,11 @@ func (s *SmartEnergyManagementPsSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.smartenergymgmtps, err = features.NewSmartEnergyManagementPs(s.localEntity, nil)
+	s.smartenergymgmtps, err = NewSmartEnergyManagementPs(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.smartenergymgmtps)
 
-	s.smartenergymgmtps, err = features.NewSmartEnergyManagementPs(s.localEntity, s.remoteEntity)
+	s.smartenergymgmtps, err = NewSmartEnergyManagementPs(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.smartenergymgmtps)
 }

--- a/features/client/timeseries.go
+++ b/features/client/timeseries.go
@@ -36,18 +36,27 @@ func NewTimeSeries(
 var _ api.TimeSeriesClientInterface = (*TimeSeries)(nil)
 
 // request FunctionTypeTimeSeriesDescriptionListData from a remote entity
-func (t *TimeSeries) RequestDescriptions() (*model.MsgCounterType, error) {
-	return t.requestData(model.FunctionTypeTimeSeriesDescriptionListData, nil, nil)
+func (t *TimeSeries) RequestDescriptions(
+	selector *model.TimeSeriesDescriptionListDataSelectorsType,
+	elements *model.TimeSeriesDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return t.requestData(model.FunctionTypeTimeSeriesDescriptionListData, selector, elements)
 }
 
 // request FunctionTypeTimeSeriesConstraintsListData from a remote entity
-func (t *TimeSeries) RequestConstraints() (*model.MsgCounterType, error) {
-	return t.requestData(model.FunctionTypeTimeSeriesConstraintsListData, nil, nil)
+func (t *TimeSeries) RequestConstraints(
+	selector *model.TimeSeriesConstraintsListDataSelectorsType,
+	elements *model.TimeSeriesConstraintsDataElementsType,
+) (*model.MsgCounterType, error) {
+	return t.requestData(model.FunctionTypeTimeSeriesConstraintsListData, selector, elements)
 }
 
 // request FunctionTypeTimeSeriesListData from a remote device
-func (t *TimeSeries) RequestData() (*model.MsgCounterType, error) {
-	return t.requestData(model.FunctionTypeTimeSeriesListData, nil, nil)
+func (t *TimeSeries) RequestData(
+	selector *model.TimeSeriesListDataSelectorsType,
+	elements *model.TimeSeriesDataElementsType,
+) (*model.MsgCounterType, error) {
+	return t.requestData(model.FunctionTypeTimeSeriesListData, selector, elements)
 }
 
 // write Time Series values

--- a/features/client/timeseries_test.go
+++ b/features/client/timeseries_test.go
@@ -1,9 +1,8 @@
-package client_test
+package client
 
 import (
 	"testing"
 
-	features "github.com/enbility/eebus-go/features/client"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -22,7 +21,7 @@ type TimeSeriesSuite struct {
 	localEntity  spineapi.EntityLocalInterface
 	remoteEntity spineapi.EntityRemoteInterface
 
-	timeSeries  *features.TimeSeries
+	timeSeries  *TimeSeries
 	sentMessage []byte
 }
 
@@ -49,29 +48,50 @@ func (s *TimeSeriesSuite) BeforeTest(suiteName, testName string) {
 	)
 
 	var err error
-	s.timeSeries, err = features.NewTimeSeries(s.localEntity, nil)
+	s.timeSeries, err = NewTimeSeries(s.localEntity, nil)
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), s.timeSeries)
 
-	s.timeSeries, err = features.NewTimeSeries(s.localEntity, s.remoteEntity)
+	s.timeSeries, err = NewTimeSeries(s.localEntity, s.remoteEntity)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), s.timeSeries)
 }
 
 func (s *TimeSeriesSuite) Test_RequestDescription() {
-	msgCounter, err := s.timeSeries.RequestDescriptions()
+	msgCounter, err := s.timeSeries.RequestDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter)
+
+	msgCounter, err = s.timeSeries.RequestDescriptions(
+		&model.TimeSeriesDescriptionListDataSelectorsType{},
+		&model.TimeSeriesDescriptionDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), msgCounter)
 }
 
 func (s *TimeSeriesSuite) Test_RequestConstraints() {
-	msgCounter, err := s.timeSeries.RequestConstraints()
+	msgCounter, err := s.timeSeries.RequestConstraints(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter)
+
+	msgCounter, err = s.timeSeries.RequestConstraints(
+		&model.TimeSeriesConstraintsListDataSelectorsType{},
+		&model.TimeSeriesConstraintsDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), msgCounter)
 }
 
 func (s *TimeSeriesSuite) Test_RequestData() {
-	counter, err := s.timeSeries.RequestData()
+	counter, err := s.timeSeries.RequestData(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+
+	counter, err = s.timeSeries.RequestData(
+		&model.TimeSeriesListDataSelectorsType{},
+		&model.TimeSeriesDataElementsType{},
+	)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.1
 
 require (
 	github.com/enbility/ship-go v0.5.0
-	github.com/enbility/spine-go v0.0.0-20240602103422-c96bc14d05b0
+	github.com/enbility/spine-go v0.0.0-20240602174658-bd2d85f71c67
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/enbility/ship-go v0.5.0 h1:Uqol2XjzDOcvT8HUAE4B/59yqd3mxhpJJ/Q2eDHNGqc=
 github.com/enbility/ship-go v0.5.0/go.mod h1:ovyrJE3oPnGT5+eQnOqWut80gFDQ0XHn3ZWU2fHV9xQ=
-github.com/enbility/spine-go v0.0.0-20240602103422-c96bc14d05b0 h1:4ACDaDZmYfJBv0TZiiyiNQvO1n4qy+Sn2u+EICPk35g=
-github.com/enbility/spine-go v0.0.0-20240602103422-c96bc14d05b0/go.mod h1:CLgAK5d4kdoZy2/Xmz9svXfwmmvazi13bs2FK2jW5WU=
+github.com/enbility/spine-go v0.0.0-20240602174658-bd2d85f71c67 h1:LJAp3IuqQzcJG6/gwh6YoQqOgyNKr9wQe9Ke871zu6E=
+github.com/enbility/spine-go v0.0.0-20240602174658-bd2d85f71c67/go.mod h1:CLgAK5d4kdoZy2/Xmz9svXfwmmvazi13bs2FK2jW5WU=
 github.com/enbility/zeroconf/v2 v2.0.0-20240210101930-d0004078577b h1:sg3c6LJ4eWffwtt9SW0lgcIX4Oh274vwdJnNFNNrDco=
 github.com/enbility/zeroconf/v2 v2.0.0-20240210101930-d0004078577b/go.mod h1:BjzRRiYX6mWdOgku1xxDE+NsV8PijTby7Q7BkYVdfDU=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=

--- a/mocks/DeviceConfigurationClientInterface.go
+++ b/mocks/DeviceConfigurationClientInterface.go
@@ -299,29 +299,29 @@ func (_c *DeviceConfigurationClientInterface_GetKeyValueDescriptionsForFilter_Ca
 	return _c
 }
 
-// RequestDescriptions provides a mock function with given fields:
-func (_m *DeviceConfigurationClientInterface) RequestDescriptions() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestKeyValueDescriptions provides a mock function with given fields: selector, elements
+func (_m *DeviceConfigurationClientInterface) RequestKeyValueDescriptions(selector *model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType, elements *model.DeviceConfigurationKeyValueDescriptionDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
-		panic("no return value specified for RequestDescriptions")
+		panic("no return value specified for RequestKeyValueDescriptions")
 	}
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType, *model.DeviceConfigurationKeyValueDescriptionDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType, *model.DeviceConfigurationKeyValueDescriptionDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType, *model.DeviceConfigurationKeyValueDescriptionDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -329,36 +329,38 @@ func (_m *DeviceConfigurationClientInterface) RequestDescriptions() (*model.MsgC
 	return r0, r1
 }
 
-// DeviceConfigurationClientInterface_RequestDescriptions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RequestDescriptions'
-type DeviceConfigurationClientInterface_RequestDescriptions_Call struct {
+// DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RequestKeyValueDescriptions'
+type DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call struct {
 	*mock.Call
 }
 
-// RequestDescriptions is a helper method to define mock.On call
-func (_e *DeviceConfigurationClientInterface_Expecter) RequestDescriptions() *DeviceConfigurationClientInterface_RequestDescriptions_Call {
-	return &DeviceConfigurationClientInterface_RequestDescriptions_Call{Call: _e.mock.On("RequestDescriptions")}
+// RequestKeyValueDescriptions is a helper method to define mock.On call
+//   - selector *model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType
+//   - elements *model.DeviceConfigurationKeyValueDescriptionDataElementsType
+func (_e *DeviceConfigurationClientInterface_Expecter) RequestKeyValueDescriptions(selector interface{}, elements interface{}) *DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call {
+	return &DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call{Call: _e.mock.On("RequestKeyValueDescriptions", selector, elements)}
 }
 
-func (_c *DeviceConfigurationClientInterface_RequestDescriptions_Call) Run(run func()) *DeviceConfigurationClientInterface_RequestDescriptions_Call {
+func (_c *DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call) Run(run func(selector *model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType, elements *model.DeviceConfigurationKeyValueDescriptionDataElementsType)) *DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType), args[1].(*model.DeviceConfigurationKeyValueDescriptionDataElementsType))
 	})
 	return _c
 }
 
-func (_c *DeviceConfigurationClientInterface_RequestDescriptions_Call) Return(_a0 *model.MsgCounterType, _a1 error) *DeviceConfigurationClientInterface_RequestDescriptions_Call {
+func (_c *DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call) Return(_a0 *model.MsgCounterType, _a1 error) *DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *DeviceConfigurationClientInterface_RequestDescriptions_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *DeviceConfigurationClientInterface_RequestDescriptions_Call {
+func (_c *DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call) RunAndReturn(run func(*model.DeviceConfigurationKeyValueDescriptionListDataSelectorsType, *model.DeviceConfigurationKeyValueDescriptionDataElementsType) (*model.MsgCounterType, error)) *DeviceConfigurationClientInterface_RequestKeyValueDescriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestKeyValues provides a mock function with given fields:
-func (_m *DeviceConfigurationClientInterface) RequestKeyValues() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestKeyValues provides a mock function with given fields: selector, elements
+func (_m *DeviceConfigurationClientInterface) RequestKeyValues(selector *model.DeviceConfigurationKeyValueListDataSelectorsType, elements *model.DeviceConfigurationKeyValueDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestKeyValues")
@@ -366,19 +368,19 @@ func (_m *DeviceConfigurationClientInterface) RequestKeyValues() (*model.MsgCoun
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.DeviceConfigurationKeyValueListDataSelectorsType, *model.DeviceConfigurationKeyValueDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.DeviceConfigurationKeyValueListDataSelectorsType, *model.DeviceConfigurationKeyValueDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.DeviceConfigurationKeyValueListDataSelectorsType, *model.DeviceConfigurationKeyValueDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -392,13 +394,15 @@ type DeviceConfigurationClientInterface_RequestKeyValues_Call struct {
 }
 
 // RequestKeyValues is a helper method to define mock.On call
-func (_e *DeviceConfigurationClientInterface_Expecter) RequestKeyValues() *DeviceConfigurationClientInterface_RequestKeyValues_Call {
-	return &DeviceConfigurationClientInterface_RequestKeyValues_Call{Call: _e.mock.On("RequestKeyValues")}
+//   - selector *model.DeviceConfigurationKeyValueListDataSelectorsType
+//   - elements *model.DeviceConfigurationKeyValueDataElementsType
+func (_e *DeviceConfigurationClientInterface_Expecter) RequestKeyValues(selector interface{}, elements interface{}) *DeviceConfigurationClientInterface_RequestKeyValues_Call {
+	return &DeviceConfigurationClientInterface_RequestKeyValues_Call{Call: _e.mock.On("RequestKeyValues", selector, elements)}
 }
 
-func (_c *DeviceConfigurationClientInterface_RequestKeyValues_Call) Run(run func()) *DeviceConfigurationClientInterface_RequestKeyValues_Call {
+func (_c *DeviceConfigurationClientInterface_RequestKeyValues_Call) Run(run func(selector *model.DeviceConfigurationKeyValueListDataSelectorsType, elements *model.DeviceConfigurationKeyValueDataElementsType)) *DeviceConfigurationClientInterface_RequestKeyValues_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.DeviceConfigurationKeyValueListDataSelectorsType), args[1].(*model.DeviceConfigurationKeyValueDataElementsType))
 	})
 	return _c
 }
@@ -408,7 +412,7 @@ func (_c *DeviceConfigurationClientInterface_RequestKeyValues_Call) Return(_a0 *
 	return _c
 }
 
-func (_c *DeviceConfigurationClientInterface_RequestKeyValues_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *DeviceConfigurationClientInterface_RequestKeyValues_Call {
+func (_c *DeviceConfigurationClientInterface_RequestKeyValues_Call) RunAndReturn(run func(*model.DeviceConfigurationKeyValueListDataSelectorsType, *model.DeviceConfigurationKeyValueDataElementsType) (*model.MsgCounterType, error)) *DeviceConfigurationClientInterface_RequestKeyValues_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/ElectricalConnectionClientInterface.go
+++ b/mocks/ElectricalConnectionClientInterface.go
@@ -20,9 +20,9 @@ func (_m *ElectricalConnectionClientInterface) EXPECT() *ElectricalConnectionCli
 	return &ElectricalConnectionClientInterface_Expecter{mock: &_m.Mock}
 }
 
-// RequestCharacteristics provides a mock function with given fields:
-func (_m *ElectricalConnectionClientInterface) RequestCharacteristics() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestCharacteristics provides a mock function with given fields: selector, elements
+func (_m *ElectricalConnectionClientInterface) RequestCharacteristics(selector *model.ElectricalConnectionCharacteristicListDataSelectorsType, elements *model.ElectricalConnectionCharacteristicDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestCharacteristics")
@@ -30,19 +30,19 @@ func (_m *ElectricalConnectionClientInterface) RequestCharacteristics() (*model.
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionCharacteristicListDataSelectorsType, *model.ElectricalConnectionCharacteristicDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionCharacteristicListDataSelectorsType, *model.ElectricalConnectionCharacteristicDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.ElectricalConnectionCharacteristicListDataSelectorsType, *model.ElectricalConnectionCharacteristicDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,13 +56,15 @@ type ElectricalConnectionClientInterface_RequestCharacteristics_Call struct {
 }
 
 // RequestCharacteristics is a helper method to define mock.On call
-func (_e *ElectricalConnectionClientInterface_Expecter) RequestCharacteristics() *ElectricalConnectionClientInterface_RequestCharacteristics_Call {
-	return &ElectricalConnectionClientInterface_RequestCharacteristics_Call{Call: _e.mock.On("RequestCharacteristics")}
+//   - selector *model.ElectricalConnectionCharacteristicListDataSelectorsType
+//   - elements *model.ElectricalConnectionCharacteristicDataElementsType
+func (_e *ElectricalConnectionClientInterface_Expecter) RequestCharacteristics(selector interface{}, elements interface{}) *ElectricalConnectionClientInterface_RequestCharacteristics_Call {
+	return &ElectricalConnectionClientInterface_RequestCharacteristics_Call{Call: _e.mock.On("RequestCharacteristics", selector, elements)}
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestCharacteristics_Call) Run(run func()) *ElectricalConnectionClientInterface_RequestCharacteristics_Call {
+func (_c *ElectricalConnectionClientInterface_RequestCharacteristics_Call) Run(run func(selector *model.ElectricalConnectionCharacteristicListDataSelectorsType, elements *model.ElectricalConnectionCharacteristicDataElementsType)) *ElectricalConnectionClientInterface_RequestCharacteristics_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.ElectricalConnectionCharacteristicListDataSelectorsType), args[1].(*model.ElectricalConnectionCharacteristicDataElementsType))
 	})
 	return _c
 }
@@ -72,14 +74,14 @@ func (_c *ElectricalConnectionClientInterface_RequestCharacteristics_Call) Retur
 	return _c
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestCharacteristics_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestCharacteristics_Call {
+func (_c *ElectricalConnectionClientInterface_RequestCharacteristics_Call) RunAndReturn(run func(*model.ElectricalConnectionCharacteristicListDataSelectorsType, *model.ElectricalConnectionCharacteristicDataElementsType) (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestCharacteristics_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestDescriptions provides a mock function with given fields:
-func (_m *ElectricalConnectionClientInterface) RequestDescriptions() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestDescriptions provides a mock function with given fields: selector, elements
+func (_m *ElectricalConnectionClientInterface) RequestDescriptions(selector *model.ElectricalConnectionDescriptionListDataSelectorsType, elements *model.ElectricalConnectionDescriptionDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestDescriptions")
@@ -87,19 +89,19 @@ func (_m *ElectricalConnectionClientInterface) RequestDescriptions() (*model.Msg
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionDescriptionListDataSelectorsType, *model.ElectricalConnectionDescriptionDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionDescriptionListDataSelectorsType, *model.ElectricalConnectionDescriptionDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.ElectricalConnectionDescriptionListDataSelectorsType, *model.ElectricalConnectionDescriptionDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -113,13 +115,15 @@ type ElectricalConnectionClientInterface_RequestDescriptions_Call struct {
 }
 
 // RequestDescriptions is a helper method to define mock.On call
-func (_e *ElectricalConnectionClientInterface_Expecter) RequestDescriptions() *ElectricalConnectionClientInterface_RequestDescriptions_Call {
-	return &ElectricalConnectionClientInterface_RequestDescriptions_Call{Call: _e.mock.On("RequestDescriptions")}
+//   - selector *model.ElectricalConnectionDescriptionListDataSelectorsType
+//   - elements *model.ElectricalConnectionDescriptionDataElementsType
+func (_e *ElectricalConnectionClientInterface_Expecter) RequestDescriptions(selector interface{}, elements interface{}) *ElectricalConnectionClientInterface_RequestDescriptions_Call {
+	return &ElectricalConnectionClientInterface_RequestDescriptions_Call{Call: _e.mock.On("RequestDescriptions", selector, elements)}
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestDescriptions_Call) Run(run func()) *ElectricalConnectionClientInterface_RequestDescriptions_Call {
+func (_c *ElectricalConnectionClientInterface_RequestDescriptions_Call) Run(run func(selector *model.ElectricalConnectionDescriptionListDataSelectorsType, elements *model.ElectricalConnectionDescriptionDataElementsType)) *ElectricalConnectionClientInterface_RequestDescriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.ElectricalConnectionDescriptionListDataSelectorsType), args[1].(*model.ElectricalConnectionDescriptionDataElementsType))
 	})
 	return _c
 }
@@ -129,14 +133,14 @@ func (_c *ElectricalConnectionClientInterface_RequestDescriptions_Call) Return(_
 	return _c
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestDescriptions_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestDescriptions_Call {
+func (_c *ElectricalConnectionClientInterface_RequestDescriptions_Call) RunAndReturn(run func(*model.ElectricalConnectionDescriptionListDataSelectorsType, *model.ElectricalConnectionDescriptionDataElementsType) (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestDescriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestParameterDescriptions provides a mock function with given fields:
-func (_m *ElectricalConnectionClientInterface) RequestParameterDescriptions() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestParameterDescriptions provides a mock function with given fields: selector, elements
+func (_m *ElectricalConnectionClientInterface) RequestParameterDescriptions(selector *model.ElectricalConnectionParameterDescriptionListDataSelectorsType, elements *model.ElectricalConnectionParameterDescriptionDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestParameterDescriptions")
@@ -144,19 +148,19 @@ func (_m *ElectricalConnectionClientInterface) RequestParameterDescriptions() (*
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionParameterDescriptionListDataSelectorsType, *model.ElectricalConnectionParameterDescriptionDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionParameterDescriptionListDataSelectorsType, *model.ElectricalConnectionParameterDescriptionDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.ElectricalConnectionParameterDescriptionListDataSelectorsType, *model.ElectricalConnectionParameterDescriptionDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -170,13 +174,15 @@ type ElectricalConnectionClientInterface_RequestParameterDescriptions_Call struc
 }
 
 // RequestParameterDescriptions is a helper method to define mock.On call
-func (_e *ElectricalConnectionClientInterface_Expecter) RequestParameterDescriptions() *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call {
-	return &ElectricalConnectionClientInterface_RequestParameterDescriptions_Call{Call: _e.mock.On("RequestParameterDescriptions")}
+//   - selector *model.ElectricalConnectionParameterDescriptionListDataSelectorsType
+//   - elements *model.ElectricalConnectionParameterDescriptionDataElementsType
+func (_e *ElectricalConnectionClientInterface_Expecter) RequestParameterDescriptions(selector interface{}, elements interface{}) *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call {
+	return &ElectricalConnectionClientInterface_RequestParameterDescriptions_Call{Call: _e.mock.On("RequestParameterDescriptions", selector, elements)}
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call) Run(run func()) *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call {
+func (_c *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call) Run(run func(selector *model.ElectricalConnectionParameterDescriptionListDataSelectorsType, elements *model.ElectricalConnectionParameterDescriptionDataElementsType)) *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.ElectricalConnectionParameterDescriptionListDataSelectorsType), args[1].(*model.ElectricalConnectionParameterDescriptionDataElementsType))
 	})
 	return _c
 }
@@ -186,14 +192,14 @@ func (_c *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call)
 	return _c
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call {
+func (_c *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call) RunAndReturn(run func(*model.ElectricalConnectionParameterDescriptionListDataSelectorsType, *model.ElectricalConnectionParameterDescriptionDataElementsType) (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestParameterDescriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestPermittedValueSets provides a mock function with given fields:
-func (_m *ElectricalConnectionClientInterface) RequestPermittedValueSets() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestPermittedValueSets provides a mock function with given fields: selector, elements
+func (_m *ElectricalConnectionClientInterface) RequestPermittedValueSets(selector *model.ElectricalConnectionPermittedValueSetListDataSelectorsType, elements *model.ElectricalConnectionPermittedValueSetDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestPermittedValueSets")
@@ -201,19 +207,19 @@ func (_m *ElectricalConnectionClientInterface) RequestPermittedValueSets() (*mod
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionPermittedValueSetListDataSelectorsType, *model.ElectricalConnectionPermittedValueSetDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.ElectricalConnectionPermittedValueSetListDataSelectorsType, *model.ElectricalConnectionPermittedValueSetDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.ElectricalConnectionPermittedValueSetListDataSelectorsType, *model.ElectricalConnectionPermittedValueSetDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -227,13 +233,15 @@ type ElectricalConnectionClientInterface_RequestPermittedValueSets_Call struct {
 }
 
 // RequestPermittedValueSets is a helper method to define mock.On call
-func (_e *ElectricalConnectionClientInterface_Expecter) RequestPermittedValueSets() *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call {
-	return &ElectricalConnectionClientInterface_RequestPermittedValueSets_Call{Call: _e.mock.On("RequestPermittedValueSets")}
+//   - selector *model.ElectricalConnectionPermittedValueSetListDataSelectorsType
+//   - elements *model.ElectricalConnectionPermittedValueSetDataElementsType
+func (_e *ElectricalConnectionClientInterface_Expecter) RequestPermittedValueSets(selector interface{}, elements interface{}) *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call {
+	return &ElectricalConnectionClientInterface_RequestPermittedValueSets_Call{Call: _e.mock.On("RequestPermittedValueSets", selector, elements)}
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call) Run(run func()) *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call {
+func (_c *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call) Run(run func(selector *model.ElectricalConnectionPermittedValueSetListDataSelectorsType, elements *model.ElectricalConnectionPermittedValueSetDataElementsType)) *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.ElectricalConnectionPermittedValueSetListDataSelectorsType), args[1].(*model.ElectricalConnectionPermittedValueSetDataElementsType))
 	})
 	return _c
 }
@@ -243,7 +251,7 @@ func (_c *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call) Re
 	return _c
 }
 
-func (_c *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call {
+func (_c *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call) RunAndReturn(run func(*model.ElectricalConnectionPermittedValueSetListDataSelectorsType, *model.ElectricalConnectionPermittedValueSetDataElementsType) (*model.MsgCounterType, error)) *ElectricalConnectionClientInterface_RequestPermittedValueSets_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/LoadControlClientInterface.go
+++ b/mocks/LoadControlClientInterface.go
@@ -20,9 +20,9 @@ func (_m *LoadControlClientInterface) EXPECT() *LoadControlClientInterface_Expec
 	return &LoadControlClientInterface_Expecter{mock: &_m.Mock}
 }
 
-// RequestLimitConstraints provides a mock function with given fields:
-func (_m *LoadControlClientInterface) RequestLimitConstraints() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestLimitConstraints provides a mock function with given fields: selector, elements
+func (_m *LoadControlClientInterface) RequestLimitConstraints(selector *model.LoadControlLimitConstraintsListDataSelectorsType, elements *model.LoadControlLimitConstraintsDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestLimitConstraints")
@@ -30,19 +30,19 @@ func (_m *LoadControlClientInterface) RequestLimitConstraints() (*model.MsgCount
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.LoadControlLimitConstraintsListDataSelectorsType, *model.LoadControlLimitConstraintsDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.LoadControlLimitConstraintsListDataSelectorsType, *model.LoadControlLimitConstraintsDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.LoadControlLimitConstraintsListDataSelectorsType, *model.LoadControlLimitConstraintsDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,13 +56,15 @@ type LoadControlClientInterface_RequestLimitConstraints_Call struct {
 }
 
 // RequestLimitConstraints is a helper method to define mock.On call
-func (_e *LoadControlClientInterface_Expecter) RequestLimitConstraints() *LoadControlClientInterface_RequestLimitConstraints_Call {
-	return &LoadControlClientInterface_RequestLimitConstraints_Call{Call: _e.mock.On("RequestLimitConstraints")}
+//   - selector *model.LoadControlLimitConstraintsListDataSelectorsType
+//   - elements *model.LoadControlLimitConstraintsDataElementsType
+func (_e *LoadControlClientInterface_Expecter) RequestLimitConstraints(selector interface{}, elements interface{}) *LoadControlClientInterface_RequestLimitConstraints_Call {
+	return &LoadControlClientInterface_RequestLimitConstraints_Call{Call: _e.mock.On("RequestLimitConstraints", selector, elements)}
 }
 
-func (_c *LoadControlClientInterface_RequestLimitConstraints_Call) Run(run func()) *LoadControlClientInterface_RequestLimitConstraints_Call {
+func (_c *LoadControlClientInterface_RequestLimitConstraints_Call) Run(run func(selector *model.LoadControlLimitConstraintsListDataSelectorsType, elements *model.LoadControlLimitConstraintsDataElementsType)) *LoadControlClientInterface_RequestLimitConstraints_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.LoadControlLimitConstraintsListDataSelectorsType), args[1].(*model.LoadControlLimitConstraintsDataElementsType))
 	})
 	return _c
 }
@@ -72,14 +74,14 @@ func (_c *LoadControlClientInterface_RequestLimitConstraints_Call) Return(_a0 *m
 	return _c
 }
 
-func (_c *LoadControlClientInterface_RequestLimitConstraints_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *LoadControlClientInterface_RequestLimitConstraints_Call {
+func (_c *LoadControlClientInterface_RequestLimitConstraints_Call) RunAndReturn(run func(*model.LoadControlLimitConstraintsListDataSelectorsType, *model.LoadControlLimitConstraintsDataElementsType) (*model.MsgCounterType, error)) *LoadControlClientInterface_RequestLimitConstraints_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestLimitData provides a mock function with given fields:
-func (_m *LoadControlClientInterface) RequestLimitData() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestLimitData provides a mock function with given fields: selector, elements
+func (_m *LoadControlClientInterface) RequestLimitData(selector *model.LoadControlLimitListDataSelectorsType, elements *model.LoadControlLimitDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestLimitData")
@@ -87,19 +89,19 @@ func (_m *LoadControlClientInterface) RequestLimitData() (*model.MsgCounterType,
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -113,13 +115,15 @@ type LoadControlClientInterface_RequestLimitData_Call struct {
 }
 
 // RequestLimitData is a helper method to define mock.On call
-func (_e *LoadControlClientInterface_Expecter) RequestLimitData() *LoadControlClientInterface_RequestLimitData_Call {
-	return &LoadControlClientInterface_RequestLimitData_Call{Call: _e.mock.On("RequestLimitData")}
+//   - selector *model.LoadControlLimitListDataSelectorsType
+//   - elements *model.LoadControlLimitDataElementsType
+func (_e *LoadControlClientInterface_Expecter) RequestLimitData(selector interface{}, elements interface{}) *LoadControlClientInterface_RequestLimitData_Call {
+	return &LoadControlClientInterface_RequestLimitData_Call{Call: _e.mock.On("RequestLimitData", selector, elements)}
 }
 
-func (_c *LoadControlClientInterface_RequestLimitData_Call) Run(run func()) *LoadControlClientInterface_RequestLimitData_Call {
+func (_c *LoadControlClientInterface_RequestLimitData_Call) Run(run func(selector *model.LoadControlLimitListDataSelectorsType, elements *model.LoadControlLimitDataElementsType)) *LoadControlClientInterface_RequestLimitData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.LoadControlLimitListDataSelectorsType), args[1].(*model.LoadControlLimitDataElementsType))
 	})
 	return _c
 }
@@ -129,14 +133,14 @@ func (_c *LoadControlClientInterface_RequestLimitData_Call) Return(_a0 *model.Ms
 	return _c
 }
 
-func (_c *LoadControlClientInterface_RequestLimitData_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *LoadControlClientInterface_RequestLimitData_Call {
+func (_c *LoadControlClientInterface_RequestLimitData_Call) RunAndReturn(run func(*model.LoadControlLimitListDataSelectorsType, *model.LoadControlLimitDataElementsType) (*model.MsgCounterType, error)) *LoadControlClientInterface_RequestLimitData_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestLimitDescriptions provides a mock function with given fields:
-func (_m *LoadControlClientInterface) RequestLimitDescriptions() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestLimitDescriptions provides a mock function with given fields: selector, elements
+func (_m *LoadControlClientInterface) RequestLimitDescriptions(selector *model.LoadControlLimitDescriptionListDataSelectorsType, elements *model.LoadControlLimitDescriptionDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestLimitDescriptions")
@@ -144,19 +148,19 @@ func (_m *LoadControlClientInterface) RequestLimitDescriptions() (*model.MsgCoun
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.LoadControlLimitDescriptionListDataSelectorsType, *model.LoadControlLimitDescriptionDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.LoadControlLimitDescriptionListDataSelectorsType, *model.LoadControlLimitDescriptionDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.LoadControlLimitDescriptionListDataSelectorsType, *model.LoadControlLimitDescriptionDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -170,13 +174,15 @@ type LoadControlClientInterface_RequestLimitDescriptions_Call struct {
 }
 
 // RequestLimitDescriptions is a helper method to define mock.On call
-func (_e *LoadControlClientInterface_Expecter) RequestLimitDescriptions() *LoadControlClientInterface_RequestLimitDescriptions_Call {
-	return &LoadControlClientInterface_RequestLimitDescriptions_Call{Call: _e.mock.On("RequestLimitDescriptions")}
+//   - selector *model.LoadControlLimitDescriptionListDataSelectorsType
+//   - elements *model.LoadControlLimitDescriptionDataElementsType
+func (_e *LoadControlClientInterface_Expecter) RequestLimitDescriptions(selector interface{}, elements interface{}) *LoadControlClientInterface_RequestLimitDescriptions_Call {
+	return &LoadControlClientInterface_RequestLimitDescriptions_Call{Call: _e.mock.On("RequestLimitDescriptions", selector, elements)}
 }
 
-func (_c *LoadControlClientInterface_RequestLimitDescriptions_Call) Run(run func()) *LoadControlClientInterface_RequestLimitDescriptions_Call {
+func (_c *LoadControlClientInterface_RequestLimitDescriptions_Call) Run(run func(selector *model.LoadControlLimitDescriptionListDataSelectorsType, elements *model.LoadControlLimitDescriptionDataElementsType)) *LoadControlClientInterface_RequestLimitDescriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.LoadControlLimitDescriptionListDataSelectorsType), args[1].(*model.LoadControlLimitDescriptionDataElementsType))
 	})
 	return _c
 }
@@ -186,7 +192,7 @@ func (_c *LoadControlClientInterface_RequestLimitDescriptions_Call) Return(_a0 *
 	return _c
 }
 
-func (_c *LoadControlClientInterface_RequestLimitDescriptions_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *LoadControlClientInterface_RequestLimitDescriptions_Call {
+func (_c *LoadControlClientInterface_RequestLimitDescriptions_Call) RunAndReturn(run func(*model.LoadControlLimitDescriptionListDataSelectorsType, *model.LoadControlLimitDescriptionDataElementsType) (*model.MsgCounterType, error)) *LoadControlClientInterface_RequestLimitDescriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/MeasurementClientInterface.go
+++ b/mocks/MeasurementClientInterface.go
@@ -20,9 +20,9 @@ func (_m *MeasurementClientInterface) EXPECT() *MeasurementClientInterface_Expec
 	return &MeasurementClientInterface_Expecter{mock: &_m.Mock}
 }
 
-// RequestConstraints provides a mock function with given fields:
-func (_m *MeasurementClientInterface) RequestConstraints() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestConstraints provides a mock function with given fields: selector, elements
+func (_m *MeasurementClientInterface) RequestConstraints(selector *model.MeasurementConstraintsListDataSelectorsType, elements *model.MeasurementConstraintsDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestConstraints")
@@ -30,19 +30,19 @@ func (_m *MeasurementClientInterface) RequestConstraints() (*model.MsgCounterTyp
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.MeasurementConstraintsListDataSelectorsType, *model.MeasurementConstraintsDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.MeasurementConstraintsListDataSelectorsType, *model.MeasurementConstraintsDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.MeasurementConstraintsListDataSelectorsType, *model.MeasurementConstraintsDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,13 +56,15 @@ type MeasurementClientInterface_RequestConstraints_Call struct {
 }
 
 // RequestConstraints is a helper method to define mock.On call
-func (_e *MeasurementClientInterface_Expecter) RequestConstraints() *MeasurementClientInterface_RequestConstraints_Call {
-	return &MeasurementClientInterface_RequestConstraints_Call{Call: _e.mock.On("RequestConstraints")}
+//   - selector *model.MeasurementConstraintsListDataSelectorsType
+//   - elements *model.MeasurementConstraintsDataElementsType
+func (_e *MeasurementClientInterface_Expecter) RequestConstraints(selector interface{}, elements interface{}) *MeasurementClientInterface_RequestConstraints_Call {
+	return &MeasurementClientInterface_RequestConstraints_Call{Call: _e.mock.On("RequestConstraints", selector, elements)}
 }
 
-func (_c *MeasurementClientInterface_RequestConstraints_Call) Run(run func()) *MeasurementClientInterface_RequestConstraints_Call {
+func (_c *MeasurementClientInterface_RequestConstraints_Call) Run(run func(selector *model.MeasurementConstraintsListDataSelectorsType, elements *model.MeasurementConstraintsDataElementsType)) *MeasurementClientInterface_RequestConstraints_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.MeasurementConstraintsListDataSelectorsType), args[1].(*model.MeasurementConstraintsDataElementsType))
 	})
 	return _c
 }
@@ -72,14 +74,14 @@ func (_c *MeasurementClientInterface_RequestConstraints_Call) Return(_a0 *model.
 	return _c
 }
 
-func (_c *MeasurementClientInterface_RequestConstraints_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *MeasurementClientInterface_RequestConstraints_Call {
+func (_c *MeasurementClientInterface_RequestConstraints_Call) RunAndReturn(run func(*model.MeasurementConstraintsListDataSelectorsType, *model.MeasurementConstraintsDataElementsType) (*model.MsgCounterType, error)) *MeasurementClientInterface_RequestConstraints_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestData provides a mock function with given fields:
-func (_m *MeasurementClientInterface) RequestData() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestData provides a mock function with given fields: selector, elements
+func (_m *MeasurementClientInterface) RequestData(selector *model.MeasurementListDataSelectorsType, elements *model.MeasurementDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestData")
@@ -87,19 +89,19 @@ func (_m *MeasurementClientInterface) RequestData() (*model.MsgCounterType, erro
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.MeasurementListDataSelectorsType, *model.MeasurementDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.MeasurementListDataSelectorsType, *model.MeasurementDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.MeasurementListDataSelectorsType, *model.MeasurementDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -113,13 +115,15 @@ type MeasurementClientInterface_RequestData_Call struct {
 }
 
 // RequestData is a helper method to define mock.On call
-func (_e *MeasurementClientInterface_Expecter) RequestData() *MeasurementClientInterface_RequestData_Call {
-	return &MeasurementClientInterface_RequestData_Call{Call: _e.mock.On("RequestData")}
+//   - selector *model.MeasurementListDataSelectorsType
+//   - elements *model.MeasurementDataElementsType
+func (_e *MeasurementClientInterface_Expecter) RequestData(selector interface{}, elements interface{}) *MeasurementClientInterface_RequestData_Call {
+	return &MeasurementClientInterface_RequestData_Call{Call: _e.mock.On("RequestData", selector, elements)}
 }
 
-func (_c *MeasurementClientInterface_RequestData_Call) Run(run func()) *MeasurementClientInterface_RequestData_Call {
+func (_c *MeasurementClientInterface_RequestData_Call) Run(run func(selector *model.MeasurementListDataSelectorsType, elements *model.MeasurementDataElementsType)) *MeasurementClientInterface_RequestData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.MeasurementListDataSelectorsType), args[1].(*model.MeasurementDataElementsType))
 	})
 	return _c
 }
@@ -129,14 +133,14 @@ func (_c *MeasurementClientInterface_RequestData_Call) Return(_a0 *model.MsgCoun
 	return _c
 }
 
-func (_c *MeasurementClientInterface_RequestData_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *MeasurementClientInterface_RequestData_Call {
+func (_c *MeasurementClientInterface_RequestData_Call) RunAndReturn(run func(*model.MeasurementListDataSelectorsType, *model.MeasurementDataElementsType) (*model.MsgCounterType, error)) *MeasurementClientInterface_RequestData_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestDescriptions provides a mock function with given fields:
-func (_m *MeasurementClientInterface) RequestDescriptions() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestDescriptions provides a mock function with given fields: selector, elements
+func (_m *MeasurementClientInterface) RequestDescriptions(selector *model.MeasurementDescriptionListDataSelectorsType, elements *model.MeasurementDescriptionDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestDescriptions")
@@ -144,19 +148,19 @@ func (_m *MeasurementClientInterface) RequestDescriptions() (*model.MsgCounterTy
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.MeasurementDescriptionListDataSelectorsType, *model.MeasurementDescriptionDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.MeasurementDescriptionListDataSelectorsType, *model.MeasurementDescriptionDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.MeasurementDescriptionListDataSelectorsType, *model.MeasurementDescriptionDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -170,13 +174,15 @@ type MeasurementClientInterface_RequestDescriptions_Call struct {
 }
 
 // RequestDescriptions is a helper method to define mock.On call
-func (_e *MeasurementClientInterface_Expecter) RequestDescriptions() *MeasurementClientInterface_RequestDescriptions_Call {
-	return &MeasurementClientInterface_RequestDescriptions_Call{Call: _e.mock.On("RequestDescriptions")}
+//   - selector *model.MeasurementDescriptionListDataSelectorsType
+//   - elements *model.MeasurementDescriptionDataElementsType
+func (_e *MeasurementClientInterface_Expecter) RequestDescriptions(selector interface{}, elements interface{}) *MeasurementClientInterface_RequestDescriptions_Call {
+	return &MeasurementClientInterface_RequestDescriptions_Call{Call: _e.mock.On("RequestDescriptions", selector, elements)}
 }
 
-func (_c *MeasurementClientInterface_RequestDescriptions_Call) Run(run func()) *MeasurementClientInterface_RequestDescriptions_Call {
+func (_c *MeasurementClientInterface_RequestDescriptions_Call) Run(run func(selector *model.MeasurementDescriptionListDataSelectorsType, elements *model.MeasurementDescriptionDataElementsType)) *MeasurementClientInterface_RequestDescriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.MeasurementDescriptionListDataSelectorsType), args[1].(*model.MeasurementDescriptionDataElementsType))
 	})
 	return _c
 }
@@ -186,7 +192,7 @@ func (_c *MeasurementClientInterface_RequestDescriptions_Call) Return(_a0 *model
 	return _c
 }
 
-func (_c *MeasurementClientInterface_RequestDescriptions_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *MeasurementClientInterface_RequestDescriptions_Call {
+func (_c *MeasurementClientInterface_RequestDescriptions_Call) RunAndReturn(run func(*model.MeasurementDescriptionListDataSelectorsType, *model.MeasurementDescriptionDataElementsType) (*model.MsgCounterType, error)) *MeasurementClientInterface_RequestDescriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/TimeSeriesClientInterface.go
+++ b/mocks/TimeSeriesClientInterface.go
@@ -20,9 +20,9 @@ func (_m *TimeSeriesClientInterface) EXPECT() *TimeSeriesClientInterface_Expecte
 	return &TimeSeriesClientInterface_Expecter{mock: &_m.Mock}
 }
 
-// RequestConstraints provides a mock function with given fields:
-func (_m *TimeSeriesClientInterface) RequestConstraints() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestConstraints provides a mock function with given fields: selector, elements
+func (_m *TimeSeriesClientInterface) RequestConstraints(selector *model.TimeSeriesConstraintsListDataSelectorsType, elements *model.TimeSeriesConstraintsDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestConstraints")
@@ -30,19 +30,19 @@ func (_m *TimeSeriesClientInterface) RequestConstraints() (*model.MsgCounterType
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.TimeSeriesConstraintsListDataSelectorsType, *model.TimeSeriesConstraintsDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.TimeSeriesConstraintsListDataSelectorsType, *model.TimeSeriesConstraintsDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.TimeSeriesConstraintsListDataSelectorsType, *model.TimeSeriesConstraintsDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,13 +56,15 @@ type TimeSeriesClientInterface_RequestConstraints_Call struct {
 }
 
 // RequestConstraints is a helper method to define mock.On call
-func (_e *TimeSeriesClientInterface_Expecter) RequestConstraints() *TimeSeriesClientInterface_RequestConstraints_Call {
-	return &TimeSeriesClientInterface_RequestConstraints_Call{Call: _e.mock.On("RequestConstraints")}
+//   - selector *model.TimeSeriesConstraintsListDataSelectorsType
+//   - elements *model.TimeSeriesConstraintsDataElementsType
+func (_e *TimeSeriesClientInterface_Expecter) RequestConstraints(selector interface{}, elements interface{}) *TimeSeriesClientInterface_RequestConstraints_Call {
+	return &TimeSeriesClientInterface_RequestConstraints_Call{Call: _e.mock.On("RequestConstraints", selector, elements)}
 }
 
-func (_c *TimeSeriesClientInterface_RequestConstraints_Call) Run(run func()) *TimeSeriesClientInterface_RequestConstraints_Call {
+func (_c *TimeSeriesClientInterface_RequestConstraints_Call) Run(run func(selector *model.TimeSeriesConstraintsListDataSelectorsType, elements *model.TimeSeriesConstraintsDataElementsType)) *TimeSeriesClientInterface_RequestConstraints_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.TimeSeriesConstraintsListDataSelectorsType), args[1].(*model.TimeSeriesConstraintsDataElementsType))
 	})
 	return _c
 }
@@ -72,14 +74,14 @@ func (_c *TimeSeriesClientInterface_RequestConstraints_Call) Return(_a0 *model.M
 	return _c
 }
 
-func (_c *TimeSeriesClientInterface_RequestConstraints_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *TimeSeriesClientInterface_RequestConstraints_Call {
+func (_c *TimeSeriesClientInterface_RequestConstraints_Call) RunAndReturn(run func(*model.TimeSeriesConstraintsListDataSelectorsType, *model.TimeSeriesConstraintsDataElementsType) (*model.MsgCounterType, error)) *TimeSeriesClientInterface_RequestConstraints_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestData provides a mock function with given fields:
-func (_m *TimeSeriesClientInterface) RequestData() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestData provides a mock function with given fields: selector, elements
+func (_m *TimeSeriesClientInterface) RequestData(selector *model.TimeSeriesListDataSelectorsType, elements *model.TimeSeriesDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestData")
@@ -87,19 +89,19 @@ func (_m *TimeSeriesClientInterface) RequestData() (*model.MsgCounterType, error
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.TimeSeriesListDataSelectorsType, *model.TimeSeriesDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.TimeSeriesListDataSelectorsType, *model.TimeSeriesDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.TimeSeriesListDataSelectorsType, *model.TimeSeriesDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -113,13 +115,15 @@ type TimeSeriesClientInterface_RequestData_Call struct {
 }
 
 // RequestData is a helper method to define mock.On call
-func (_e *TimeSeriesClientInterface_Expecter) RequestData() *TimeSeriesClientInterface_RequestData_Call {
-	return &TimeSeriesClientInterface_RequestData_Call{Call: _e.mock.On("RequestData")}
+//   - selector *model.TimeSeriesListDataSelectorsType
+//   - elements *model.TimeSeriesDataElementsType
+func (_e *TimeSeriesClientInterface_Expecter) RequestData(selector interface{}, elements interface{}) *TimeSeriesClientInterface_RequestData_Call {
+	return &TimeSeriesClientInterface_RequestData_Call{Call: _e.mock.On("RequestData", selector, elements)}
 }
 
-func (_c *TimeSeriesClientInterface_RequestData_Call) Run(run func()) *TimeSeriesClientInterface_RequestData_Call {
+func (_c *TimeSeriesClientInterface_RequestData_Call) Run(run func(selector *model.TimeSeriesListDataSelectorsType, elements *model.TimeSeriesDataElementsType)) *TimeSeriesClientInterface_RequestData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.TimeSeriesListDataSelectorsType), args[1].(*model.TimeSeriesDataElementsType))
 	})
 	return _c
 }
@@ -129,14 +133,14 @@ func (_c *TimeSeriesClientInterface_RequestData_Call) Return(_a0 *model.MsgCount
 	return _c
 }
 
-func (_c *TimeSeriesClientInterface_RequestData_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *TimeSeriesClientInterface_RequestData_Call {
+func (_c *TimeSeriesClientInterface_RequestData_Call) RunAndReturn(run func(*model.TimeSeriesListDataSelectorsType, *model.TimeSeriesDataElementsType) (*model.MsgCounterType, error)) *TimeSeriesClientInterface_RequestData_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// RequestDescriptions provides a mock function with given fields:
-func (_m *TimeSeriesClientInterface) RequestDescriptions() (*model.MsgCounterType, error) {
-	ret := _m.Called()
+// RequestDescriptions provides a mock function with given fields: selector, elements
+func (_m *TimeSeriesClientInterface) RequestDescriptions(selector *model.TimeSeriesDescriptionListDataSelectorsType, elements *model.TimeSeriesDescriptionDataElementsType) (*model.MsgCounterType, error) {
+	ret := _m.Called(selector, elements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RequestDescriptions")
@@ -144,19 +148,19 @@ func (_m *TimeSeriesClientInterface) RequestDescriptions() (*model.MsgCounterTyp
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*model.MsgCounterType, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(*model.TimeSeriesDescriptionListDataSelectorsType, *model.TimeSeriesDescriptionDataElementsType) (*model.MsgCounterType, error)); ok {
+		return rf(selector, elements)
 	}
-	if rf, ok := ret.Get(0).(func() *model.MsgCounterType); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*model.TimeSeriesDescriptionListDataSelectorsType, *model.TimeSeriesDescriptionDataElementsType) *model.MsgCounterType); ok {
+		r0 = rf(selector, elements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*model.TimeSeriesDescriptionListDataSelectorsType, *model.TimeSeriesDescriptionDataElementsType) error); ok {
+		r1 = rf(selector, elements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -170,13 +174,15 @@ type TimeSeriesClientInterface_RequestDescriptions_Call struct {
 }
 
 // RequestDescriptions is a helper method to define mock.On call
-func (_e *TimeSeriesClientInterface_Expecter) RequestDescriptions() *TimeSeriesClientInterface_RequestDescriptions_Call {
-	return &TimeSeriesClientInterface_RequestDescriptions_Call{Call: _e.mock.On("RequestDescriptions")}
+//   - selector *model.TimeSeriesDescriptionListDataSelectorsType
+//   - elements *model.TimeSeriesDescriptionDataElementsType
+func (_e *TimeSeriesClientInterface_Expecter) RequestDescriptions(selector interface{}, elements interface{}) *TimeSeriesClientInterface_RequestDescriptions_Call {
+	return &TimeSeriesClientInterface_RequestDescriptions_Call{Call: _e.mock.On("RequestDescriptions", selector, elements)}
 }
 
-func (_c *TimeSeriesClientInterface_RequestDescriptions_Call) Run(run func()) *TimeSeriesClientInterface_RequestDescriptions_Call {
+func (_c *TimeSeriesClientInterface_RequestDescriptions_Call) Run(run func(selector *model.TimeSeriesDescriptionListDataSelectorsType, elements *model.TimeSeriesDescriptionDataElementsType)) *TimeSeriesClientInterface_RequestDescriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(*model.TimeSeriesDescriptionListDataSelectorsType), args[1].(*model.TimeSeriesDescriptionDataElementsType))
 	})
 	return _c
 }
@@ -186,7 +192,7 @@ func (_c *TimeSeriesClientInterface_RequestDescriptions_Call) Return(_a0 *model.
 	return _c
 }
 
-func (_c *TimeSeriesClientInterface_RequestDescriptions_Call) RunAndReturn(run func() (*model.MsgCounterType, error)) *TimeSeriesClientInterface_RequestDescriptions_Call {
+func (_c *TimeSeriesClientInterface_RequestDescriptions_Call) RunAndReturn(run func(*model.TimeSeriesDescriptionListDataSelectorsType, *model.TimeSeriesDescriptionDataElementsType) (*model.MsgCounterType, error)) *TimeSeriesClientInterface_RequestDescriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/cem/cevc/events.go
+++ b/usecases/cem/cevc/events.go
@@ -54,7 +54,7 @@ func (e *CEVC) evConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get device configuration descriptions
-		if _, err := evDeviceConfiguration.RequestDescriptions(); err != nil {
+		if _, err := evDeviceConfiguration.RequestKeyValueDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -69,12 +69,12 @@ func (e *CEVC) evConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get time series descriptions
-		if _, err := evTimeSeries.RequestDescriptions(); err != nil {
+		if _, err := evTimeSeries.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 
 		// get time series constraints
-		if _, err := evTimeSeries.RequestConstraints(); err != nil {
+		if _, err := evTimeSeries.RequestConstraints(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -99,7 +99,7 @@ func (e *CEVC) evConnected(entity spineapi.EntityRemoteInterface) {
 func (e *CEVC) evTimeSeriesDescriptionDataUpdate(payload spineapi.EventPayload) {
 	if evTimeSeries, err := client.NewTimeSeries(e.LocalEntity, payload.Entity); err == nil {
 		// get time series values
-		if _, err := evTimeSeries.RequestData(); err != nil {
+		if _, err := evTimeSeries.RequestData(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}

--- a/usecases/cem/evcc/events.go
+++ b/usecases/cem/evcc/events.go
@@ -73,7 +73,7 @@ func (e *EVCC) evConnected(payload spineapi.EventPayload) {
 			logging.Log().Debug(err)
 		}
 		// get ev configuration data
-		if _, err := evDeviceConfiguration.RequestDescriptions(); err != nil {
+		if _, err := evDeviceConfiguration.RequestKeyValueDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -95,12 +95,12 @@ func (e *EVCC) evConnected(payload spineapi.EventPayload) {
 		}
 
 		// get electrical connection parameter descriptions
-		if _, err := evElectricalConnection.RequestParameterDescriptions(); err != nil {
+		if _, err := evElectricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 
 		// get electrical permitted values descriptions
-		if _, err := evElectricalConnection.RequestPermittedValueSets(); err != nil {
+		if _, err := evElectricalConnection.RequestPermittedValueSets(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -128,7 +128,7 @@ func (e *EVCC) evDisconnected(payload spineapi.EventPayload) {
 func (e *EVCC) evConfigurationDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if evDeviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
-		if _, err := evDeviceConfiguration.RequestKeyValues(); err != nil {
+		if _, err := evDeviceConfiguration.RequestKeyValues(nil, nil); err != nil {
 			logging.Log().Error("Error getting configuration key values:", err)
 		}
 	}
@@ -185,7 +185,7 @@ func (e *EVCC) evManufacturerDataUpdate(payload spineapi.EventPayload) {
 // the electrical connection parameter description data of an EV was updated
 func (e *EVCC) evElectricalParamerDescriptionUpdate(entity spineapi.EntityRemoteInterface) {
 	if evElectricalConnection, err := client.NewElectricalConnection(e.LocalEntity, entity); err == nil {
-		if _, err := evElectricalConnection.RequestPermittedValueSets(); err != nil {
+		if _, err := evElectricalConnection.RequestPermittedValueSets(nil, nil); err != nil {
 			logging.Log().Error("Error getting electrical permitted values:", err)
 		}
 	}

--- a/usecases/cem/evcem/events.go
+++ b/usecases/cem/evcem/events.go
@@ -48,12 +48,12 @@ func (e *EVCEM) evConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get electrical connection descriptions
-		if _, err := evElectricalConnection.RequestDescriptions(); err != nil {
+		if _, err := evElectricalConnection.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 
 		// get electrical connection parameter descriptions
-		if _, err := evElectricalConnection.RequestParameterDescriptions(); err != nil {
+		if _, err := evElectricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -64,12 +64,12 @@ func (e *EVCEM) evConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get measurement descriptions
-		if _, err := evMeasurement.RequestDescriptions(); err != nil {
+		if _, err := evMeasurement.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 
 		// get measurement constraints
-		if _, err := evMeasurement.RequestConstraints(); err != nil {
+		if _, err := evMeasurement.RequestConstraints(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -98,7 +98,7 @@ func (e *EVCEM) evElectricalConnectionDescriptionDataUpdate(payload spineapi.Eve
 func (e *EVCEM) evMeasurementDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if evMeasurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// get measurement values
-		if _, err := evMeasurement.RequestData(); err != nil {
+		if _, err := evMeasurement.RequestData(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}

--- a/usecases/cem/evcem/public.go
+++ b/usecases/cem/evcem/public.go
@@ -96,7 +96,7 @@ func (e *EVCEM) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float6
 	// if there was no timestamp provided or the time for the last value
 	// is older than 1 minute, send a read request
 	if refetch {
-		_, _ = evMeasurement.RequestData()
+		_, _ = evMeasurement.RequestData(nil, nil)
 	}
 
 	return result, nil

--- a/usecases/cem/evsoc/events.go
+++ b/usecases/cem/evsoc/events.go
@@ -44,12 +44,12 @@ func (e *EVSOC) evConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get measurement descriptions
-		if _, err := evMeasurement.RequestDescriptions(); err != nil {
+		if _, err := evMeasurement.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 
 		// get measurement constraints
-		if _, err := evMeasurement.RequestConstraints(); err != nil {
+		if _, err := evMeasurement.RequestConstraints(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}

--- a/usecases/cem/opev/events.go
+++ b/usecases/cem/opev/events.go
@@ -52,12 +52,12 @@ func (e *OPEV) evConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get descriptions
-		if _, err := evLoadControl.RequestLimitDescriptions(); err != nil {
+		if _, err := evLoadControl.RequestLimitDescriptions(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 
 		// get constraints
-		if _, err := evLoadControl.RequestLimitConstraints(); err != nil {
+		if _, err := evLoadControl.RequestLimitConstraints(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -67,7 +67,7 @@ func (e *OPEV) evConnected(entity spineapi.EntityRemoteInterface) {
 func (e *OPEV) evLoadControlLimitDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if evLoadControl, err := client.NewLoadControl(e.LocalEntity, entity); err == nil {
 		// get values
-		if _, err := evLoadControl.RequestLimitData(); err != nil {
+		if _, err := evLoadControl.RequestLimitData(nil, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}

--- a/usecases/cem/vabd/events.go
+++ b/usecases/cem/vabd/events.go
@@ -44,11 +44,11 @@ func (e *VABD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get electrical connection parameter
-		if _, err := electricalConnection.RequestDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := electricalConnection.RequestParameterDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -59,11 +59,11 @@ func (e *VABD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get measurement parameters
-		if _, err := measurement.RequestDescriptions(); err != nil {
+		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := measurement.RequestConstraints(); err != nil {
+		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -73,7 +73,7 @@ func (e *VABD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 func (e *VABD) inverterMeasurementDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
-		if _, err := measurement.RequestData(); err != nil {
+		if _, err := measurement.RequestData(nil, nil); err != nil {
 			logging.Log().Error("Error getting measurement list values:", err)
 		}
 	}

--- a/usecases/cem/vapd/events.go
+++ b/usecases/cem/vapd/events.go
@@ -50,7 +50,7 @@ func (e *VAPD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get configuration data
-		if _, err := deviceConfiguration.RequestDescriptions(); err != nil {
+		if _, err := deviceConfiguration.RequestKeyValueDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -61,11 +61,11 @@ func (e *VAPD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get electrical connection parameter
-		if _, err := electricalConnection.RequestDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := electricalConnection.RequestParameterDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -76,11 +76,11 @@ func (e *VAPD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get measurement parameters
-		if _, err := measurement.RequestDescriptions(); err != nil {
+		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := measurement.RequestConstraints(); err != nil {
+		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -90,7 +90,7 @@ func (e *VAPD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 func (e *VAPD) inverterConfigurationDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
-		if _, err := deviceConfiguration.RequestKeyValues(); err != nil {
+		if _, err := deviceConfiguration.RequestKeyValues(nil, nil); err != nil {
 			logging.Log().Error("Error getting configuration key values:", err)
 		}
 	}
@@ -114,7 +114,7 @@ func (e *VAPD) inverterConfigurationDataUpdate(payload spineapi.EventPayload) {
 func (e *VAPD) inverterMeasurementDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
-		if _, err := measurement.RequestData(); err != nil {
+		if _, err := measurement.RequestData(nil, nil); err != nil {
 			logging.Log().Error("Error getting measurement list values:", err)
 		}
 	}

--- a/usecases/eg/lpc/events_test.go
+++ b/usecases/eg/lpc/events_test.go
@@ -51,6 +51,30 @@ func (s *EgLPCSuite) Test_Failures() {
 	s.sut.configurationDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
+func (s *EgLPCSuite) Test_loadControlLimitDescriptionDataUpdate() {
+	s.sut.loadControlLimitDescriptionDataUpdate(s.mockRemoteEntity)
+
+	s.sut.loadControlLimitDescriptionDataUpdate(s.monitoredEntity)
+
+	descData := &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
+			{
+				LimitId:        util.Ptr(model.LoadControlLimitIdType(0)),
+				LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
+				LimitCategory:  util.Ptr(model.LoadControlCategoryTypeObligation),
+				LimitDirection: util.Ptr(model.EnergyDirectionTypeConsume),
+				ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
+	fErr := rFeature.UpdateData(model.FunctionTypeLoadControlLimitDescriptionListData, descData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	s.sut.loadControlLimitDescriptionDataUpdate(s.monitoredEntity)
+}
+
 func (s *EgLPCSuite) Test_loadControlLimitDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,

--- a/usecases/eg/lpc/public.go
+++ b/usecases/eg/lpc/public.go
@@ -47,7 +47,6 @@ func (e *LPC) ConsumptionLimit(entity spineapi.EntityRemoteInterface) (
 
 	filter := model.LoadControlLimitDescriptionDataType{
 		LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
-		LimitCategory:  util.Ptr(model.LoadControlCategoryTypeObligation),
 		LimitDirection: util.Ptr(model.EnergyDirectionTypeConsume),
 		ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 	}
@@ -92,7 +91,6 @@ func (e *LPC) WriteConsumptionLimit(
 
 	filter := model.LoadControlLimitDescriptionDataType{
 		LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
-		LimitCategory:  util.Ptr(model.LoadControlCategoryTypeObligation),
 		LimitDirection: util.Ptr(model.EnergyDirectionTypeConsume),
 		ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 	}

--- a/usecases/eg/lpp/events.go
+++ b/usecases/eg/lpp/events.go
@@ -53,13 +53,34 @@ func (e *LPP) connected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get descriptions
-		if _, err := loadControl.RequestLimitDescriptions(); err != nil {
+		selector := &model.LoadControlLimitDescriptionListDataSelectorsType{
+			LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
+			LimitDirection: util.Ptr(model.EnergyDirectionTypeProduce),
+			ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
+		}
+		if _, err := loadControl.RequestLimitDescriptions(selector, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
 
-	if localDeviceDiag, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
-		if _, err := localDeviceDiag.Subscribe(); err != nil {
+	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
+		if _, err := deviceConfiguration.Subscribe(); err != nil {
+			logging.Log().Debug(err)
+		}
+
+		if _, err := deviceConfiguration.Bind(); err != nil {
+			logging.Log().Debug(err)
+		}
+
+		// get descriptions
+		// don't use selectors yet, as we would have to query 2 which could result in 2 full reads
+		if _, err := deviceConfiguration.RequestKeyValueDescriptions(nil, nil); err != nil {
+			logging.Log().Debug(err)
+		}
+	}
+
+	if deviceDiagnosis, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
+		if _, err := deviceDiagnosis.Subscribe(); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -69,7 +90,18 @@ func (e *LPP) connected(entity spineapi.EntityRemoteInterface) {
 func (e *LPP) loadControlLimitDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if loadControl, err := client.NewLoadControl(e.LocalEntity, entity); err == nil {
 		// get values
-		if _, err := loadControl.RequestLimitData(); err != nil {
+		var selector *model.LoadControlLimitListDataSelectorsType
+		filter := model.LoadControlLimitDescriptionDataType{
+			LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
+			LimitDirection: util.Ptr(model.EnergyDirectionTypeProduce),
+			ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
+		}
+		if descs, err := loadControl.GetLimitDescriptionsForFilter(filter); err == nil && len(descs) > 0 {
+			selector = &model.LoadControlLimitListDataSelectorsType{
+				LimitId: descs[0].LimitId,
+			}
+		}
+		if _, err := loadControl.RequestLimitData(selector, nil); err != nil {
 			logging.Log().Debug(err)
 		}
 	}
@@ -80,7 +112,6 @@ func (e *LPP) loadControlLimitDataUpdate(payload spineapi.EventPayload) {
 	if lc, err := client.NewLoadControl(e.LocalEntity, payload.Entity); err == nil {
 		filter := model.LoadControlLimitDescriptionDataType{
 			LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
-			LimitCategory:  util.Ptr(model.LoadControlCategoryTypeObligation),
 			LimitDirection: util.Ptr(model.EnergyDirectionTypeProduce),
 			ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 		}
@@ -94,7 +125,7 @@ func (e *LPP) loadControlLimitDataUpdate(payload spineapi.EventPayload) {
 func (e *LPP) configurationDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
-		if _, err := deviceConfiguration.RequestKeyValues(); err != nil {
+		if _, err := deviceConfiguration.RequestKeyValues(nil, nil); err != nil {
 			logging.Log().Error("Error getting configuration key values:", err)
 		}
 	}

--- a/usecases/eg/lpp/events_test.go
+++ b/usecases/eg/lpp/events_test.go
@@ -51,6 +51,30 @@ func (s *EgLPPSuite) Test_Failures() {
 	s.sut.configurationDescriptionDataUpdate(s.mockRemoteEntity)
 }
 
+func (s *EgLPPSuite) Test_loadControlLimitDescriptionDataUpdate() {
+	s.sut.loadControlLimitDescriptionDataUpdate(s.mockRemoteEntity)
+
+	s.sut.loadControlLimitDescriptionDataUpdate(s.monitoredEntity)
+
+	descData := &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
+			{
+				LimitId:        util.Ptr(model.LoadControlLimitIdType(0)),
+				LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
+				LimitCategory:  util.Ptr(model.LoadControlCategoryTypeObligation),
+				LimitDirection: util.Ptr(model.EnergyDirectionTypeProduce),
+				ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
+	fErr := rFeature.UpdateData(model.FunctionTypeLoadControlLimitDescriptionListData, descData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	s.sut.loadControlLimitDescriptionDataUpdate(s.monitoredEntity)
+}
+
 func (s *EgLPPSuite) Test_loadControlLimitDataUpdate() {
 	payload := spineapi.EventPayload{
 		Ski:    remoteSki,

--- a/usecases/eg/lpp/public.go
+++ b/usecases/eg/lpp/public.go
@@ -47,7 +47,6 @@ func (e *LPP) ProductionLimit(entity spineapi.EntityRemoteInterface) (
 
 	filter := model.LoadControlLimitDescriptionDataType{
 		LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
-		LimitCategory:  util.Ptr(model.LoadControlCategoryTypeObligation),
 		LimitDirection: util.Ptr(model.EnergyDirectionTypeProduce),
 		ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 	}
@@ -92,7 +91,6 @@ func (e *LPP) WriteProductionLimit(
 
 	filter := model.LoadControlLimitDescriptionDataType{
 		LimitType:      util.Ptr(model.LoadControlLimitTypeTypeSignDependentAbsValueLimit),
-		LimitCategory:  util.Ptr(model.LoadControlCategoryTypeObligation),
 		LimitDirection: util.Ptr(model.EnergyDirectionTypeProduce),
 		ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 	}

--- a/usecases/ma/mgcp/events.go
+++ b/usecases/ma/mgcp/events.go
@@ -50,7 +50,7 @@ func (e *MGCP) gridConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get configuration data
-		if _, err := deviceConfiguration.RequestDescriptions(); err != nil {
+		if _, err := deviceConfiguration.RequestKeyValueDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -61,11 +61,11 @@ func (e *MGCP) gridConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get electrical connection parameter
-		if _, err := electricalConnection.RequestDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := electricalConnection.RequestParameterDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -76,11 +76,11 @@ func (e *MGCP) gridConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get measurement parameters
-		if _, err := measurement.RequestDescriptions(); err != nil {
+		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := measurement.RequestConstraints(); err != nil {
+		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -90,7 +90,7 @@ func (e *MGCP) gridConnected(entity spineapi.EntityRemoteInterface) {
 func (e *MGCP) gridConfigurationDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
-		if _, err := deviceConfiguration.RequestKeyValues(); err != nil {
+		if _, err := deviceConfiguration.RequestKeyValues(nil, nil); err != nil {
 			logging.Log().Error("Error getting configuration key values:", err)
 		}
 	}
@@ -112,7 +112,7 @@ func (e *MGCP) gridConfigurationDataUpdate(payload spineapi.EventPayload) {
 func (e *MGCP) gridMeasurementDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
-		if _, err := measurement.RequestData(); err != nil {
+		if _, err := measurement.RequestData(nil, nil); err != nil {
 			logging.Log().Error("Error getting measurement list values:", err)
 		}
 	}

--- a/usecases/ma/mpc/events.go
+++ b/usecases/ma/mpc/events.go
@@ -44,11 +44,11 @@ func (e *MPC) deviceConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get electrical connection parameter
-		if _, err := electricalConnection.RequestDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := electricalConnection.RequestParameterDescriptions(); err != nil {
+		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -59,11 +59,11 @@ func (e *MPC) deviceConnected(entity spineapi.EntityRemoteInterface) {
 		}
 
 		// get measurement parameters
-		if _, err := measurement.RequestDescriptions(); err != nil {
+		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 
-		if _, err := measurement.RequestConstraints(); err != nil {
+		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
 			logging.Log().Error(err)
 		}
 	}
@@ -73,7 +73,7 @@ func (e *MPC) deviceConnected(entity spineapi.EntityRemoteInterface) {
 func (e *MPC) deviceMeasurementDescriptionDataUpdate(entity spineapi.EntityRemoteInterface) {
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
-		if _, err := measurement.RequestData(); err != nil {
+		if _, err := measurement.RequestData(nil, nil); err != nil {
 			logging.Log().Error("Error getting measurement list values:", err)
 		}
 	}


### PR DESCRIPTION
- Client features can now send read requests with selectors and elements
- First partly usage in LPC and LPP of energy guard actor
- Add missing device configuration reads to LPC and LPP in energy guard actor