### PR TITLE
Share LPC and LPP failsafe duration minimum

### DIFF
--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -189,12 +189,19 @@ func (e *LPC) AddFeatures() {
 				Unit:      util.Ptr(model.UnitOfMeasurementTypeW),
 			},
 		)
-		dcs.AddKeyValueDescription(
-			model.DeviceConfigurationKeyValueDescriptionDataType{
-				KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
-				ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeDuration),
-			},
-		)
+
+		// only add if it doesn't exist yet
+		filter := model.DeviceConfigurationKeyValueDescriptionDataType{
+			KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+		}
+		if data, err := dcs.GetKeyValueDescriptionsForFilter(filter); err == nil && len(data) == 0 {
+			dcs.AddKeyValueDescription(
+				model.DeviceConfigurationKeyValueDescriptionDataType{
+					KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+					ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeDuration),
+				},
+			)
+		}
 
 		value := &model.DeviceConfigurationKeyValueValueType{
 			ScaledNumber: model.NewScaledNumberType(0),

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -79,7 +79,7 @@ func (e *LPP) SetProductionLimit(limit ucapi.LoadLimit) (resultErr error) {
 	return loadControlf.UpdateLimitDataForId(limitData, deleteTimePeriod, limidId)
 }
 
-// return the currently pending incoming consumption write limits
+// return the currently pending incoming production write limits
 func (e *LPP) PendingProductionLimits() map[model.MsgCounterType]ucapi.LoadLimit {
 	result := make(map[model.MsgCounterType]ucapi.LoadLimit)
 
@@ -127,7 +127,7 @@ func (e *LPP) PendingProductionLimits() map[model.MsgCounterType]ucapi.LoadLimit
 	return result
 }
 
-// accept or deny an incoming consumption write limit
+// accept or deny an incoming production write limit
 //
 // use PendingProductionLimits to get the list of currently pending requests
 func (e *LPP) ApproveOrDenyProductionLimit(msgCounter model.MsgCounterType, approve bool, reason string) {

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -189,12 +189,19 @@ func (e *LPP) AddFeatures() {
 				Unit:      util.Ptr(model.UnitOfMeasurementTypeW),
 			},
 		)
-		dcs.AddKeyValueDescription(
-			model.DeviceConfigurationKeyValueDescriptionDataType{
-				KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
-				ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeDuration),
-			},
-		)
+
+		// only add if it doesn't exist yet
+		filter := model.DeviceConfigurationKeyValueDescriptionDataType{
+			KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+		}
+		if data, err := dcs.GetKeyValueDescriptionsForFilter(filter); err == nil && len(data) == 0 {
+			dcs.AddKeyValueDescription(
+				model.DeviceConfigurationKeyValueDescriptionDataType{
+					KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+					ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeDuration),
+				},
+			)
+		}
 
 		value := &model.DeviceConfigurationKeyValueValueType{
 			ScaledNumber: model.NewScaledNumberType(0),


### PR DESCRIPTION
If LPC and LPP in a controllable system are used in the same entity, then the failsafe duration minimum is a shared data point and will be used from both use cases.

Also fix minor typo in comments