### PR TITLE
Add workaround for PMCP reporting wrong uc address

### DIFF
--- a/usecases/usecase/events.go
+++ b/usecases/usecase/events.go
@@ -64,6 +64,12 @@ func (u *UseCaseBase) useCaseDataUpdate(
 			// if the address is given, use that for further checks
 			if uc.Address != nil {
 				ucEntity := remoteDevice.Entity(uc.Address.Entity)
+				// the PMCP EVSE reports EV use cases with the address of the EVSE
+				if *uc.Actor == model.UseCaseActorTypeEV && len(uc.Address.Entity) == 1 {
+					// add the EV subentity to the address
+					evAddress := append(uc.Address.Entity, 1)
+					ucEntity = remoteDevice.Entity(evAddress)
+				}
 				if ucEntity != nil {
 					entitiesToCheck = append(entitiesToCheck, ucEntity)
 				}

--- a/usecases/usecase/events_test.go
+++ b/usecases/usecase/events_test.go
@@ -144,3 +144,74 @@ func (s *UseCaseSuite) Test_useCaseDataUpdate() {
 	result = s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1)
 	assert.False(s.T(), result)
 }
+
+func (s *UseCaseSuite) Test_useCaseDataUpdate_PMCP() {
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.remoteDevice.Entities()[0],
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.uc.useCaseDataUpdate(payload)
+
+	result := s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1)
+	assert.False(s.T(), result)
+
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	// the PMCP device reports the wrong entity address for the EV use cases :(
+	data := &model.NodeManagementUseCaseDataType{
+		UseCaseInformation: []model.UseCaseInformationDataType{
+			{
+				Address: &model.FeatureAddressType{
+					Device: util.Ptr(model.AddressDeviceType("d:_i:19667_PorscheEVSE_0012345")),
+					Entity: []model.AddressEntityType{1},
+				},
+				Actor: util.Ptr(model.UseCaseActorTypeEVSE),
+				UseCaseSupport: []model.UseCaseSupportType{
+					{
+						UseCaseName:     util.Ptr(model.UseCaseNameType("evseCommissioningAndConfiguration")),
+						UseCaseVersion:  util.Ptr(model.SpecificationVersionType("1.0.0")),
+						ScenarioSupport: []model.UseCaseScenarioSupportType{1, 2},
+					},
+				},
+			},
+			{
+				Address: &model.FeatureAddressType{
+					Device: util.Ptr(model.AddressDeviceType("d:_i:19667_PorscheEVSE_0012345")),
+					Entity: []model.AddressEntityType{1}, // this should include the subentity 1 to point to the EV entity
+				},
+				Actor: util.Ptr(model.UseCaseActorTypeEV),
+				UseCaseSupport: []model.UseCaseSupportType{
+					{
+						UseCaseName:     util.Ptr(model.UseCaseNameType("evCommissioningAndConfiguration")),
+						UseCaseVersion:  util.Ptr(model.SpecificationVersionType("1.0.0")),
+						ScenarioSupport: []model.UseCaseScenarioSupportType{1, 2, 3, 6, 7, 8},
+					},
+					{
+						UseCaseName:     util.Ptr(model.UseCaseNameType("overloadProtectionByEvChargingCurrentCurtailment")),
+						UseCaseVersion:  util.Ptr(model.SpecificationVersionType("1.0.0")),
+						ScenarioSupport: []model.UseCaseScenarioSupportType{1, 2, 3},
+					},
+					{
+						UseCaseName:     util.Ptr(model.UseCaseNameType("measurementOfElectricityDuringEvCharging")),
+						UseCaseVersion:  util.Ptr(model.SpecificationVersionType("1.0.0")),
+						ScenarioSupport: []model.UseCaseScenarioSupportType{1},
+					},
+				},
+			},
+		},
+	}
+	nodeFeature.UpdateData(model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	s.uc.useCaseDataUpdate(payload)
+
+	result = s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1)
+	assert.True(s.T(), result)
+}


### PR DESCRIPTION
The PMCP device reports EV usecases at the entity address of the EVSE entity (e.g. “[1]”), instead of the EV entity (e.g. “[1,1]”)

This change checks for the actor type to be an EV and patches the address to include the EV subentity if it doesn’t have it