### PR TITLE
Make DataUpdateHeartbeat event names more consistent

### DIFF
--- a/usecases/cs/lpp/types.go
+++ b/usecases/cs/lpp/types.go
@@ -43,5 +43,5 @@ const (
 	// E.g. going into or out of the Failsafe state
 	//
 	// Use Case LPP, Scenario 3
-	DataUpdateHeartbeat api.EventType = "uclppserver-DataUpdateHeartbeat"
+	DataUpdateHeartbeat api.EventType = "cs-lpp-DataUpdateHeartbeat"
 )

--- a/usecases/eg/lpc/types.go
+++ b/usecases/eg/lpc/types.go
@@ -35,5 +35,5 @@ const (
 	// E.g. going into or out of the Failsafe state
 	//
 	// Use Case LPC, Scenario 3
-	DataUpdateHeartbeat api.EventType = "cs-lpc-DataUpdateHeartbeat"
+	DataUpdateHeartbeat api.EventType = "eg-lpc-DataUpdateHeartbeat"
 )

--- a/usecases/eg/lpp/types.go
+++ b/usecases/eg/lpp/types.go
@@ -35,5 +35,5 @@ const (
 	// E.g. going into or out of the Failsafe state
 	//
 	// Use Case LPP, Scenario 3
-	DataUpdateHeartbeat api.EventType = "cs-lpp-DataUpdateHeartbeat"
+	DataUpdateHeartbeat api.EventType = "eg-lpp-DataUpdateHeartbeat"
 )


### PR DESCRIPTION
This also allows differentiating between eglpc.DataUpdateHeartbeat and cslpc.DataUpdateHeartbeat events.

While syncing my branch on dev, I saw https://github.com/enbility/eebus-go/pull/137 and noticed that the DataUpdateHeartbeat events for eg/lpc and cs/lpc used the same identifier which means they can't be differentiated from another over e.g. json-rpc. I also took the liberty of changing the "uclppserver-" identifier to "cs-lpp-" to make it consistent with the other event names.
