### PR TITLE
Add workaround for invalid MEB measurements

### DIFF
--- a/usecases/cem/evcem/public_test.go
+++ b/usecases/cem/evcem/public_test.go
@@ -1,6 +1,8 @@
 package evcem
 
 import (
+	"time"
+
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 	"github.com/stretchr/testify/assert"
@@ -101,6 +103,61 @@ func (s *CemEVCEMSuite) Test_EVCurrentPerPhase() {
 			{
 				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
 				Value:         model.NewScaledNumberType(10),
+			},
+		},
+	}
+
+	fErr = rFeature.UpdateData(model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.CurrentPerPhase(s.evEntity)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 10.0, data[0])
+
+	now := time.Now().Add(-50 * time.Second)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				Timestamp:     model.NewAbsoluteOrRelativeTimeTypeFromTime(now),
+			},
+		},
+	}
+
+	fErr = rFeature.UpdateData(model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.CurrentPerPhase(s.evEntity)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 10.0, data[0])
+
+	now = now.Add(-1 * time.Hour)
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				Timestamp:     model.NewAbsoluteOrRelativeTimeTypeFromTime(now),
+			},
+		},
+	}
+
+	fErr = rFeature.UpdateData(model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.CurrentPerPhase(s.evEntity)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 10.0, data[0])
+
+	now = now.Add(-1 * time.Hour)
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				Timestamp:     model.NewAbsoluteOrRelativeTimeTypeFromTime(now),
 			},
 		},
 	}


### PR DESCRIPTION
The PMCC EVSE can connect to MEB EVs via ISO and then uses the EV as NTP server. Sadly that server reports the wrong time and thus all measurements are invalid.

This commit adds a workaround to test if the measurement is within 1 minute if the time is shifted by 1 or 2 hours.