### PR TITLE
Fix LoadControlLimits in OPEV and OSCEV not filtering for unit

### DIFF
--- a/usecases/cem/opev/public.go
+++ b/usecases/cem/opev/public.go
@@ -65,6 +65,7 @@ func (e *OPEV) LoadControlLimits(entity spineapi.EntityRemoteInterface) (
 	filter := model.LoadControlLimitDescriptionDataType{
 		LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
 		LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+		Unit:          util.Ptr(model.UnitOfMeasurementTypeA),
 		ScopeType:     util.Ptr(model.ScopeTypeTypeOverloadProtection),
 	}
 	return internal.LoadControlLimits(e.LocalEntity, entity, filter)

--- a/usecases/cem/oscev/public.go
+++ b/usecases/cem/oscev/public.go
@@ -65,6 +65,7 @@ func (e *OSCEV) LoadControlLimits(entity spineapi.EntityRemoteInterface) (
 	filter := model.LoadControlLimitDescriptionDataType{
 		LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
 		LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
+		Unit:          util.Ptr(model.UnitOfMeasurementTypeA),
 		ScopeType:     util.Ptr(model.ScopeTypeTypeSelfConsumption),
 	}
 	return internal.LoadControlLimits(e.LocalEntity, entity, filter)


### PR DESCRIPTION
As per [[1]](https://www.eebus.org/wp-content/uploads/2023/04/EEBus_UC_TS_OptimizationOfSelfConsumptionDuringEVCharging_V1.0.1b.pdf#page=34) & [[2]](https://www.eebus.org/wp-content/uploads/2023/04/EEBus_UC_TS_OverloadProtectionByEVChargingCurrentCurtailment_V1.0.1b.pdf#page=35), the load control limit descriptions for OSCEV and OPEV shall have their "unit" fields equal to "A". In the implementation of the function LoadControlLimits for both [OSCEV](https://github.com/enbility/eebus-go/blob/cec369509aff4f41f006a53620bf3189f210cbcd/usecases/cem/oscev/public.go#L65) and [OPEV](https://github.com/enbility/eebus-go/blob/cec369509aff4f41f006a53620bf3189f210cbcd/usecases/cem/opev/public.go#L69), the filter is missing the unit field.