### PR TITLE
Refactor service start & stop

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,6 +24,9 @@ type ServiceInterface interface {
 	// shutdown the service
 	Shutdown()
 
+	// return if the service is running
+	IsRunning() bool
+
 	// add a use case to the service
 	AddUseCase(useCase UseCaseInterface)
 

--- a/mocks/ServiceInterface.go
+++ b/mocks/ServiceInterface.go
@@ -218,6 +218,51 @@ func (_c *ServiceInterface_IsAutoAcceptEnabled_Call) RunAndReturn(run func() boo
 	return _c
 }
 
+// IsRunning provides a mock function with given fields:
+func (_m *ServiceInterface) IsRunning() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsRunning")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// ServiceInterface_IsRunning_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsRunning'
+type ServiceInterface_IsRunning_Call struct {
+	*mock.Call
+}
+
+// IsRunning is a helper method to define mock.On call
+func (_e *ServiceInterface_Expecter) IsRunning() *ServiceInterface_IsRunning_Call {
+	return &ServiceInterface_IsRunning_Call{Call: _e.mock.On("IsRunning")}
+}
+
+func (_c *ServiceInterface_IsRunning_Call) Run(run func()) *ServiceInterface_IsRunning_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ServiceInterface_IsRunning_Call) Return(_a0 bool) *ServiceInterface_IsRunning_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ServiceInterface_IsRunning_Call) RunAndReturn(run func() bool) *ServiceInterface_IsRunning_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LocalDevice provides a mock function with given fields:
 func (_m *ServiceInterface) LocalDevice() spine_goapi.DeviceLocalInterface {
 	ret := _m.Called()

--- a/service/service.go
+++ b/service/service.go
@@ -164,6 +164,8 @@ func (s *Service) Start() {
 	}
 
 	s.connectionsHub.Start()
+
+	s.isRunning = true
 }
 
 // Shutdown all services and stop the server.

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -171,12 +171,21 @@ func (s *ServiceSuite) Test_Setup() {
 	assert.Equal(s.T(), "d:_n:vendor_model-serial", string(*address))
 
 	s.sut.connectionsHub = s.conHub
-	s.conHub.EXPECT().Start()
+	s.conHub.EXPECT().Start().Once()
 	s.sut.Start()
 
 	time.Sleep(time.Millisecond * 200)
 
-	s.conHub.EXPECT().Shutdown()
+	isRunning := s.sut.IsRunning()
+	assert.True(s.T(), isRunning)
+
+	// nothing should happen
+	s.sut.Start()
+
+	s.conHub.EXPECT().Shutdown().Once()
+	s.sut.Shutdown()
+
+	// nothing should happen
 	s.sut.Shutdown()
 
 	device := s.sut.LocalDevice()


### PR DESCRIPTION
Make it possible to shutdown an initialized service and start it again. Also add the option to get the current service run status