### PR TITLE
Fix ma/mpc usecase to validate the correct actor type

### DIFF
--- a/usecases/ma/mpc/types.go
+++ b/usecases/ma/mpc/types.go
@@ -6,7 +6,7 @@ const (
 	// Update of the list of remote entities supporting the Use Case
 	//
 	// Use `RemoteEntities` to get the current data
-	UseCaseSupportUpdate api.EventType = "ma-mpc-oscev-UseCaseSupportUpdate"
+	UseCaseSupportUpdate api.EventType = "ma-mpc-UseCaseSupportUpdate"
 
 	// Total momentary active power consumption or production
 	//

--- a/usecases/ma/mpc/usecase.go
+++ b/usecases/ma/mpc/usecase.go
@@ -16,7 +16,7 @@ type MPC struct {
 var _ ucapi.MaMPCInterface = (*MPC)(nil)
 
 func NewMPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCallback) *MPC {
-	validActorTypes := []model.UseCaseActorType{model.UseCaseActorTypeMonitoringAppliance}
+	validActorTypes := []model.UseCaseActorType{model.UseCaseActorTypeMonitoredUnit}
 	validEntityTypes := []model.EntityTypeType{
 		model.EntityTypeTypeCompressor,
 		model.EntityTypeTypeElectricalImmersionHeater,


### PR DESCRIPTION
The ma/mpc usecase should filter for actors of type MonitoredUnit but was filtering for actors of type MonitoringAppliance which lead to the uc never finding any entities.

This PR also adds a commit which adjusts the string representation of the ma/mpc UseCaseSupportUpdate EventType from "ma-mpc-oscev-UseCaseSupportUpdate" to "ma-mpc-UseCaseSupportUpdate" as it isn't relevant here. This is technically an API-breaking change, but all subscribers should be using the constant mpc.UseCaseSupportUpdate instead of its string representation and therefore automatically always use the correct variant for their version of eebus-go. I could, however, drop the commit from this PR if preferred.