### PR TITLE
 Fix inconsistent DataUpdate event type identifiers for LPP use cases

### DIFF
--- a/usecases/cs/lpp/types.go
+++ b/usecases/cs/lpp/types.go
@@ -43,5 +43,5 @@ const (
 	// E.g. going into or out of the Failsafe state
 	//
 	// Use Case LPP, Scenario 3
-	DataUpdateHeartbeat api.EventType = "uclpcserver-DataUpdateHeartbeat"
+	DataUpdateHeartbeat api.EventType = "uclppserver-DataUpdateHeartbeat"
 )

--- a/usecases/eg/lpp/types.go
+++ b/usecases/eg/lpp/types.go
@@ -35,5 +35,5 @@ const (
 	// E.g. going into or out of the Failsafe state
 	//
 	// Use Case LPC, Scenario 3
-	DataUpdateHeartbeat api.EventType = "cs-lpc-DataUpdateHeartbeat"
+	DataUpdateHeartbeat api.EventType = "cs-lpp-DataUpdateHeartbeat"
 )

--- a/usecases/eg/lpp/types.go
+++ b/usecases/eg/lpp/types.go
@@ -12,7 +12,7 @@ const (
 	//
 	// Use `ProductionLimit` to get the current data
 	//
-	// Use Case LPC, Scenario 1
+	// Use Case LPP, Scenario 1
 	DataUpdateLimit api.EventType = "eg-lpp-DataUpdateLimit"
 
 	// Failsafe limit for the produced active (real) power of the
@@ -20,7 +20,7 @@ const (
 	//
 	// Use `FailsafeProductionActivePowerLimit` to get the current data
 	//
-	// Use Case LPC, Scenario 2
+	// Use Case LPP, Scenario 2
 	DataUpdateFailsafeProductionActivePowerLimit api.EventType = "eg-lpp-DataUpdateFailsafeProductionActivePowerLimit"
 
 	// Minimum time the Controllable System remains in "failsafe state" unless conditions
@@ -28,12 +28,12 @@ const (
 	//
 	// Use `FailsafeDurationMinimum` to get the current data
 	//
-	// Use Case LPC, Scenario 2
+	// Use Case LPP, Scenario 2
 	DataUpdateFailsafeDurationMinimum api.EventType = "eg-lpp-DataUpdateFailsafeDurationMinimum"
 
 	// Indicates a notify heartbeat event the application should care of.
 	// E.g. going into or out of the Failsafe state
 	//
-	// Use Case LPC, Scenario 3
+	// Use Case LPP, Scenario 3
 	DataUpdateHeartbeat api.EventType = "cs-lpp-DataUpdateHeartbeat"
 )


### PR DESCRIPTION
This pull request resolves inconsistencies in the event type identifiers within usecases/cs/lpp/types.go and usecases/eg/lpp/types.go. The following changes were made:

 - Corrected event type identifiers to align with LPP scenarios instead of LPC scenarios where applicable. This helps ensure the identifiers accurately reflect their use cases and scenarios.
- Updated DataUpdateHeartbeat in both files to reflect the correct uclppserver and cs-lpp prefixes.

These changes improve code accuracy, documentation and maintain the correct mapping of constants to their respective use cases in the EEBUS library.