### PR TITLE
Add support for heartbeat events in EG LPC/LPP

### DIFF
--- a/usecases/eg/lpc/events.go
+++ b/usecases/eg/lpc/events.go
@@ -19,6 +19,11 @@ func (e *LPC) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
+	if internal.IsHeartbeat(payload) && e.EventCB != nil {
+		e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateHeartbeat)
+		return
+	}
+
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return

--- a/usecases/eg/lpc/events_test.go
+++ b/usecases/eg/lpc/events_test.go
@@ -41,6 +41,15 @@ func (s *EgLPCSuite) Test_Events() {
 	payload.Data = util.Ptr(model.DeviceConfigurationKeyValueListDataType{})
 	s.sut.HandleEvent(payload)
 
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Function = model.FunctionTypeDeviceDiagnosisHeartbeatData
+	deviceDiagF := s.sut.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	payload.LocalFeature = deviceDiagF
+	payload.CmdClassifier = util.Ptr(model.CmdClassifierTypeNotify)
+	payload.Data = util.Ptr(model.DeviceDiagnosisHeartbeatDataType{})
+	s.sut.HandleEvent(payload)
+
 	payload.Data = util.Ptr(model.NodeManagementUseCaseDataType{})
 	s.sut.HandleEvent(payload)
 }

--- a/usecases/eg/lpc/types.go
+++ b/usecases/eg/lpc/types.go
@@ -30,4 +30,10 @@ const (
 	//
 	// Use Case LPC, Scenario 2
 	DataUpdateFailsafeDurationMinimum api.EventType = "eg-lpc-DataUpdateFailsafeDurationMinimum"
+
+	// Indicates a notify heartbeat event the application should care of.
+	// E.g. going into or out of the Failsafe state
+	//
+	// Use Case LPC, Scenario 3
+	DataUpdateHeartbeat api.EventType = "cs-lpc-DataUpdateHeartbeat"
 )

--- a/usecases/eg/lpp/events.go
+++ b/usecases/eg/lpp/events.go
@@ -20,6 +20,11 @@ func (e *LPP) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
+	if internal.IsHeartbeat(payload) && e.EventCB != nil {
+		e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateHeartbeat)
+		return
+	}
+
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return

--- a/usecases/eg/lpp/events_test.go
+++ b/usecases/eg/lpp/events_test.go
@@ -41,6 +41,15 @@ func (s *EgLPPSuite) Test_Events() {
 	payload.Data = util.Ptr(model.DeviceConfigurationKeyValueListDataType{})
 	s.sut.HandleEvent(payload)
 
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Function = model.FunctionTypeDeviceDiagnosisHeartbeatData
+	deviceDiagF := s.sut.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	payload.LocalFeature = deviceDiagF
+	payload.CmdClassifier = util.Ptr(model.CmdClassifierTypeNotify)
+	payload.Data = util.Ptr(model.DeviceDiagnosisHeartbeatDataType{})
+	s.sut.HandleEvent(payload)
+
 	payload.Data = util.Ptr(model.NodeManagementUseCaseDataType{})
 	s.sut.HandleEvent(payload)
 }

--- a/usecases/eg/lpp/types.go
+++ b/usecases/eg/lpp/types.go
@@ -30,4 +30,10 @@ const (
 	//
 	// Use Case LPC, Scenario 2
 	DataUpdateFailsafeDurationMinimum api.EventType = "eg-lpp-DataUpdateFailsafeDurationMinimum"
+
+	// Indicates a notify heartbeat event the application should care of.
+	// E.g. going into or out of the Failsafe state
+	//
+	// Use Case LPC, Scenario 3
+	DataUpdateHeartbeat api.EventType = "cs-lpc-DataUpdateHeartbeat"
 )


### PR DESCRIPTION
The Energy Guard implementations of LPC and LPP should also get incoming heartbeat events, so it can react on missing heartbeatss from the controllable systems.