### PR TITLE
Fix: have CurrentLimits method in opev and oscev filter for LoadControlLimitDescription instead of MeasurementDescription

### DIFF
--- a/usecases/cem/opev/public.go
+++ b/usecases/cem/opev/public.go
@@ -47,14 +47,18 @@ func (e *OPEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if len(limitDescs) != 3 {
+	if len(limitDescs) == 0 {
 		return nil, nil, nil, api.ErrDataNotAvailable
 	}
 
 	measDescs := make([]model.MeasurementDescriptionDataType, 0)
 	for _, ld := range limitDescs {
+		measId := ld.MeasurementId
+		if measId == nil {
+			return nil, nil, nil, api.ErrDataNotAvailable
+		}
 		filter := model.MeasurementDescriptionDataType{
-			MeasurementId: ld.MeasurementId,
+			MeasurementId: measId,
 		}
 		mds, err := meas.GetDescriptionsForFilter(filter)
 		if err != nil {

--- a/usecases/cem/opev/public.go
+++ b/usecases/cem/opev/public.go
@@ -26,23 +26,46 @@ func (e *OPEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64, 
 		return nil, nil, nil, err
 	}
 
+	lc, err := client.NewLoadControl(e.LocalEntity, entity)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	meas, err := client.NewMeasurement(e.LocalEntity, entity)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	filter := model.MeasurementDescriptionDataType{
-		MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-		CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-		Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-		ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+	filter := model.LoadControlLimitDescriptionDataType {
+		LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+		LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+		Unit:          util.Ptr(model.UnitOfMeasurementTypeA),
+		ScopeType:     util.Ptr(model.ScopeTypeTypeOverloadProtection),
 	}
-	measDesc, err := meas.GetDescriptionsForFilter(filter)
+	
+	limitDescs, err := lc.GetLimitDescriptionsForFilter(filter)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	if len(limitDescs) != 3 {
+		return nil, nil, nil, api.ErrDataNotAvailable
+	}
 
-	return ec.GetPhaseCurrentLimits(measDesc)
+	measDescs := make([]model.MeasurementDescriptionDataType, 0)
+	for _, ld := range limitDescs {
+		filter := model.MeasurementDescriptionDataType{
+			MeasurementId: ld.MeasurementId,
+		}
+		mds, err := meas.GetDescriptionsForFilter(filter)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if len(mds) != 1 {
+			return nil, nil, nil, api.ErrDataNotAvailable
+		}
+		measDescs = append(measDescs, mds[0])
+	}
+	return ec.GetPhaseCurrentLimits(measDescs)
 }
 
 // return the current loadcontrol obligation limits

--- a/usecases/cem/opev/public.go
+++ b/usecases/cem/opev/public.go
@@ -31,11 +31,6 @@ func (e *OPEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64, 
 		return nil, nil, nil, err
 	}
 
-	meas, err := client.NewMeasurement(e.LocalEntity, entity)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	filter := model.LoadControlLimitDescriptionDataType {
 		LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
 		LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
@@ -60,14 +55,7 @@ func (e *OPEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64, 
 		filter := model.MeasurementDescriptionDataType{
 			MeasurementId: measId,
 		}
-		mds, err := meas.GetDescriptionsForFilter(filter)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		if len(mds) != 1 {
-			return nil, nil, nil, api.ErrDataNotAvailable
-		}
-		measDescs = append(measDescs, mds[0])
+		measDescs = append(measDescs, filter)
 	}
 	return ec.GetPhaseCurrentLimits(measDescs)
 }

--- a/usecases/cem/opev/public.go
+++ b/usecases/cem/opev/public.go
@@ -52,10 +52,10 @@ func (e *OPEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64, 
 		if measId == nil {
 			return nil, nil, nil, api.ErrDataNotAvailable
 		}
-		filter := model.MeasurementDescriptionDataType{
+		md := model.MeasurementDescriptionDataType{
 			MeasurementId: measId,
 		}
-		measDescs = append(measDescs, filter)
+		measDescs = append(measDescs, md)
 	}
 	return ec.GetPhaseCurrentLimits(measDescs)
 }

--- a/usecases/cem/opev/public_test.go
+++ b/usecases/cem/opev/public_test.go
@@ -16,8 +16,57 @@ func (s *CemOPEVSuite) Test_Public() {
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
 	assert.NotNil(s.T(), err)
 
+	lc := s.evEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
+	assert.NotNil(s.T(), lc)
+
 	meas := s.evEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
 	assert.NotNil(s.T(), meas)
+
+	lData := &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
+			{
+				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType: util.Ptr(model.ScopeTypeTypeOverloadProtection),
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+			},
+		},
+	}
+
+	_,errT := lc.UpdateData(true, model.FunctionTypeLoadControlLimitDescriptionListData, lData, nil, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
+
+	lData = &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
+			{
+				LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType: util.Ptr(model.ScopeTypeTypeOverloadProtection),
+				MeasurementId: util.Ptr(model.MeasurementIdType(1)),
+			},
+			{
+				LimitId: util.Ptr(model.LoadControlLimitIdType(2)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType: util.Ptr(model.ScopeTypeTypeOverloadProtection),
+				MeasurementId: util.Ptr(model.MeasurementIdType(2)),
+			},
+		},
+	}
+
+	_,errT = lc.UpdateData(true, model.FunctionTypeLoadControlLimitDescriptionListData, lData, &model.FilterType{}, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
 
 	mData := &model.MeasurementDescriptionListDataType{
 		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
@@ -30,7 +79,31 @@ func (s *CemOPEVSuite) Test_Public() {
 			},
 		},
 	}
-	_, errT := meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
+	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
+
+	mData = &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(1)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(2)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+			},
+		},
+	}
+	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, &model.FilterType{}, nil)
 	assert.Nil(s.T(), errT)
 
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)

--- a/usecases/cem/opev/public_test.go
+++ b/usecases/cem/opev/public_test.go
@@ -24,14 +24,6 @@ func (s *CemOPEVSuite) Test_Public() {
 
 	lData := &model.LoadControlLimitDescriptionListDataType{
 		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
-			{
-				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
-				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
-				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
-				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType: util.Ptr(model.ScopeTypeTypeOverloadProtection),
-				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
-			},
 		},
 	}
 
@@ -44,20 +36,26 @@ func (s *CemOPEVSuite) Test_Public() {
 	lData = &model.LoadControlLimitDescriptionListDataType{
 		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
 			{
-				LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
 				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
 				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
 				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
 				ScopeType: util.Ptr(model.ScopeTypeTypeOverloadProtection),
-				MeasurementId: util.Ptr(model.MeasurementIdType(1)),
 			},
+		},
+	}
+
+	_,errT = lc.UpdateData(true, model.FunctionTypeLoadControlLimitDescriptionListData, lData, nil, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
+
+	lData = &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
 			{
-				LimitId: util.Ptr(model.LoadControlLimitIdType(2)),
-				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
-				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
-				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType: util.Ptr(model.ScopeTypeTypeOverloadProtection),
-				MeasurementId: util.Ptr(model.MeasurementIdType(2)),
+				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
 			},
 		},
 	}
@@ -70,13 +68,6 @@ func (s *CemOPEVSuite) Test_Public() {
 
 	mData := &model.MeasurementDescriptionListDataType{
 		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
-			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
-				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
-			},
 		},
 	}
 	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
@@ -88,14 +79,7 @@ func (s *CemOPEVSuite) Test_Public() {
 	mData = &model.MeasurementDescriptionListDataType{
 		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
 			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(1)),
-				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
-			},
-			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(2)),
+				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
 				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
 				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
 				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
@@ -103,7 +87,7 @@ func (s *CemOPEVSuite) Test_Public() {
 			},
 		},
 	}
-	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, &model.FilterType{}, nil)
+	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
 	assert.Nil(s.T(), errT)
 
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)

--- a/usecases/cem/opev/public_test.go
+++ b/usecases/cem/opev/public_test.go
@@ -66,33 +66,6 @@ func (s *CemOPEVSuite) Test_Public() {
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
 	assert.NotNil(s.T(), err)
 
-	mData := &model.MeasurementDescriptionListDataType{
-		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
-		},
-	}
-	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
-	assert.Nil(s.T(), errT)
-
-	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
-	assert.NotNil(s.T(), err)
-
-	mData = &model.MeasurementDescriptionListDataType{
-		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
-			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
-				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
-			},
-		},
-	}
-	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
-	assert.Nil(s.T(), errT)
-
-	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
-	assert.NotNil(s.T(), err)
-
 	_, err = s.sut.LoadControlLimits(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 

--- a/usecases/cem/oscev/public.go
+++ b/usecases/cem/oscev/public.go
@@ -31,11 +31,6 @@ func (e *OSCEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64,
 		return nil, nil, nil, err
 	}
 
-	meas, err := client.NewMeasurement(e.LocalEntity, entity)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	filter := model.LoadControlLimitDescriptionDataType {
 		LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
 		LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
@@ -60,14 +55,7 @@ func (e *OSCEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64,
 		filter := model.MeasurementDescriptionDataType{
 			MeasurementId: measId,
 		}
-		mds, err := meas.GetDescriptionsForFilter(filter)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		if len(mds) != 1 {
-			return nil, nil, nil, api.ErrDataNotAvailable
-		}
-		measDescs = append(measDescs, mds[0])
+		measDescs = append(measDescs, filter)
 	}
 	return ec.GetPhaseCurrentLimits(measDescs)
 }

--- a/usecases/cem/oscev/public.go
+++ b/usecases/cem/oscev/public.go
@@ -47,14 +47,18 @@ func (e *OSCEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64,
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if len(limitDescs) != 3 {
+	if len(limitDescs) == 0 {
 		return nil, nil, nil, api.ErrDataNotAvailable
 	}
 
 	measDescs := make([]model.MeasurementDescriptionDataType, 0)
 	for _, ld := range limitDescs {
+		measId := ld.MeasurementId
+		if measId == nil {
+			return nil, nil, nil, api.ErrDataNotAvailable
+		}
 		filter := model.MeasurementDescriptionDataType{
-			MeasurementId: ld.MeasurementId,
+			MeasurementId: measId,
 		}
 		mds, err := meas.GetDescriptionsForFilter(filter)
 		if err != nil {

--- a/usecases/cem/oscev/public.go
+++ b/usecases/cem/oscev/public.go
@@ -52,10 +52,10 @@ func (e *OSCEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64,
 		if measId == nil {
 			return nil, nil, nil, api.ErrDataNotAvailable
 		}
-		filter := model.MeasurementDescriptionDataType{
+		md := model.MeasurementDescriptionDataType{
 			MeasurementId: measId,
 		}
-		measDescs = append(measDescs, filter)
+		measDescs = append(measDescs, md)
 	}
 	return ec.GetPhaseCurrentLimits(measDescs)
 }

--- a/usecases/cem/oscev/public.go
+++ b/usecases/cem/oscev/public.go
@@ -26,23 +26,46 @@ func (e *OSCEV) CurrentLimits(entity spineapi.EntityRemoteInterface) ([]float64,
 		return nil, nil, nil, err
 	}
 
+	lc, err := client.NewLoadControl(e.LocalEntity, entity)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	meas, err := client.NewMeasurement(e.LocalEntity, entity)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	filter := model.MeasurementDescriptionDataType{
-		MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-		CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-		Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-		ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+	filter := model.LoadControlLimitDescriptionDataType {
+		LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+		LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
+		Unit:          util.Ptr(model.UnitOfMeasurementTypeA),
+		ScopeType:     util.Ptr(model.ScopeTypeTypeSelfConsumption),
 	}
-	measDesc, err := meas.GetDescriptionsForFilter(filter)
+	
+	limitDescs, err := lc.GetLimitDescriptionsForFilter(filter)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	if len(limitDescs) != 3 {
+		return nil, nil, nil, api.ErrDataNotAvailable
+	}
 
-	return ec.GetPhaseCurrentLimits(measDesc)
+	measDescs := make([]model.MeasurementDescriptionDataType, 0)
+	for _, ld := range limitDescs {
+		filter := model.MeasurementDescriptionDataType{
+			MeasurementId: ld.MeasurementId,
+		}
+		mds, err := meas.GetDescriptionsForFilter(filter)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if len(mds) != 1 {
+			return nil, nil, nil, api.ErrDataNotAvailable
+		}
+		measDescs = append(measDescs, mds[0])
+	}
+	return ec.GetPhaseCurrentLimits(measDescs)
 }
 
 // return the current loadcontrol recommendation limits

--- a/usecases/cem/oscev/public_test.go
+++ b/usecases/cem/oscev/public_test.go
@@ -24,14 +24,6 @@ func (s *CemOSCEVSuite) Test_Public() {
 
 	lData := &model.LoadControlLimitDescriptionListDataType{
 		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
-			{
-				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
-				LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
-				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
-				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType: util.Ptr(model.ScopeTypeTypeSelfConsumption),
-				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
-			},
 		},
 	}
 
@@ -44,20 +36,26 @@ func (s *CemOSCEVSuite) Test_Public() {
 	lData = &model.LoadControlLimitDescriptionListDataType{
 		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
 			{
-				LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
 				LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
 				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
 				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
 				ScopeType: util.Ptr(model.ScopeTypeTypeSelfConsumption),
-				MeasurementId: util.Ptr(model.MeasurementIdType(1)),
 			},
+		},
+	}
+
+	_,errT = lc.UpdateData(true, model.FunctionTypeLoadControlLimitDescriptionListData, lData, nil, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
+
+	lData = &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
 			{
-				LimitId: util.Ptr(model.LoadControlLimitIdType(2)),
-				LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
-				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
-				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType: util.Ptr(model.ScopeTypeTypeSelfConsumption),
-				MeasurementId: util.Ptr(model.MeasurementIdType(2)),
+				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
 			},
 		},
 	}
@@ -70,13 +68,6 @@ func (s *CemOSCEVSuite) Test_Public() {
 
 	mData := &model.MeasurementDescriptionListDataType{
 		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
-			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
-				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
-			},
 		},
 	}
 	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
@@ -88,14 +79,7 @@ func (s *CemOSCEVSuite) Test_Public() {
 	mData = &model.MeasurementDescriptionListDataType{
 		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
 			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(1)),
-				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
-			},
-			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(2)),
+				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
 				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
 				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
 				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
@@ -103,7 +87,7 @@ func (s *CemOSCEVSuite) Test_Public() {
 			},
 		},
 	}
-	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, &model.FilterType{}, nil)
+	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
 	assert.Nil(s.T(), errT)
 
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)

--- a/usecases/cem/oscev/public_test.go
+++ b/usecases/cem/oscev/public_test.go
@@ -66,33 +66,6 @@ func (s *CemOSCEVSuite) Test_Public() {
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
 	assert.NotNil(s.T(), err)
 
-	mData := &model.MeasurementDescriptionListDataType{
-		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
-		},
-	}
-	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
-	assert.Nil(s.T(), errT)
-
-	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
-	assert.NotNil(s.T(), err)
-
-	mData = &model.MeasurementDescriptionListDataType{
-		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
-			{
-				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
-				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
-				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
-				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
-				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
-			},
-		},
-	}
-	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
-	assert.Nil(s.T(), errT)
-
-	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
-	assert.NotNil(s.T(), err)
-
 	_, err = s.sut.LoadControlLimits(s.mockRemoteEntity)
 	assert.NotNil(s.T(), err)
 

--- a/usecases/cem/oscev/public_test.go
+++ b/usecases/cem/oscev/public_test.go
@@ -16,8 +16,57 @@ func (s *CemOSCEVSuite) Test_Public() {
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
 	assert.NotNil(s.T(), err)
 
+	lc := s.evEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
+	assert.NotNil(s.T(), lc)
+
 	meas := s.evEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
 	assert.NotNil(s.T(), meas)
+
+	lData := &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
+			{
+				LimitId: util.Ptr(model.LoadControlLimitIdType(0)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
+				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType: util.Ptr(model.ScopeTypeTypeSelfConsumption),
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+			},
+		},
+	}
+
+	_,errT := lc.UpdateData(true, model.FunctionTypeLoadControlLimitDescriptionListData, lData, nil, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
+
+	lData = &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
+			{
+				LimitId: util.Ptr(model.LoadControlLimitIdType(1)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
+				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType: util.Ptr(model.ScopeTypeTypeSelfConsumption),
+				MeasurementId: util.Ptr(model.MeasurementIdType(1)),
+			},
+			{
+				LimitId: util.Ptr(model.LoadControlLimitIdType(2)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeRecommendation),
+				LimitType: util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				Unit: util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType: util.Ptr(model.ScopeTypeTypeSelfConsumption),
+				MeasurementId: util.Ptr(model.MeasurementIdType(2)),
+			},
+		},
+	}
+
+	_,errT = lc.UpdateData(true, model.FunctionTypeLoadControlLimitDescriptionListData, lData, &model.FilterType{}, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
 
 	mData := &model.MeasurementDescriptionListDataType{
 		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
@@ -30,7 +79,31 @@ func (s *CemOSCEVSuite) Test_Public() {
 			},
 		},
 	}
-	_, errT := meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
+	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, nil, nil)
+	assert.Nil(s.T(), errT)
+
+	_, _, _, err = s.sut.CurrentLimits(s.evEntity)
+	assert.NotNil(s.T(), err)
+
+	mData = &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(1)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(2)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				Unit:            util.Ptr(model.UnitOfMeasurementTypeA),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+			},
+		},
+	}
+	_, errT = meas.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, mData, &model.FilterType{}, nil)
 	assert.Nil(s.T(), errT)
 
 	_, _, _, err = s.sut.CurrentLimits(s.evEntity)


### PR DESCRIPTION
Since the "ScopeType" field in the LoadControlLimitDescription is more relevant (with a value of "overloadProtection" and "selfConsumption" for OPEV and OSCEV, respectively), it shall be used as the filter for obtaining the relevant ElectricalConnectionPermittedValueSetListData items in the CurrentLimits getters for [OPEV](https://github.com/enbility/eebus-go/blob/59e7016a7018364d209f72331685b0ef0ba97b67/usecases/cem/opev/public.go#L19) and [OSCEV](https://github.com/enbility/eebus-go/blob/59e7016a7018364d209f72331685b0ef0ba97b67/usecases/cem/oscev/public.go#L19). From the relevant LoadControlLimitDescriptionData items, one can get their corresponding measurement IDs and use them to filter for relevant parameter description items.