### PR TITLE
Remove voltage configuration

### DIFF
--- a/api/configuration.go
+++ b/api/configuration.go
@@ -64,11 +64,6 @@ type Configuration struct {
 	// The certificate used for the service and its connections, required
 	certificate tls.Certificate
 
-	// The sites grid voltage
-	// This is useful when e.g. power values are not available and therefor
-	// need to be calculated using the current values
-	voltage float64
-
 	// The timeout to be used for sending heartbeats
 	heartbeatTimeout time.Duration
 
@@ -86,13 +81,11 @@ func NewConfiguration(
 	entityTypes []model.EntityTypeType,
 	port int,
 	certificate tls.Certificate,
-	voltage float64,
 	heartbeatTimeout time.Duration,
 ) (*Configuration, error) {
 	configuration := &Configuration{
 		certificate:           certificate,
 		port:                  port,
-		voltage:               voltage,
 		heartbeatTimeout:      heartbeatTimeout,
 		mdnsProviderSelection: mdns.MdnsProviderSelectionGoZeroConfOnly,
 	}
@@ -240,11 +233,6 @@ func (s *Configuration) Port() int {
 
 func (s *Configuration) SetCertificate(cert tls.Certificate) {
 	s.certificate = cert
-}
-
-// return the sites predefined grid voltage
-func (s *Configuration) Voltage() float64 {
-	return s.voltage
 }
 
 func (s *Configuration) HeartbeatTimeout() time.Duration {

--- a/api/configuration_test.go
+++ b/api/configuration_test.go
@@ -27,54 +27,53 @@ func (s *ConfigurationSuite) Test_Configuration() {
 	model := "model"
 	serial := "serial"
 	port := 4567
-	volt := 230.0
 	heartbeatTimeout := time.Second * 4
 	entityTypes := []spinemodel.EntityTypeType{spinemodel.EntityTypeTypeCEM}
 
 	config, err := NewConfiguration("", brand, model, serial, spinemodel.DeviceTypeTypeEnergyManagementSystem,
-		entityTypes, 0, certificate, volt, heartbeatTimeout)
+		entityTypes, 0, certificate, heartbeatTimeout)
 
 	assert.Nil(s.T(), config)
 	assert.NotNil(s.T(), err)
 
 	config, err = NewConfiguration("", brand, model, serial, spinemodel.DeviceTypeTypeEnergyManagementSystem,
-		entityTypes, port, certificate, volt, heartbeatTimeout)
+		entityTypes, port, certificate, heartbeatTimeout)
 
 	assert.Nil(s.T(), config)
 	assert.NotNil(s.T(), err)
 
 	config, err = NewConfiguration(vendor, "", model, serial, spinemodel.DeviceTypeTypeEnergyManagementSystem,
-		entityTypes, port, certificate, 230, heartbeatTimeout)
+		entityTypes, port, certificate, heartbeatTimeout)
 
 	assert.Nil(s.T(), config)
 	assert.NotNil(s.T(), err)
 
 	config, err = NewConfiguration(vendor, brand, "", serial, spinemodel.DeviceTypeTypeEnergyManagementSystem,
-		entityTypes, port, certificate, 230, heartbeatTimeout)
+		entityTypes, port, certificate, heartbeatTimeout)
 
 	assert.Nil(s.T(), config)
 	assert.NotNil(s.T(), err)
 
 	config, err = NewConfiguration(vendor, brand, model, "", spinemodel.DeviceTypeTypeEnergyManagementSystem,
-		entityTypes, port, certificate, 230, heartbeatTimeout)
+		entityTypes, port, certificate, heartbeatTimeout)
 
 	assert.Nil(s.T(), config)
 	assert.NotNil(s.T(), err)
 
 	config, err = NewConfiguration(vendor, brand, model, serial, "",
-		entityTypes, port, certificate, 230, heartbeatTimeout)
+		entityTypes, port, certificate, heartbeatTimeout)
 
 	assert.Nil(s.T(), config)
 	assert.NotNil(s.T(), err)
 
 	config, err = NewConfiguration(vendor, brand, model, serial, spinemodel.DeviceTypeTypeEnergyManagementSystem,
-		[]spinemodel.EntityTypeType{}, port, certificate, 230, heartbeatTimeout)
+		[]spinemodel.EntityTypeType{}, port, certificate, heartbeatTimeout)
 
 	assert.Nil(s.T(), config)
 	assert.NotNil(s.T(), err)
 
 	config, err = NewConfiguration(vendor, brand, model, serial, spinemodel.DeviceTypeTypeEnergyManagementSystem,
-		entityTypes, port, certificate, 230, heartbeatTimeout)
+		entityTypes, port, certificate, heartbeatTimeout)
 
 	assert.NotNil(s.T(), config)
 	assert.Nil(s.T(), err)
@@ -109,9 +108,6 @@ func (s *ConfigurationSuite) Test_Configuration() {
 	config.SetAlternateMdnsServiceName(alternate)
 	id = config.MdnsServiceName()
 	assert.Equal(s.T(), alternate, id)
-
-	voltage := config.Voltage()
-	assert.Equal(s.T(), volt, voltage)
 
 	portValue := config.Port()
 	assert.Equal(s.T(), port, portValue)

--- a/cmd/controlbox/main.go
+++ b/cmd/controlbox/main.go
@@ -78,7 +78,7 @@ func (h *controlbox) run() {
 		"Demo", "Demo", "ControlBox", "123456789",
 		model.DeviceTypeTypeElectricitySupplySystem,
 		[]model.EntityTypeType{model.EntityTypeTypeGridGuard},
-		port, certificate, 230, time.Second*60)
+		port, certificate, time.Second*60)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/evse/main.go
+++ b/cmd/evse/main.go
@@ -74,7 +74,7 @@ func (h *evse) run() {
 		"Demo", "Demo", "EVSE", "234567890",
 		model.DeviceTypeTypeChargingStation,
 		[]model.EntityTypeType{model.EntityTypeTypeEVSE},
-		port, certificate, 230, time.Second*4)
+		port, certificate, time.Second*4)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/hems/main.go
+++ b/cmd/hems/main.go
@@ -80,7 +80,7 @@ func (h *hems) run() {
 		"Demo", "Demo", "HEMS", "123456789",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		port, certificate, 230, time.Second*4)
+		port, certificate, time.Second*4)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/features/server/deviceconfiguration_test.go
+++ b/features/server/deviceconfiguration_test.go
@@ -42,7 +42,7 @@ func (s *DeviceConfigurationSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/features/server/devicediagnosis_test.go
+++ b/features/server/devicediagnosis_test.go
@@ -42,7 +42,7 @@ func (s *DeviceDiagnosisSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/features/server/electricalconnection_test.go
+++ b/features/server/electricalconnection_test.go
@@ -42,7 +42,7 @@ func (s *ElectricalConnectionSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/features/server/feature_test.go
+++ b/features/server/feature_test.go
@@ -47,7 +47,7 @@ func (s *FeatureSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/features/server/loadcontrol_test.go
+++ b/features/server/loadcontrol_test.go
@@ -42,7 +42,7 @@ func (s *LoadControlSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/features/server/measurement_test.go
+++ b/features/server/measurement_test.go
@@ -42,7 +42,7 @@ func (s *MeasurementSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -50,7 +50,7 @@ func (s *ServiceSuite) BeforeTest(suiteName, testName string) {
 	var err error
 	s.config, err = api.NewConfiguration(
 		"vendor", "brand", "model", "serial", model.DeviceTypeTypeEnergyManagementSystem,
-		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, 230.0, time.Second*4)
+		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, time.Second*4)
 	assert.Nil(s.T(), nil, err)
 
 	s.sut = NewService(s.config, s.serviceReader)
@@ -179,7 +179,7 @@ func (s *ServiceSuite) Test_Setup_IANA() {
 	certificate := tls.Certificate{}
 	s.config, err = api.NewConfiguration(
 		"12345", "brand", "model", "serial", model.DeviceTypeTypeEnergyManagementSystem,
-		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, 230.0, time.Second*4)
+		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, time.Second*4)
 	assert.Nil(s.T(), nil, err)
 
 	s.sut = NewService(s.config, s.serviceReader)
@@ -219,7 +219,7 @@ func (s *ServiceSuite) Test_Setup_Error_DeviceName() {
 		"modelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodelmodel",
 		"serialserialserialserialserialserialserialserialserialserialserialserialserialserialserialserialserial",
 		model.DeviceTypeTypeEnergyManagementSystem,
-		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, 230.0, time.Second*4)
+		[]model.EntityTypeType{model.EntityTypeTypeCEM}, 4729, certificate, time.Second*4)
 	assert.Nil(s.T(), nil, err)
 
 	s.sut = NewService(s.config, s.serviceReader)

--- a/usecases/cem/cevc/testhelper_test.go
+++ b/usecases/cem/cevc/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemCEVCSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/evcc/testhelper_test.go
+++ b/usecases/cem/evcc/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemEVCCSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/evcem/public_test.go
+++ b/usecases/cem/evcem/public_test.go
@@ -408,9 +408,8 @@ func (s *CemEVCEMSuite) Test_EVPowerPerPhase_Current() {
 	assert.Nil(s.T(), fErr)
 
 	data, err = s.sut.PowerPerPhase(s.evEntity)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 3, len(data))
-	assert.Equal(s.T(), 1170.7, data[0])
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0, len(data))
 }
 
 func (s *CemEVCEMSuite) Test_EVChargedEnergy() {
@@ -456,4 +455,112 @@ func (s *CemEVCEMSuite) Test_EVChargedEnergy() {
 	data, err = s.sut.EnergyCharged(s.evEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 80.0, data)
+}
+
+func (s *CemEVCEMSuite) Test_EVChargedEnergy_ElliGen1() {
+	data, err := s.sut.EnergyCharged(s.mockRemoteEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	data, err = s.sut.EnergyCharged(s.evEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	measDesc := &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(1)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(2)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(3)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeW),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(4)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeW),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(5)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeW),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(6)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeEnergy),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeCharge),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeWh),
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.evEntity, model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
+	fErr := rFeature.UpdateData(model.FunctionTypeMeasurementDescriptionListData, measDesc, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyCharged(s.evEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	measData := &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(5.09),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(1)),
+				Value:         model.NewScaledNumberType(4.04),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(2)),
+				Value:         model.NewScaledNumberType(5.09),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(3)),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(4)),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(5)),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(6)),
+			},
+		},
+	}
+
+	fErr = rFeature.UpdateData(model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyCharged(s.evEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
 }

--- a/usecases/cem/evcem/testhelper_test.go
+++ b/usecases/cem/evcem/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemEVCEMSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/evsecc/testhelper_test.go
+++ b/usecases/cem/evsecc/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemEVSECCSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/evsoc/testhelper_test.go
+++ b/usecases/cem/evsoc/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemEVSOCSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/opev/testhelper_test.go
+++ b/usecases/cem/opev/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemOPEVSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/oscev/testhelper_test.go
+++ b/usecases/cem/oscev/testhelper_test.go
@@ -47,7 +47,7 @@ func (s *CemOSCEVSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/vabd/testhelper_test.go
+++ b/usecases/cem/vabd/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemVABDSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cem/vapd/testhelper_test.go
+++ b/usecases/cem/vapd/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *CemVAPDSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cs/lpc/testhelper_test.go
+++ b/usecases/cs/lpc/testhelper_test.go
@@ -51,7 +51,7 @@ func (s *CsLPCSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/cs/lpp/testhelper_test.go
+++ b/usecases/cs/lpp/testhelper_test.go
@@ -51,7 +51,7 @@ func (s *CsLPPSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/eg/lpc/testhelper_test.go
+++ b/usecases/eg/lpc/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *EgLPCSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/eg/lpp/testhelper_test.go
+++ b/usecases/eg/lpp/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *EgLPPSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/internal/testhelper_test.go
+++ b/usecases/internal/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *InternalSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/ma/mgcp/testhelper_test.go
+++ b/usecases/ma/mgcp/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *GcpMGCPSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/ma/mpc/testhelper_test.go
+++ b/usecases/ma/mpc/testhelper_test.go
@@ -48,7 +48,7 @@ func (s *MaMPCSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()

--- a/usecases/usecase/testhelper_test.go
+++ b/usecases/usecase/testhelper_test.go
@@ -57,7 +57,7 @@ func (s *UseCaseSuite) BeforeTest(suiteName, testName string) {
 		"test", "test", "test", "test",
 		model.DeviceTypeTypeEnergyManagementSystem,
 		[]model.EntityTypeType{model.EntityTypeTypeCEM},
-		9999, cert, 230.0, time.Second*4)
+		9999, cert, time.Second*4)
 
 	serviceHandler := mocks.NewServiceReaderInterface(s.T())
 	serviceHandler.EXPECT().ServicePairingDetailUpdate(mock.Anything, mock.Anything).Return().Maybe()


### PR DESCRIPTION
- No need to setup default voltage
- EVCem `PowerPerPhase` returns an error if power is not available instead of using currents and static voltage value