### PR TITLE
LPC & LPP usecase improvements

### DIFF
--- a/cmd/hems/main.go
+++ b/cmd/hems/main.go
@@ -15,9 +15,15 @@ import (
 
 	"github.com/enbility/eebus-go/api"
 	"github.com/enbility/eebus-go/service"
-	"github.com/enbility/eebus-go/usecases/eg/lpc"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	"github.com/enbility/eebus-go/usecases/cs/lpc"
+	cslpc "github.com/enbility/eebus-go/usecases/cs/lpc"
+	cslpp "github.com/enbility/eebus-go/usecases/cs/lpp"
+	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
+	eglpp "github.com/enbility/eebus-go/usecases/eg/lpp"
 	shipapi "github.com/enbility/ship-go/api"
 	"github.com/enbility/ship-go/cert"
+	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 )
 
@@ -25,6 +31,11 @@ var remoteSki string
 
 type hems struct {
 	myService *service.Service
+
+	uccslpc ucapi.CsLPCInterface
+	uccslpp ucapi.CsLPPInterface
+	uceglpc ucapi.EgLPCInterface
+	uceglpp ucapi.EgLPPInterface
 }
 
 func (h *hems) run() {
@@ -84,8 +95,14 @@ func (h *hems) run() {
 	}
 
 	localEntity := h.myService.LocalDevice().EntityForType(model.EntityTypeTypeCEM)
-	uclpc := lpc.NewLPC(localEntity, nil)
-	h.myService.AddUseCase(uclpc)
+	h.uccslpc = cslpc.NewLPC(localEntity, h.OnLPCEvent)
+	h.myService.AddUseCase(h.uccslpc)
+	h.uccslpp = cslpp.NewLPP(localEntity, h.OnLPPEvent)
+	h.myService.AddUseCase(h.uccslpp)
+	h.uceglpc = eglpc.NewLPC(localEntity, nil)
+	h.myService.AddUseCase(h.uceglpc)
+	h.uceglpp = eglpp.NewLPP(localEntity, nil)
+	h.myService.AddUseCase(h.uceglpp)
 
 	if len(remoteSki) == 0 {
 		os.Exit(0)
@@ -95,6 +112,54 @@ func (h *hems) run() {
 
 	h.myService.Start()
 	// defer h.myService.Shutdown()
+}
+
+// Controllable System LPC Event Handler
+
+func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+	if entity.EntityType() != model.EntityTypeTypeGridGuard {
+		return
+	}
+
+	switch event {
+	case lpc.WriteApprovalRequired:
+		// get pending writes
+		pendingWrites := h.uccslpc.PendingConsumptionLimits()
+
+		// approve any write
+		for msgCounter, write := range pendingWrites {
+			fmt.Println("Approving LPC write with msgCounter", msgCounter, "and limit", write.Value, "W")
+			h.uccslpc.ApproveOrDenyConsumptionLimit(msgCounter, true, "")
+		}
+	case lpc.DataUpdateLimit:
+		if currentLimit, err := h.uccslpc.ConsumptionLimit(); err != nil {
+			fmt.Println("New LPC Limit set to", currentLimit.Value, "W")
+		}
+	}
+}
+
+// Controllable System LPP Event Handler
+
+func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
+	if entity.EntityType() != model.EntityTypeTypeGridGuard {
+		return
+	}
+
+	switch event {
+	case lpc.WriteApprovalRequired:
+		// get pending writes
+		pendingWrites := h.uccslpp.PendingProductionLimits()
+
+		// approve any write
+		for msgCounter, write := range pendingWrites {
+			fmt.Println("Approving LPP write with msgCounter", msgCounter, "and limit", write.Value, "W")
+			h.uccslpp.ApproveOrDenyProductionLimit(msgCounter, true, "")
+		}
+	case lpc.DataUpdateLimit:
+		if currentLimit, err := h.uccslpp.ProductionLimit(); err != nil {
+			fmt.Println("New LPP Limit set to", currentLimit.Value, "W")
+		}
+	}
 }
 
 // EEBUSServiceHandler
@@ -158,22 +223,18 @@ func main() {
 
 func (h *hems) Trace(args ...interface{}) {
 	// h.print("TRACE", args...)
-	h.print("TRACE", args...)
 }
 
 func (h *hems) Tracef(format string, args ...interface{}) {
-	// h.print("TRACE", args...)
-	h.printFormat("TRACE", format, args...)
+	// h.printFormat("TRACE", format, args...)
 }
 
 func (h *hems) Debug(args ...interface{}) {
-	// h.print("TRACE", args...)
-	h.print("DEBUG", args...)
+	// h.print("DEBUG", args...)
 }
 
 func (h *hems) Debugf(format string, args ...interface{}) {
-	// h.print("TRACE", args...)
-	h.printFormat("DEBUG", format, args...)
+	// h.printFormat("DEBUG", format, args...)
 }
 
 func (h *hems) Info(args ...interface{}) {

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -7,6 +7,7 @@ import (
 	"github.com/enbility/eebus-go/api"
 	"github.com/enbility/eebus-go/features/server"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 )
@@ -94,7 +95,7 @@ func (e *LPC) PendingConsumptionLimits() map[model.MsgCounterType]ucapi.LoadLimi
 		data := msg.Cmd.LoadControlLimitListData
 
 		// elements are only added to the map if all required fields exist
-		// therefor not check for these are needed here
+		// therefor no checks for these are needed here
 
 		// find the item which contains the limit for this usecase
 		for _, item := range data.LoadControlLimitData {
@@ -133,21 +134,31 @@ func (e *LPC) ApproveOrDenyConsumptionLimit(msgCounter model.MsgCounterType, app
 	e.pendingMux.Lock()
 	defer e.pendingMux.Unlock()
 
-	msg, ok := e.pendingLimits[msgCounter]
-	if !ok {
-		return
-	}
-
 	f := e.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
 
 	result := model.ErrorType{
 		ErrorNumber: model.ErrorNumberType(0),
 	}
+
+	msg, ok := e.pendingLimits[msgCounter]
+	if !ok {
+		// it is not a limit of this usecase, so approve it
+		newMsg := &spineapi.Message{
+			RequestHeader: &model.HeaderType{
+				MsgCounter: &msgCounter,
+			},
+		}
+		f.ApproveOrDenyWrite(newMsg, result)
+		return
+	}
+
 	if !approve {
 		result.ErrorNumber = model.ErrorNumberType(7)
 		result.Description = util.Ptr(model.DescriptionType(reason))
 	}
 	f.ApproveOrDenyWrite(msg, result)
+
+	delete(e.pendingLimits, msgCounter)
 }
 
 // Scenario 2

--- a/usecases/cs/lpc/public_test.go
+++ b/usecases/cs/lpc/public_test.go
@@ -49,6 +49,12 @@ func (s *CsLPCSuite) Test_PendingConsumptionLimits() {
 						Value:         model.NewScaledNumberType(1000),
 						TimePeriod:    model.NewTimePeriodTypeWithRelativeEndTime(time.Minute * 2),
 					},
+					{
+						LimitId:       util.Ptr(model.LoadControlLimitIdType(1)),
+						IsLimitActive: util.Ptr(true),
+						Value:         model.NewScaledNumberType(1000),
+						TimePeriod:    model.NewTimePeriodTypeWithRelativeEndTime(time.Minute * 2),
+					},
 				},
 			},
 		},
@@ -63,7 +69,13 @@ func (s *CsLPCSuite) Test_PendingConsumptionLimits() {
 
 	s.sut.ApproveOrDenyConsumptionLimit(model.MsgCounterType(499), true, "")
 
+	data = s.sut.PendingConsumptionLimits()
+	assert.Equal(s.T(), 1, len(data))
+
 	s.sut.ApproveOrDenyConsumptionLimit(msgCounter, false, "leave me alone")
+
+	data = s.sut.PendingConsumptionLimits()
+	assert.Equal(s.T(), 0, len(data))
 }
 
 func (s *CsLPCSuite) Test_Failsafe() {

--- a/usecases/cs/lpp/public_test.go
+++ b/usecases/cs/lpp/public_test.go
@@ -49,7 +49,12 @@ func (s *CsLPPSuite) Test_PendingProductionLimits() {
 						Value:         model.NewScaledNumberType(1000),
 						TimePeriod:    model.NewTimePeriodTypeWithRelativeEndTime(time.Minute * 2),
 					},
-				},
+					{
+						LimitId:       util.Ptr(model.LoadControlLimitIdType(1)),
+						IsLimitActive: util.Ptr(true),
+						Value:         model.NewScaledNumberType(1000),
+						TimePeriod:    model.NewTimePeriodTypeWithRelativeEndTime(time.Minute * 2),
+					}},
 			},
 		},
 		DeviceRemote: s.remoteDevice,
@@ -63,7 +68,13 @@ func (s *CsLPPSuite) Test_PendingProductionLimits() {
 
 	s.sut.ApproveOrDenyProductionLimit(model.MsgCounterType(499), true, "")
 
+	data = s.sut.PendingProductionLimits()
+	assert.Equal(s.T(), 1, len(data))
+
 	s.sut.ApproveOrDenyProductionLimit(msgCounter, false, "leave me alone")
+
+	data = s.sut.PendingProductionLimits()
+	assert.Equal(s.T(), 0, len(data))
 }
 
 func (s *CsLPPSuite) Test_Failsafe() {

--- a/usecases/eg/lpc/events.go
+++ b/usecases/eg/lpc/events.go
@@ -82,6 +82,10 @@ func (e *LPC) connected(entity spineapi.EntityRemoteInterface) {
 		if _, err := deviceDiagnosis.Subscribe(); err != nil {
 			logging.Log().Debug(err)
 		}
+
+		if _, err := deviceDiagnosis.RequestHeartbeat(); err != nil {
+			logging.Log().Debug(err)
+		}
 	}
 }
 

--- a/usecases/eg/lpc/usecase.go
+++ b/usecases/eg/lpc/usecase.go
@@ -18,6 +18,7 @@ var _ ucapi.EgLPCInterface = (*LPC)(nil)
 func NewLPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCallback) *LPC {
 	validActorTypes := []model.UseCaseActorType{model.UseCaseActorTypeControllableSystem}
 	validEntityTypes := []model.EntityTypeType{
+		model.EntityTypeTypeCEM,
 		model.EntityTypeTypeCompressor,
 		model.EntityTypeTypeEVSE,
 		model.EntityTypeTypeHeatPumpAppliance,

--- a/usecases/eg/lpp/events.go
+++ b/usecases/eg/lpp/events.go
@@ -83,6 +83,10 @@ func (e *LPP) connected(entity spineapi.EntityRemoteInterface) {
 		if _, err := deviceDiagnosis.Subscribe(); err != nil {
 			logging.Log().Debug(err)
 		}
+
+		if _, err := deviceDiagnosis.RequestHeartbeat(); err != nil {
+			logging.Log().Debug(err)
+		}
 	}
 }
 

--- a/usecases/eg/lpp/usecase.go
+++ b/usecases/eg/lpp/usecase.go
@@ -18,6 +18,7 @@ var _ ucapi.EgLPPInterface = (*LPP)(nil)
 func NewLPP(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCallback) *LPP {
 	validActorTypes := []model.UseCaseActorType{model.UseCaseActorTypeControllableSystem}
 	validEntityTypes := []model.EntityTypeType{
+		model.EntityTypeTypeCEM,
 		model.EntityTypeTypeEVSE,
 		model.EntityTypeTypeInverter,
 		model.EntityTypeTypeSmartEnergyAppliance,


### PR DESCRIPTION
- Controllable System LPC & LPP
  - If a write approval request is not for the usecase, approve it
  - clean up pending write approval list
- Energy Guard LPC & LPP
  - send read request for heartbeats
  - allow remote CEM entity
- Demo controlbox improvements
  - also supports LPP, but only sends a LPC limit
- Demo HEMS improvements
  - support LPC & LPP as Energy guard and controllable system
  - comment SPINE message logging