### PR TITLE
Properly handle invalid measurement data

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -9,6 +9,9 @@ var ErrMetadataNotAvailable = errors.New("meta data not available")
 // ErrDataNotAvailable indicates that no data set is yet available
 var ErrDataNotAvailable = errors.New("data not available")
 
+// ErrDataInvalid indicates that the currently available data is not valid and should be ignored
+var ErrDataInvalid = errors.New("data not valid")
+
 // ErrDataForMetadataKeyNotFound indicates that no data item is found for the given key
 var ErrDataForMetadataKeyNotFound = errors.New("data for key not found")
 

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -62,6 +62,12 @@ func MeasurementPhaseSpecificDataForFilter(
 			}
 		}
 
+		// if the value state is set and not normal, the value is not valid and should be ignored
+		// therefore we return an error
+		if item.ValueState != nil && *item.ValueState != model.MeasurementValueStateTypeNormal {
+			return nil, api.ErrDataInvalid
+		}
+
 		value := item.Value.GetValue()
 
 		result = append(result, value)

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -161,4 +161,38 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 	)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), []float64{10, 10, 10}, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(10)),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				ValueState:    util.Ptr(model.MeasurementValueStateTypeError),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(1)),
+				Value:         model.NewScaledNumberType(10),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(2)),
+				Value:         model.NewScaledNumberType(10),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		ucapi.PhaseNameMapping,
+	)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
 }

--- a/usecases/ma/mgcp/public_test.go
+++ b/usecases/ma/mgcp/public_test.go
@@ -173,6 +173,23 @@ func (s *GcpMGCPSuite) Test_EnergyFeedIn() {
 	data, err = s.sut.EnergyFeedIn(s.smgwEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 10.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				ValueState:    util.Ptr(model.MeasurementValueStateTypeError),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyFeedIn(s.smgwEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
 }
 
 func (s *GcpMGCPSuite) Test_EnergyConsumed() {
@@ -218,6 +235,23 @@ func (s *GcpMGCPSuite) Test_EnergyConsumed() {
 	data, err = s.sut.EnergyConsumed(s.smgwEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 10.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				ValueState:    util.Ptr(model.MeasurementValueStateTypeError),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyConsumed(s.smgwEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
 }
 
 func (s *GcpMGCPSuite) Test_CurrentPerPhase() {
@@ -461,4 +495,21 @@ func (s *GcpMGCPSuite) Test_Frequency() {
 	data, err = s.sut.Frequency(s.smgwEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 50.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(50),
+				ValueState:    util.Ptr(model.MeasurementValueStateTypeError),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.Frequency(s.smgwEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
 }

--- a/usecases/ma/mpc/public_test.go
+++ b/usecases/ma/mpc/public_test.go
@@ -221,6 +221,21 @@ func (s *MaMPCSuite) Test_EnergyConsumed() {
 		MeasurementData: []model.MeasurementDataType{
 			{
 				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyConsumed(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
 				Value:         model.NewScaledNumberType(10),
 			},
 		},
@@ -232,6 +247,23 @@ func (s *MaMPCSuite) Test_EnergyConsumed() {
 	data, err = s.sut.EnergyConsumed(s.monitoredEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 10.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				ValueState:    util.Ptr(model.MeasurementValueStateTypeError),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyConsumed(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
 }
 
 func (s *MaMPCSuite) Test_EnergyProduced() {
@@ -266,6 +298,21 @@ func (s *MaMPCSuite) Test_EnergyProduced() {
 		MeasurementData: []model.MeasurementDataType{
 			{
 				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyProduced(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
 				Value:         model.NewScaledNumberType(10),
 			},
 		},
@@ -277,6 +324,23 @@ func (s *MaMPCSuite) Test_EnergyProduced() {
 	data, err = s.sut.EnergyProduced(s.monitoredEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 10.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+				ValueState:    util.Ptr(model.MeasurementValueStateTypeError),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.EnergyProduced(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
 }
 
 func (s *MaMPCSuite) Test_CurrentPerPhase() {
@@ -509,6 +573,21 @@ func (s *MaMPCSuite) Test_Frequency() {
 		MeasurementData: []model.MeasurementDataType{
 			{
 				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.Frequency(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
 				Value:         model.NewScaledNumberType(50),
 			},
 		},
@@ -520,4 +599,21 @@ func (s *MaMPCSuite) Test_Frequency() {
 	data, err = s.sut.Frequency(s.monitoredEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 50.0, data)
+
+	measData = &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(50),
+				ValueState:    util.Ptr(model.MeasurementValueStateTypeError),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = s.sut.Frequency(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), 0.0, data)
 }


### PR DESCRIPTION
If a measurement is provided with an ValueState != Normal, then the value should be ignored by the application. To handle that, the public API will then report an ErrDataInvalid error, so the application knows that the currently no valid data is available.

This is the case for MPC and MGPC use cases