### PR TITLE
Properly support EG LPC & LPP for all device types

### DIFF
--- a/usecases/api/eg_lpc.go
+++ b/usecases/api/eg_lpc.go
@@ -83,9 +83,9 @@ type EgLPCInterface interface {
 	// Scenario 4
 
 	// return nominal maximum active (real) power the Controllable System is
-	// able to consume according to the device label or data sheet.
+	// able to consume according to the contract (EMS), device label or data sheet.
 	//
 	// parameters:
 	//   - entity: the entity of the e.g. EVSE
-	PowerConsumptionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error)
+	ConsumptionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error)
 }

--- a/usecases/api/eg_lpp.go
+++ b/usecases/api/eg_lpp.go
@@ -83,9 +83,9 @@ type EgLPPInterface interface {
 	// Scenario 4
 
 	// return nominal maximum active (real) power the Controllable System is
-	// able to produce according to the device label or data sheet.
+	// able to produce according to the contract (EMS), device label or data sheet.
 	//
 	// parameters:
 	//   - entity: the entity of the e.g. EVSE
-	PowerProductionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error)
+	ProductionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error)
 }

--- a/usecases/eg/lpc/public_test.go
+++ b/usecases/eg/lpc/public_test.go
@@ -333,11 +333,11 @@ func (s *EgLPCSuite) Test_WriteFailsafeDurationMinimum() {
 }
 
 func (s *EgLPCSuite) Test_PowerConsumptionNominalMax() {
-	data, err := s.sut.PowerConsumptionNominalMax(s.mockRemoteEntity)
+	data, err := s.sut.ConsumptionNominalMax(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
 
-	data, err = s.sut.PowerConsumptionNominalMax(s.monitoredEntity)
+	data, err = s.sut.ConsumptionNominalMax(s.monitoredEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
 
@@ -357,7 +357,27 @@ func (s *EgLPCSuite) Test_PowerConsumptionNominalMax() {
 	fErr := rFeature.UpdateData(model.FunctionTypeElectricalConnectionCharacteristicListData, charData, nil, nil)
 	assert.Nil(s.T(), fErr)
 
-	data, err = s.sut.PowerConsumptionNominalMax(s.monitoredEntity)
+	data, err = s.sut.ConsumptionNominalMax(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	charData = &model.ElectricalConnectionCharacteristicListDataType{
+		ElectricalConnectionCharacteristicData: []model.ElectricalConnectionCharacteristicDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				CharacteristicId:       util.Ptr(model.ElectricalConnectionCharacteristicIdType(0)),
+				CharacteristicContext:  util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
+				CharacteristicType:     util.Ptr(model.ElectricalConnectionCharacteristicTypeTypeContractualConsumptionNominalMax),
+				Value:                  model.NewScaledNumberType(8000),
+			},
+		},
+	}
+
+	rFeature = s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+	fErr = rFeature.UpdateData(model.FunctionTypeElectricalConnectionCharacteristicListData, charData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.ConsumptionNominalMax(s.monitoredEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 8000.0, data)
 }

--- a/usecases/eg/lpp/public.go
+++ b/usecases/eg/lpp/public.go
@@ -236,8 +236,8 @@ func (e *LPP) WriteFailsafeDurationMinimum(entity spineapi.EntityRemoteInterface
 // Scenario 4
 
 // return nominal maximum active (real) power the Controllable System is
-// able to produce according to the device label or data sheet.
-func (e *LPP) PowerProductionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error) {
+// able to produce according to the contract (EMS), device label or data sheet.
+func (e *LPP) ProductionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return 0, api.ErrNoCompatibleEntity
 	}
@@ -249,12 +249,33 @@ func (e *LPP) PowerProductionNominalMax(entity spineapi.EntityRemoteInterface) (
 
 	filter := model.ElectricalConnectionCharacteristicDataType{
 		CharacteristicContext: util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
-		CharacteristicType:    util.Ptr(model.ElectricalConnectionCharacteristicTypeTypePowerProductionNominalMax),
+		CharacteristicType:    util.Ptr(e.characteristicType(entity)),
 	}
 	data, err := electricalConnection.GetCharacteristicsForFilter(filter)
-	if err != nil || len(data) == 0 || data[0].Value == nil {
+	if err != nil {
 		return 0, err
+	} else if len(data) == 0 || data[0].Value == nil {
+		return 0, api.ErrDataNotAvailable
 	}
 
 	return data[0].Value.GetValue(), nil
+}
+
+// returns the characteristictype depending on the remote entities device devicetype
+func (e *LPP) characteristicType(entity spineapi.EntityRemoteInterface) model.ElectricalConnectionCharacteristicTypeType {
+	// According to LPC V1.0 2.2, lines 400ff:
+	// - a HEMS provides contractual consumption nominal max
+	// - any other devices provides power consupmtion nominal max
+	characteristic := model.ElectricalConnectionCharacteristicTypeTypePowerProductionNominalMax
+
+	if entity == nil || entity.Device() == nil {
+		return characteristic
+	}
+
+	deviceType := entity.Device().DeviceType()
+	if deviceType == nil || *deviceType == model.DeviceTypeTypeEnergyManagementSystem {
+		characteristic = model.ElectricalConnectionCharacteristicTypeTypeContractualProductionNominalMax
+	}
+
+	return characteristic
 }

--- a/usecases/eg/lpp/public_test.go
+++ b/usecases/eg/lpp/public_test.go
@@ -327,11 +327,11 @@ func (s *EgLPPSuite) Test_WriteFailsafeDurationMinimum() {
 }
 
 func (s *EgLPPSuite) Test_PowerProductionNominalMax() {
-	data, err := s.sut.PowerProductionNominalMax(s.mockRemoteEntity)
+	data, err := s.sut.ProductionNominalMax(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
 
-	data, err = s.sut.PowerProductionNominalMax(s.monitoredEntity)
+	data, err = s.sut.ProductionNominalMax(s.monitoredEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0.0, data)
 
@@ -351,7 +351,27 @@ func (s *EgLPPSuite) Test_PowerProductionNominalMax() {
 	fErr := rFeature.UpdateData(model.FunctionTypeElectricalConnectionCharacteristicListData, charData, nil, nil)
 	assert.Nil(s.T(), fErr)
 
-	data, err = s.sut.PowerProductionNominalMax(s.monitoredEntity)
+	data, err = s.sut.ProductionNominalMax(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	charData = &model.ElectricalConnectionCharacteristicListDataType{
+		ElectricalConnectionCharacteristicData: []model.ElectricalConnectionCharacteristicDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				CharacteristicId:       util.Ptr(model.ElectricalConnectionCharacteristicIdType(0)),
+				CharacteristicContext:  util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
+				CharacteristicType:     util.Ptr(model.ElectricalConnectionCharacteristicTypeTypeContractualProductionNominalMax),
+				Value:                  model.NewScaledNumberType(8000),
+			},
+		},
+	}
+
+	rFeature = s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+	fErr = rFeature.UpdateData(model.FunctionTypeElectricalConnectionCharacteristicListData, charData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.ProductionNominalMax(s.monitoredEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 8000.0, data)
 }

--- a/usecases/mocks/EgLPCInterface.go
+++ b/usecases/mocks/EgLPCInterface.go
@@ -196,6 +196,62 @@ func (_c *EgLPCInterface_ConsumptionLimit_Call) RunAndReturn(run func(spine_goap
 	return _c
 }
 
+// ConsumptionNominalMax provides a mock function with given fields: entity
+func (_m *EgLPCInterface) ConsumptionNominalMax(entity spine_goapi.EntityRemoteInterface) (float64, error) {
+	ret := _m.Called(entity)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConsumptionNominalMax")
+	}
+
+	var r0 float64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) (float64, error)); ok {
+		return rf(entity)
+	}
+	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) float64); ok {
+		r0 = rf(entity)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	if rf, ok := ret.Get(1).(func(spine_goapi.EntityRemoteInterface) error); ok {
+		r1 = rf(entity)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EgLPCInterface_ConsumptionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConsumptionNominalMax'
+type EgLPCInterface_ConsumptionNominalMax_Call struct {
+	*mock.Call
+}
+
+// ConsumptionNominalMax is a helper method to define mock.On call
+//   - entity spine_goapi.EntityRemoteInterface
+func (_e *EgLPCInterface_Expecter) ConsumptionNominalMax(entity interface{}) *EgLPCInterface_ConsumptionNominalMax_Call {
+	return &EgLPCInterface_ConsumptionNominalMax_Call{Call: _e.mock.On("ConsumptionNominalMax", entity)}
+}
+
+func (_c *EgLPCInterface_ConsumptionNominalMax_Call) Run(run func(entity spine_goapi.EntityRemoteInterface)) *EgLPCInterface_ConsumptionNominalMax_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(spine_goapi.EntityRemoteInterface))
+	})
+	return _c
+}
+
+func (_c *EgLPCInterface_ConsumptionNominalMax_Call) Return(_a0 float64, _a1 error) *EgLPCInterface_ConsumptionNominalMax_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *EgLPCInterface_ConsumptionNominalMax_Call) RunAndReturn(run func(spine_goapi.EntityRemoteInterface) (float64, error)) *EgLPCInterface_ConsumptionNominalMax_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FailsafeConsumptionActivePowerLimit provides a mock function with given fields: entity
 func (_m *EgLPCInterface) FailsafeConsumptionActivePowerLimit(entity spine_goapi.EntityRemoteInterface) (float64, error) {
 	ret := _m.Called(entity)
@@ -397,62 +453,6 @@ func (_c *EgLPCInterface_IsScenarioAvailableAtEntity_Call) Return(_a0 bool) *EgL
 }
 
 func (_c *EgLPCInterface_IsScenarioAvailableAtEntity_Call) RunAndReturn(run func(spine_goapi.EntityRemoteInterface, uint) bool) *EgLPCInterface_IsScenarioAvailableAtEntity_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// PowerConsumptionNominalMax provides a mock function with given fields: entity
-func (_m *EgLPCInterface) PowerConsumptionNominalMax(entity spine_goapi.EntityRemoteInterface) (float64, error) {
-	ret := _m.Called(entity)
-
-	if len(ret) == 0 {
-		panic("no return value specified for PowerConsumptionNominalMax")
-	}
-
-	var r0 float64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) (float64, error)); ok {
-		return rf(entity)
-	}
-	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) float64); ok {
-		r0 = rf(entity)
-	} else {
-		r0 = ret.Get(0).(float64)
-	}
-
-	if rf, ok := ret.Get(1).(func(spine_goapi.EntityRemoteInterface) error); ok {
-		r1 = rf(entity)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// EgLPCInterface_PowerConsumptionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PowerConsumptionNominalMax'
-type EgLPCInterface_PowerConsumptionNominalMax_Call struct {
-	*mock.Call
-}
-
-// PowerConsumptionNominalMax is a helper method to define mock.On call
-//   - entity spine_goapi.EntityRemoteInterface
-func (_e *EgLPCInterface_Expecter) PowerConsumptionNominalMax(entity interface{}) *EgLPCInterface_PowerConsumptionNominalMax_Call {
-	return &EgLPCInterface_PowerConsumptionNominalMax_Call{Call: _e.mock.On("PowerConsumptionNominalMax", entity)}
-}
-
-func (_c *EgLPCInterface_PowerConsumptionNominalMax_Call) Run(run func(entity spine_goapi.EntityRemoteInterface)) *EgLPCInterface_PowerConsumptionNominalMax_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(spine_goapi.EntityRemoteInterface))
-	})
-	return _c
-}
-
-func (_c *EgLPCInterface_PowerConsumptionNominalMax_Call) Return(_a0 float64, _a1 error) *EgLPCInterface_PowerConsumptionNominalMax_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *EgLPCInterface_PowerConsumptionNominalMax_Call) RunAndReturn(run func(spine_goapi.EntityRemoteInterface) (float64, error)) *EgLPCInterface_PowerConsumptionNominalMax_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/mocks/EgLPPInterface.go
+++ b/usecases/mocks/EgLPPInterface.go
@@ -345,62 +345,6 @@ func (_c *EgLPPInterface_IsScenarioAvailableAtEntity_Call) RunAndReturn(run func
 	return _c
 }
 
-// PowerProductionNominalMax provides a mock function with given fields: entity
-func (_m *EgLPPInterface) PowerProductionNominalMax(entity spine_goapi.EntityRemoteInterface) (float64, error) {
-	ret := _m.Called(entity)
-
-	if len(ret) == 0 {
-		panic("no return value specified for PowerProductionNominalMax")
-	}
-
-	var r0 float64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) (float64, error)); ok {
-		return rf(entity)
-	}
-	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) float64); ok {
-		r0 = rf(entity)
-	} else {
-		r0 = ret.Get(0).(float64)
-	}
-
-	if rf, ok := ret.Get(1).(func(spine_goapi.EntityRemoteInterface) error); ok {
-		r1 = rf(entity)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// EgLPPInterface_PowerProductionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PowerProductionNominalMax'
-type EgLPPInterface_PowerProductionNominalMax_Call struct {
-	*mock.Call
-}
-
-// PowerProductionNominalMax is a helper method to define mock.On call
-//   - entity spine_goapi.EntityRemoteInterface
-func (_e *EgLPPInterface_Expecter) PowerProductionNominalMax(entity interface{}) *EgLPPInterface_PowerProductionNominalMax_Call {
-	return &EgLPPInterface_PowerProductionNominalMax_Call{Call: _e.mock.On("PowerProductionNominalMax", entity)}
-}
-
-func (_c *EgLPPInterface_PowerProductionNominalMax_Call) Run(run func(entity spine_goapi.EntityRemoteInterface)) *EgLPPInterface_PowerProductionNominalMax_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(spine_goapi.EntityRemoteInterface))
-	})
-	return _c
-}
-
-func (_c *EgLPPInterface_PowerProductionNominalMax_Call) Return(_a0 float64, _a1 error) *EgLPPInterface_PowerProductionNominalMax_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *EgLPPInterface_PowerProductionNominalMax_Call) RunAndReturn(run func(spine_goapi.EntityRemoteInterface) (float64, error)) *EgLPPInterface_PowerProductionNominalMax_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ProductionLimit provides a mock function with given fields: entity
 func (_m *EgLPPInterface) ProductionLimit(entity spine_goapi.EntityRemoteInterface) (api.LoadLimit, error) {
 	ret := _m.Called(entity)
@@ -453,6 +397,62 @@ func (_c *EgLPPInterface_ProductionLimit_Call) Return(limit api.LoadLimit, resul
 }
 
 func (_c *EgLPPInterface_ProductionLimit_Call) RunAndReturn(run func(spine_goapi.EntityRemoteInterface) (api.LoadLimit, error)) *EgLPPInterface_ProductionLimit_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ProductionNominalMax provides a mock function with given fields: entity
+func (_m *EgLPPInterface) ProductionNominalMax(entity spine_goapi.EntityRemoteInterface) (float64, error) {
+	ret := _m.Called(entity)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ProductionNominalMax")
+	}
+
+	var r0 float64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) (float64, error)); ok {
+		return rf(entity)
+	}
+	if rf, ok := ret.Get(0).(func(spine_goapi.EntityRemoteInterface) float64); ok {
+		r0 = rf(entity)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	if rf, ok := ret.Get(1).(func(spine_goapi.EntityRemoteInterface) error); ok {
+		r1 = rf(entity)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EgLPPInterface_ProductionNominalMax_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ProductionNominalMax'
+type EgLPPInterface_ProductionNominalMax_Call struct {
+	*mock.Call
+}
+
+// ProductionNominalMax is a helper method to define mock.On call
+//   - entity spine_goapi.EntityRemoteInterface
+func (_e *EgLPPInterface_Expecter) ProductionNominalMax(entity interface{}) *EgLPPInterface_ProductionNominalMax_Call {
+	return &EgLPPInterface_ProductionNominalMax_Call{Call: _e.mock.On("ProductionNominalMax", entity)}
+}
+
+func (_c *EgLPPInterface_ProductionNominalMax_Call) Run(run func(entity spine_goapi.EntityRemoteInterface)) *EgLPPInterface_ProductionNominalMax_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(spine_goapi.EntityRemoteInterface))
+	})
+	return _c
+}
+
+func (_c *EgLPPInterface_ProductionNominalMax_Call) Return(_a0 float64, _a1 error) *EgLPPInterface_ProductionNominalMax_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *EgLPPInterface_ProductionNominalMax_Call) RunAndReturn(run func(spine_goapi.EntityRemoteInterface) (float64, error)) *EgLPPInterface_ProductionNominalMax_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Depending on the devices type (Energy Management System or not), the nominal max values for LPC and LPP from a controllable systems have a different type.

This change now uses the remote entities associated devices devicetype and uses the proper associated CharacteristicType value.