### PR TITLE
Fix potential race condition leading to nil dereference

### DIFF
--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -7,7 +7,6 @@ import (
 	"github.com/enbility/eebus-go/api"
 	"github.com/enbility/eebus-go/features/server"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
-	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 )
@@ -134,29 +133,13 @@ func (e *LPP) ApproveOrDenyProductionLimit(msgCounter model.MsgCounterType, appr
 	e.pendingMux.Lock()
 	defer e.pendingMux.Unlock()
 
-	f := e.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
-
-	result := model.ErrorType{
-		ErrorNumber: model.ErrorNumberType(0),
-	}
-
 	msg, ok := e.pendingLimits[msgCounter]
 	if !ok {
-		// it is not a limit of this usecase, so approve it
-		newMsg := &spineapi.Message{
-			RequestHeader: &model.HeaderType{
-				MsgCounter: &msgCounter,
-			},
-		}
-		f.ApproveOrDenyWrite(newMsg, result)
+		// no pending limit for this msgCounter, this is a caller error
 		return
 	}
 
-	if !approve {
-		result.ErrorNumber = model.ErrorNumberType(7)
-		result.Description = util.Ptr(model.DescriptionType(reason))
-	}
-	f.ApproveOrDenyWrite(msg, result)
+	e.approveOrDenyProductionLimit(msg, approve, reason)
 
 	delete(e.pendingLimits, msgCounter)
 }

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -102,6 +102,20 @@ func (e *LPP) loadControlServerAndLimitId() (lc *server.LoadControl, limitid mod
 	return lc, *description.LimitId, nil
 }
 
+func (e *LPP) approveOrDenyProductionLimit(msg *spineapi.Message, approve bool, reason string) {
+	f := e.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
+
+	result := model.ErrorType{
+		ErrorNumber: model.ErrorNumberType(0),
+	}
+
+	if !approve {
+		result.ErrorNumber = model.ErrorNumberType(7)
+		result.Description = util.Ptr(model.DescriptionType(reason))
+	}
+	f.ApproveOrDenyWrite(msg, result)
+}
+
 // callback invoked on incoming write messages to this
 // loadcontrol server feature.
 // the implementation only considers write messages for this use case and
@@ -145,7 +159,7 @@ func (e *LPP) loadControlWriteCB(msg *spineapi.Message) {
 	e.pendingMux.Unlock()
 
 	// approve, because this is no request for this usecase
-	go e.ApproveOrDenyProductionLimit(*msg.RequestHeader.MsgCounter, true, "")
+	go e.approveOrDenyProductionLimit(msg, true, "")
 }
 
 func (e *LPP) AddFeatures() {


### PR DESCRIPTION
Split ApproveOrDeny*Limit public functions into a public part which takes a msgCounter and resolves it to a Message using the pendingLimits as before and a private part which takes a *Message and can be called directly from the internal WriteApprovalCallbacks. This removes the need to call FeatureLocalInterface.ApproveOrDenyWrite with an "empty" message when a message is not found in the pendingLimits for ApprovalRequests that don't match the current use case.

Fixes #104