### PR TITLE
Properly support CS LPC & LPP for all device types

### DIFF
--- a/usecases/api/cs_lpc.go
+++ b/usecases/api/cs_lpc.go
@@ -81,14 +81,18 @@ type CsLPCInterface interface {
 
 	// Scenario 4
 
-	// return nominal maximum active (real) power the Controllable System is
-	// allowed to consume due to the customer's contract.
-	ContractualConsumptionNominalMax() (float64, error)
+	// return nominal maximum active (real) power the Controllable System is allowed to consume.
+	//
+	// If the local device type is an EnergyManagementSystem, the contractual consumption
+	// nominal max is returned, otherwise the power consumption nominal max is returned.
+	ConsumptionNominalMax() (float64, error)
 
-	// set nominal maximum active (real) power the Controllable System is
-	// allowed to consume due to the customer's contract.
+	// set power nominal maximum active (real) power the Controllable System is allowed to consume.
+	//
+	// If the local device type is an EnergyManagementSystem, the contractual consumption
+	// nominal max is set, otherwise the power consumption nominal max is set.
 	//
 	// parameters:
-	//   - value: contractual nominal max power consumption in W
-	SetContractualConsumptionNominalMax(value float64) (resultErr error)
+	//   - value: nominal max power consumption in W
+	SetConsumptionNominalMax(value float64) (resultErr error)
 }

--- a/usecases/api/cs_lpp.go
+++ b/usecases/api/cs_lpp.go
@@ -81,14 +81,18 @@ type CsLPPInterface interface {
 
 	// Scenario 4
 
-	// return nominal maximum active (real) power the Controllable System is
-	// allowed to produce due to the customer's contract.
-	ContractualProductionNominalMax() (float64, error)
+	// return nominal maximum active (real) power the Controllable System is allowed to produce.
+	//
+	// If the local device type is an EnergyManagementSystem, the contractual production
+	// nominal max is returned, otherwise the power production nominal max is returned.
+	ProductionNominalMax() (float64, error)
 
-	// set nominal maximum active (real) power the Controllable System is
-	// allowed to produce due to the customer's contract.
+	// set power nominal maximum active (real) power the Controllable System is allowed to produce.
+	//
+	// If the local device type is an EnergyManagementSystem, the contractual production
+	// nominal max is set, otherwise the power production nominal max is set.
 	//
 	// parameters:
-	//   - value: contractual nominal max power production in W
-	SetContractualProductionNominalMax(value float64) (resultErr error)
+	//   - value: nominal max power production in W
+	SetProductionNominalMax(value float64) (resultErr error)
 }

--- a/usecases/cs/lpc/public_test.go
+++ b/usecases/cs/lpc/public_test.go
@@ -152,15 +152,15 @@ func (s *CsLPCSuite) Test_IsHeartbeatWithinDuration() {
 	assert.True(s.T(), value)
 }
 
-func (s *CsLPCSuite) Test_ContractualConsumptionNominalMax() {
-	value, err := s.sut.ContractualConsumptionNominalMax()
+func (s *CsLPCSuite) Test_ConsumptionNominalMax() {
+	value, err := s.sut.ConsumptionNominalMax()
 	assert.Equal(s.T(), 0.0, value)
 	assert.NotNil(s.T(), err)
 
-	err = s.sut.SetContractualConsumptionNominalMax(10)
+	err = s.sut.SetConsumptionNominalMax(10)
 	assert.Nil(s.T(), err)
 
-	value, err = s.sut.ContractualConsumptionNominalMax()
+	value, err = s.sut.ConsumptionNominalMax()
 	assert.Equal(s.T(), 10.0, value)
 	assert.Nil(s.T(), err)
 }

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -245,7 +245,7 @@ func (e *LPC) AddFeatures() {
 			ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
 			ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(0)),
 			CharacteristicContext:  util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
-			CharacteristicType:     util.Ptr(model.ElectricalConnectionCharacteristicTypeTypeContractualConsumptionNominalMax),
+			CharacteristicType:     util.Ptr(e.characteristicType()),
 			Unit:                   util.Ptr(model.UnitOfMeasurementTypeW),
 		}
 		_, _ = ec.AddCharacteristic(newCharData)

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -353,9 +353,9 @@ func (e *LPP) SetProductionNominalMax(value float64) error {
 func (e *LPP) characteristicType() model.ElectricalConnectionCharacteristicTypeType {
 	deviceType := e.LocalEntity.Device().DeviceType()
 
-	// According to LPC V1.0 2.2, lines 400ff:
-	// - a HEMS provides contractual consumption nominal max
-	// - any other devices provides power consupmtion nominal max
+	// According to LPP V1.0 2.2, lines 420ff:
+	// - a HEMS provides contractual production nominal max
+	// - any other devices provides power production nominal max
 	characteristic := model.ElectricalConnectionCharacteristicTypeTypePowerProductionNominalMax
 	if deviceType == nil || *deviceType == model.DeviceTypeTypeEnergyManagementSystem {
 		characteristic = model.ElectricalConnectionCharacteristicTypeTypeContractualProductionNominalMax

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -285,9 +285,11 @@ func (e *LPP) IsHeartbeatWithinDuration() bool {
 
 // Scenario 4
 
-// return nominal maximum active (real) power the Controllable System is
-// allowed to produce due to the customer's contract.
-func (e *LPP) ContractualProductionNominalMax() (value float64, resultErr error) {
+// return nominal maximum active (real) power the Controllable System is allowed to produce.
+//
+// If the local device type is an EnergyManagementSystem, the contractual production
+// nominal max is returned, otherwise the power production nominal max is returned.
+func (e *LPP) ProductionNominalMax() (value float64, resultErr error) {
 	value = 0
 	resultErr = api.ErrDataNotAvailable
 
@@ -301,7 +303,7 @@ func (e *LPP) ContractualProductionNominalMax() (value float64, resultErr error)
 		ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
 		ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(0)),
 		CharacteristicContext:  util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
-		CharacteristicType:     util.Ptr(model.ElectricalConnectionCharacteristicTypeTypeContractualProductionNominalMax),
+		CharacteristicType:     util.Ptr(e.characteristicType()),
 	}
 	charData, err := ec.GetCharacteristicsForFilter(filter)
 	if err != nil || len(charData) == 0 ||
@@ -313,9 +315,14 @@ func (e *LPP) ContractualProductionNominalMax() (value float64, resultErr error)
 	return charData[0].Value.GetValue(), nil
 }
 
-// set nominal maximum active (real) power the Controllable System is
-// allowed to produce due to the customer's contract.
-func (e *LPP) SetContractualProductionNominalMax(value float64) error {
+// set nominal maximum active (real) power the Controllable System is allowed to produce.
+//
+// If the local device type is an EnergyManagementSystem, the contractual production
+// nominal max is set, otherwise the power production nominal max is set.
+//
+// parameters:
+//   - value: nominal max power production in W
+func (e *LPP) SetProductionNominalMax(value float64) error {
 	ec, err := server.NewElectricalConnection(e.LocalEntity)
 	if err != nil {
 		return err
@@ -327,7 +334,7 @@ func (e *LPP) SetContractualProductionNominalMax(value float64) error {
 		ElectricalConnectionId: electricalConnectionid,
 		ParameterId:            parameterId,
 		CharacteristicContext:  util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
-		CharacteristicType:     util.Ptr(model.ElectricalConnectionCharacteristicTypeTypeContractualProductionNominalMax),
+		CharacteristicType:     util.Ptr(e.characteristicType()),
 	})
 	if err != nil || len(charList) == 0 {
 		return api.ErrDataNotAvailable
@@ -340,4 +347,19 @@ func (e *LPP) SetContractualProductionNominalMax(value float64) error {
 		Value:                  model.NewScaledNumberType(value),
 	}
 	return ec.UpdateCharacteristic(data, nil)
+}
+
+// returns the characteristictype depending on the local entities device devicetype
+func (e *LPP) characteristicType() model.ElectricalConnectionCharacteristicTypeType {
+	deviceType := e.LocalEntity.Device().DeviceType()
+
+	// According to LPC V1.0 2.2, lines 400ff:
+	// - a HEMS provides contractual consumption nominal max
+	// - any other devices provides power consupmtion nominal max
+	characteristic := model.ElectricalConnectionCharacteristicTypeTypePowerProductionNominalMax
+	if deviceType == nil || *deviceType == model.DeviceTypeTypeEnergyManagementSystem {
+		characteristic = model.ElectricalConnectionCharacteristicTypeTypeContractualProductionNominalMax
+	}
+
+	return characteristic
 }

--- a/usecases/cs/lpp/public_test.go
+++ b/usecases/cs/lpp/public_test.go
@@ -152,14 +152,14 @@ func (s *CsLPPSuite) Test_IsHeartbeatWithinDuration() {
 }
 
 func (s *CsLPPSuite) Test_ContractualProductionNominalMax() {
-	value, err := s.sut.ContractualProductionNominalMax()
+	value, err := s.sut.ProductionNominalMax()
 	assert.Equal(s.T(), 0.0, value)
 	assert.NotNil(s.T(), err)
 
-	err = s.sut.SetContractualProductionNominalMax(10)
+	err = s.sut.SetProductionNominalMax(10)
 	assert.Nil(s.T(), err)
 
-	value, err = s.sut.ContractualProductionNominalMax()
+	value, err = s.sut.ProductionNominalMax()
 	assert.Equal(s.T(), 10.0, value)
 	assert.Nil(s.T(), err)
 }

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -245,7 +245,7 @@ func (e *LPP) AddFeatures() {
 			ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
 			ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(0)),
 			CharacteristicContext:  util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
-			CharacteristicType:     util.Ptr(model.ElectricalConnectionCharacteristicTypeTypeContractualProductionNominalMax),
+			CharacteristicType:     util.Ptr(e.characteristicType()),
 			Unit:                   util.Ptr(model.UnitOfMeasurementTypeW),
 		}
 		_, _ = ec.AddCharacteristic(newCharData)

--- a/usecases/mocks/CsLPCInterface.go
+++ b/usecases/mocks/CsLPCInterface.go
@@ -230,12 +230,12 @@ func (_c *CsLPCInterface_ConsumptionLimit_Call) RunAndReturn(run func() (api.Loa
 	return _c
 }
 
-// ContractualConsumptionNominalMax provides a mock function with given fields:
-func (_m *CsLPCInterface) ContractualConsumptionNominalMax() (float64, error) {
+// ConsumptionNominalMax provides a mock function with given fields:
+func (_m *CsLPCInterface) ConsumptionNominalMax() (float64, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for ContractualConsumptionNominalMax")
+		panic("no return value specified for ConsumptionNominalMax")
 	}
 
 	var r0 float64
@@ -258,29 +258,29 @@ func (_m *CsLPCInterface) ContractualConsumptionNominalMax() (float64, error) {
 	return r0, r1
 }
 
-// CsLPCInterface_ContractualConsumptionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ContractualConsumptionNominalMax'
-type CsLPCInterface_ContractualConsumptionNominalMax_Call struct {
+// CsLPCInterface_ConsumptionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConsumptionNominalMax'
+type CsLPCInterface_ConsumptionNominalMax_Call struct {
 	*mock.Call
 }
 
-// ContractualConsumptionNominalMax is a helper method to define mock.On call
-func (_e *CsLPCInterface_Expecter) ContractualConsumptionNominalMax() *CsLPCInterface_ContractualConsumptionNominalMax_Call {
-	return &CsLPCInterface_ContractualConsumptionNominalMax_Call{Call: _e.mock.On("ContractualConsumptionNominalMax")}
+// ConsumptionNominalMax is a helper method to define mock.On call
+func (_e *CsLPCInterface_Expecter) ConsumptionNominalMax() *CsLPCInterface_ConsumptionNominalMax_Call {
+	return &CsLPCInterface_ConsumptionNominalMax_Call{Call: _e.mock.On("ConsumptionNominalMax")}
 }
 
-func (_c *CsLPCInterface_ContractualConsumptionNominalMax_Call) Run(run func()) *CsLPCInterface_ContractualConsumptionNominalMax_Call {
+func (_c *CsLPCInterface_ConsumptionNominalMax_Call) Run(run func()) *CsLPCInterface_ConsumptionNominalMax_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *CsLPCInterface_ContractualConsumptionNominalMax_Call) Return(_a0 float64, _a1 error) *CsLPCInterface_ContractualConsumptionNominalMax_Call {
+func (_c *CsLPCInterface_ConsumptionNominalMax_Call) Return(_a0 float64, _a1 error) *CsLPCInterface_ConsumptionNominalMax_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *CsLPCInterface_ContractualConsumptionNominalMax_Call) RunAndReturn(run func() (float64, error)) *CsLPCInterface_ContractualConsumptionNominalMax_Call {
+func (_c *CsLPCInterface_ConsumptionNominalMax_Call) RunAndReturn(run func() (float64, error)) *CsLPCInterface_ConsumptionNominalMax_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -719,12 +719,12 @@ func (_c *CsLPCInterface_SetConsumptionLimit_Call) RunAndReturn(run func(api.Loa
 	return _c
 }
 
-// SetContractualConsumptionNominalMax provides a mock function with given fields: value
-func (_m *CsLPCInterface) SetContractualConsumptionNominalMax(value float64) error {
+// SetConsumptionNominalMax provides a mock function with given fields: value
+func (_m *CsLPCInterface) SetConsumptionNominalMax(value float64) error {
 	ret := _m.Called(value)
 
 	if len(ret) == 0 {
-		panic("no return value specified for SetContractualConsumptionNominalMax")
+		panic("no return value specified for SetConsumptionNominalMax")
 	}
 
 	var r0 error
@@ -737,30 +737,30 @@ func (_m *CsLPCInterface) SetContractualConsumptionNominalMax(value float64) err
 	return r0
 }
 
-// CsLPCInterface_SetContractualConsumptionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetContractualConsumptionNominalMax'
-type CsLPCInterface_SetContractualConsumptionNominalMax_Call struct {
+// CsLPCInterface_SetConsumptionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetConsumptionNominalMax'
+type CsLPCInterface_SetConsumptionNominalMax_Call struct {
 	*mock.Call
 }
 
-// SetContractualConsumptionNominalMax is a helper method to define mock.On call
+// SetConsumptionNominalMax is a helper method to define mock.On call
 //   - value float64
-func (_e *CsLPCInterface_Expecter) SetContractualConsumptionNominalMax(value interface{}) *CsLPCInterface_SetContractualConsumptionNominalMax_Call {
-	return &CsLPCInterface_SetContractualConsumptionNominalMax_Call{Call: _e.mock.On("SetContractualConsumptionNominalMax", value)}
+func (_e *CsLPCInterface_Expecter) SetConsumptionNominalMax(value interface{}) *CsLPCInterface_SetConsumptionNominalMax_Call {
+	return &CsLPCInterface_SetConsumptionNominalMax_Call{Call: _e.mock.On("SetConsumptionNominalMax", value)}
 }
 
-func (_c *CsLPCInterface_SetContractualConsumptionNominalMax_Call) Run(run func(value float64)) *CsLPCInterface_SetContractualConsumptionNominalMax_Call {
+func (_c *CsLPCInterface_SetConsumptionNominalMax_Call) Run(run func(value float64)) *CsLPCInterface_SetConsumptionNominalMax_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(float64))
 	})
 	return _c
 }
 
-func (_c *CsLPCInterface_SetContractualConsumptionNominalMax_Call) Return(resultErr error) *CsLPCInterface_SetContractualConsumptionNominalMax_Call {
+func (_c *CsLPCInterface_SetConsumptionNominalMax_Call) Return(resultErr error) *CsLPCInterface_SetConsumptionNominalMax_Call {
 	_c.Call.Return(resultErr)
 	return _c
 }
 
-func (_c *CsLPCInterface_SetContractualConsumptionNominalMax_Call) RunAndReturn(run func(float64) error) *CsLPCInterface_SetContractualConsumptionNominalMax_Call {
+func (_c *CsLPCInterface_SetConsumptionNominalMax_Call) RunAndReturn(run func(float64) error) *CsLPCInterface_SetConsumptionNominalMax_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/mocks/CsLPPInterface.go
+++ b/usecases/mocks/CsLPPInterface.go
@@ -175,61 +175,6 @@ func (_c *CsLPPInterface_AvailableScenariosForEntity_Call) RunAndReturn(run func
 	return _c
 }
 
-// ContractualProductionNominalMax provides a mock function with given fields:
-func (_m *CsLPPInterface) ContractualProductionNominalMax() (float64, error) {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ContractualProductionNominalMax")
-	}
-
-	var r0 float64
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (float64, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() float64); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(float64)
-	}
-
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// CsLPPInterface_ContractualProductionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ContractualProductionNominalMax'
-type CsLPPInterface_ContractualProductionNominalMax_Call struct {
-	*mock.Call
-}
-
-// ContractualProductionNominalMax is a helper method to define mock.On call
-func (_e *CsLPPInterface_Expecter) ContractualProductionNominalMax() *CsLPPInterface_ContractualProductionNominalMax_Call {
-	return &CsLPPInterface_ContractualProductionNominalMax_Call{Call: _e.mock.On("ContractualProductionNominalMax")}
-}
-
-func (_c *CsLPPInterface_ContractualProductionNominalMax_Call) Run(run func()) *CsLPPInterface_ContractualProductionNominalMax_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *CsLPPInterface_ContractualProductionNominalMax_Call) Return(_a0 float64, _a1 error) *CsLPPInterface_ContractualProductionNominalMax_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *CsLPPInterface_ContractualProductionNominalMax_Call) RunAndReturn(run func() (float64, error)) *CsLPPInterface_ContractualProductionNominalMax_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // FailsafeDurationMinimum provides a mock function with given fields:
 func (_m *CsLPPInterface) FailsafeDurationMinimum() (time.Duration, bool, error) {
 	ret := _m.Called()
@@ -594,6 +539,61 @@ func (_c *CsLPPInterface_ProductionLimit_Call) RunAndReturn(run func() (api.Load
 	return _c
 }
 
+// ProductionNominalMax provides a mock function with given fields:
+func (_m *CsLPPInterface) ProductionNominalMax() (float64, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ProductionNominalMax")
+	}
+
+	var r0 float64
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (float64, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() float64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CsLPPInterface_ProductionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ProductionNominalMax'
+type CsLPPInterface_ProductionNominalMax_Call struct {
+	*mock.Call
+}
+
+// ProductionNominalMax is a helper method to define mock.On call
+func (_e *CsLPPInterface_Expecter) ProductionNominalMax() *CsLPPInterface_ProductionNominalMax_Call {
+	return &CsLPPInterface_ProductionNominalMax_Call{Call: _e.mock.On("ProductionNominalMax")}
+}
+
+func (_c *CsLPPInterface_ProductionNominalMax_Call) Run(run func()) *CsLPPInterface_ProductionNominalMax_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CsLPPInterface_ProductionNominalMax_Call) Return(_a0 float64, _a1 error) *CsLPPInterface_ProductionNominalMax_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *CsLPPInterface_ProductionNominalMax_Call) RunAndReturn(run func() (float64, error)) *CsLPPInterface_ProductionNominalMax_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoteEntitiesScenarios provides a mock function with given fields:
 func (_m *CsLPPInterface) RemoteEntitiesScenarios() []eebus_goapi.RemoteEntityScenarios {
 	ret := _m.Called()
@@ -669,52 +669,6 @@ func (_c *CsLPPInterface_RemoveUseCase_Call) Return() *CsLPPInterface_RemoveUseC
 }
 
 func (_c *CsLPPInterface_RemoveUseCase_Call) RunAndReturn(run func()) *CsLPPInterface_RemoveUseCase_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetContractualProductionNominalMax provides a mock function with given fields: value
-func (_m *CsLPPInterface) SetContractualProductionNominalMax(value float64) error {
-	ret := _m.Called(value)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetContractualProductionNominalMax")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(float64) error); ok {
-		r0 = rf(value)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// CsLPPInterface_SetContractualProductionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetContractualProductionNominalMax'
-type CsLPPInterface_SetContractualProductionNominalMax_Call struct {
-	*mock.Call
-}
-
-// SetContractualProductionNominalMax is a helper method to define mock.On call
-//   - value float64
-func (_e *CsLPPInterface_Expecter) SetContractualProductionNominalMax(value interface{}) *CsLPPInterface_SetContractualProductionNominalMax_Call {
-	return &CsLPPInterface_SetContractualProductionNominalMax_Call{Call: _e.mock.On("SetContractualProductionNominalMax", value)}
-}
-
-func (_c *CsLPPInterface_SetContractualProductionNominalMax_Call) Run(run func(value float64)) *CsLPPInterface_SetContractualProductionNominalMax_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(float64))
-	})
-	return _c
-}
-
-func (_c *CsLPPInterface_SetContractualProductionNominalMax_Call) Return(resultErr error) *CsLPPInterface_SetContractualProductionNominalMax_Call {
-	_c.Call.Return(resultErr)
-	return _c
-}
-
-func (_c *CsLPPInterface_SetContractualProductionNominalMax_Call) RunAndReturn(run func(float64) error) *CsLPPInterface_SetContractualProductionNominalMax_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -855,6 +809,52 @@ func (_c *CsLPPInterface_SetProductionLimit_Call) Return(resultErr error) *CsLPP
 }
 
 func (_c *CsLPPInterface_SetProductionLimit_Call) RunAndReturn(run func(api.LoadLimit) error) *CsLPPInterface_SetProductionLimit_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetProductionNominalMax provides a mock function with given fields: value
+func (_m *CsLPPInterface) SetProductionNominalMax(value float64) error {
+	ret := _m.Called(value)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetProductionNominalMax")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(float64) error); ok {
+		r0 = rf(value)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// CsLPPInterface_SetProductionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetProductionNominalMax'
+type CsLPPInterface_SetProductionNominalMax_Call struct {
+	*mock.Call
+}
+
+// SetProductionNominalMax is a helper method to define mock.On call
+//   - value float64
+func (_e *CsLPPInterface_Expecter) SetProductionNominalMax(value interface{}) *CsLPPInterface_SetProductionNominalMax_Call {
+	return &CsLPPInterface_SetProductionNominalMax_Call{Call: _e.mock.On("SetProductionNominalMax", value)}
+}
+
+func (_c *CsLPPInterface_SetProductionNominalMax_Call) Run(run func(value float64)) *CsLPPInterface_SetProductionNominalMax_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(float64))
+	})
+	return _c
+}
+
+func (_c *CsLPPInterface_SetProductionNominalMax_Call) Return(resultErr error) *CsLPPInterface_SetProductionNominalMax_Call {
+	_c.Call.Return(resultErr)
+	return _c
+}
+
+func (_c *CsLPPInterface_SetProductionNominalMax_Call) RunAndReturn(run func(float64) error) *CsLPPInterface_SetProductionNominalMax_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Depending on the devices type (Energy Management System or not), the nominal max values for LPC and LPP as a controllable systems have a different type.

This change now uses the local entities associated devices devicetype and uses the proper associated CharacteristicType value.