### PR TITLE
Make sure the device name address is spec conform

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/enbility/eebus-go/api"
@@ -96,7 +97,12 @@ func (s *Service) Setup() error {
 	}
 
 	// Create the SPINE device address, according to Protocol Specification 7.1.1.2
-	deviceAdress := fmt.Sprintf("d:_i:%s_%s%s", vendor, sd.DeviceModel(), serial)
+	var deviceAddress string
+	vendorType := "i"
+	if _, err := strconv.Atoi(vendor); err != nil {
+		vendorType = "n"
+	}
+	deviceAddress = fmt.Sprintf("d:_%s:%s_%s%s", vendorType, vendor, sd.DeviceModel(), serial)
 
 	// Create the local SPINE device
 	s.spineLocalDevice = spine.NewDeviceLocal(
@@ -104,7 +110,7 @@ func (s *Service) Setup() error {
 		sd.DeviceModel(),
 		sd.DeviceSerialNumber(),
 		sd.Identifier(),
-		deviceAdress,
+		deviceAddress,
 		sd.DeviceType(),
 		sd.FeatureSet(),
 		sd.HeartbeatTimeout(),

--- a/service/service.go
+++ b/service/service.go
@@ -104,6 +104,10 @@ func (s *Service) Setup() error {
 	}
 	deviceAddress = fmt.Sprintf("d:_%s:%s_%s%s", vendorType, vendor, sd.DeviceModel(), serial)
 
+	if len(deviceAddress) > 256 {
+		return fmt.Errorf("generated device address may not be longer than 256 characters: %s", deviceAddress)
+	}
+
 	// Create the local SPINE device
 	s.spineLocalDevice = spine.NewDeviceLocal(
 		sd.DeviceBrand(),

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -209,3 +209,28 @@ func (s *ServiceSuite) Test_Setup_IANA() {
 	device := s.sut.LocalDevice()
 	assert.NotNil(s.T(), device)
 }
+
+func (s *ServiceSuite) Test_Setup_Error_DeviceName() {
+	var err error
+	certificate := tls.Certificate{}
+	s.config, err = api.NewConfiguration(
+		"1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+		"brand",
+		"modelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodel",
+		"serialserialserialserialserialserialserialserialserialserialserialserialserialserialserialserialserial",
+		model.DeviceTypeTypeEnergyManagementSystem,
+		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, 230.0, time.Second*4)
+	assert.Nil(s.T(), nil, err)
+
+	s.sut = NewService(s.config, s.serviceReader)
+
+	err = s.sut.Setup()
+	assert.NotNil(s.T(), err)
+
+	certificate, err = cert.CreateCertificate("unit", "org", "de", "cn")
+	assert.Nil(s.T(), err)
+	s.config.SetCertificate(certificate)
+
+	err = s.sut.Setup()
+	assert.NotNil(s.T(), err)
+}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -158,6 +158,45 @@ func (s *ServiceSuite) Test_Setup() {
 	err = s.sut.Setup()
 	assert.Nil(s.T(), err)
 
+	address := s.sut.LocalDevice().Address()
+	assert.Equal(s.T(), "d:_n:vendor_model-serial", string(*address))
+
+	s.sut.connectionsHub = s.conHub
+	s.conHub.EXPECT().Start()
+	s.sut.Start()
+
+	time.Sleep(time.Millisecond * 200)
+
+	s.conHub.EXPECT().Shutdown()
+	s.sut.Shutdown()
+
+	device := s.sut.LocalDevice()
+	assert.NotNil(s.T(), device)
+}
+
+func (s *ServiceSuite) Test_Setup_IANA() {
+	var err error
+	certificate := tls.Certificate{}
+	s.config, err = api.NewConfiguration(
+		"12345", "brand", "model", "serial", model.DeviceTypeTypeEnergyManagementSystem,
+		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, 230.0, time.Second*4)
+	assert.Nil(s.T(), nil, err)
+
+	s.sut = NewService(s.config, s.serviceReader)
+
+	err = s.sut.Setup()
+	assert.NotNil(s.T(), err)
+
+	certificate, err = cert.CreateCertificate("unit", "org", "de", "cn")
+	assert.Nil(s.T(), err)
+	s.config.SetCertificate(certificate)
+
+	err = s.sut.Setup()
+	assert.Nil(s.T(), err)
+
+	address := s.sut.LocalDevice().Address()
+	assert.Equal(s.T(), "d:_i:12345_model-serial", string(*address))
+
 	s.sut.connectionsHub = s.conHub
 	s.conHub.EXPECT().Start()
 	s.sut.Start()


### PR DESCRIPTION
If the vendor code is a number, only then use the “d:_i:” notation, otherwise use “d:_n:” notation