### PR TITLE
Add write approval callbacks for Failsafe values of CS-LPC usecase

### DIFF
--- a/examples/evse/main.go
+++ b/examples/evse/main.go
@@ -151,7 +151,7 @@ func (h *evse) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 	}
 
 	switch event {
-	case lpc.WriteApprovalRequired:
+	case lpc.LimitWriteApprovalRequired:
 		// get pending writes
 		pendingWrites := h.uclpc.PendingConsumptionLimits()
 

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -164,11 +164,9 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 		for msgCounter, configs := range pendingDeviceConfigWrites {
 			fmt.Printf("Approving LPC device config write with msgCounter %d for features: ", msgCounter)
 			for _, config := range configs {
-				keyName := "nil"
 				if config.Description.KeyName != nil {
-					keyName = string(*config.Description.KeyName)
+					fmt.Printf("%s ", string(*config.Description.KeyName))
 				}
-				fmt.Printf("%s ", keyName)
 			}
 			fmt.Print("\n")
 			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
@@ -201,11 +199,9 @@ func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 		for msgCounter, configs := range pendingDeviceConfigWrites {
 			fmt.Printf("Approving LPP device config write with msgCounter %d for features: ", msgCounter)
 			for _, config := range configs {
-				keyName := "nil"
 				if config.Description.KeyName != nil {
-					keyName = string(*config.Description.KeyName)
+					fmt.Printf("%s ", string(*config.Description.KeyName))
 				}
-				fmt.Printf("%s ", keyName)
 			}
 			fmt.Print("\n")
 			h.uccslpp.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -164,9 +164,7 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 		for msgCounter, configs := range pendingDeviceConfigWrites {
 			fmt.Printf("Approving LPC device config write with msgCounter %d for features: ", msgCounter)
 			for _, config := range configs {
-				if config.Description.KeyName != nil {
-					fmt.Printf("%s ", string(*config.Description.KeyName))
-				}
+				fmt.Printf("%s ", string(config.KeyName))
 			}
 			fmt.Print("\n")
 			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/enbility/eebus-go/api"
+	"github.com/enbility/eebus-go/features/server"
 	"github.com/enbility/eebus-go/service"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	"github.com/enbility/eebus-go/usecases/cem/vabd"
@@ -159,13 +160,23 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 			fmt.Println("Approving LPC limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpc.ApproveOrDenyConsumptionLimit(msgCounter, true, "")
 		}
-		for msgCounter, config := range pendingDeviceConfigWrites {
-			fmt.Print("Approving LPC device config write with msgCounter ", msgCounter)
-			if config.FailsafeDuration != nil {
-				fmt.Printf(" and FailsafeDurationMinimum %s", *config.FailsafeDuration)
+		for msgCounter, configs := range pendingDeviceConfigWrites {
+			localEntity := h.myService.LocalDevice().EntityForType(model.EntityTypeTypeCEM)
+			dc, err := server.NewDeviceConfiguration(localEntity)
+			if err != nil {
+				fmt.Println("Not approving LPC device configuration writes because of error:")
+				fmt.Println(err)
+				return
 			}
-			if config.FailsafeLimit != nil {
-				fmt.Printf(" and FailsafeConsumptionLimit %f", *config.FailsafeLimit)
+			fmt.Printf("Approving LPC device config write with msgCounter %d ", msgCounter)
+			for _, config := range(configs) {
+				description, err := dc.GetKeyValueDescriptionFoKeyId(*config.KeyId)
+				if description == nil || err != nil {
+					fmt.Printf("LPC approving device configuation writes: no device configuration for KeyID %d found\n", *config.KeyId)
+					continue
+				}
+
+				fmt.Printf("including %s ", *description.KeyName)
 			}
 			fmt.Print("\n")
 			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
@@ -191,16 +202,26 @@ func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 			fmt.Println("Approving LPP limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpp.ApproveOrDenyProductionLimit(msgCounter, true, "")
 		}
-		for msgCounter, config := range pendingDeviceConfigWrites {
-			fmt.Print("Approving LPP device config write with msgCounter ", msgCounter)
-			if config.FailsafeDuration != nil {
-				fmt.Printf(" and FailsafeDurationMinimum %s", *config.FailsafeDuration)
+		for msgCounter, configs := range pendingDeviceConfigWrites {
+			localEntity := h.myService.LocalDevice().EntityForType(model.EntityTypeTypeCEM)
+			dc, err := server.NewDeviceConfiguration(localEntity)
+			if err != nil {
+				fmt.Println("Not approving LPC device configuration writes because of error:")
+				fmt.Println(err)
+				return
 			}
-			if config.FailsafeLimit != nil {
-				fmt.Printf(" and FailsafeProductionLimit %f", *config.FailsafeLimit)
+
+			fmt.Printf("Approving LPP device config write with msgCounter %d ", msgCounter)
+			for _, config := range(configs) {
+				description, err := dc.GetKeyValueDescriptionFoKeyId(*config.KeyId)
+				if description == nil || err != nil {
+					fmt.Printf("LPP approving device configuation writes: no device configuration for KeyID %d found\n", *config.KeyId)
+					continue
+				}
+				fmt.Printf("including %s  ", *description.KeyName)
 			}
 			fmt.Print("\n")
-			h.uccslpp.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
+			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
 		}
 	case cslpp.DataUpdateLimit:
 		if currentLimit, err := h.uccslpp.ProductionLimit(); err == nil {

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -93,7 +93,7 @@ func (h *hems) run() {
 	configuration.SetAlternateIdentifier("Demo-HEMS-123456789")
 
 	h.myService = service.NewService(configuration, h)
-	//h.myService.SetLogging(h)
+	h.myService.SetLogging(h)
 
 	if err = h.myService.Setup(); err != nil {
 		fmt.Println(err)
@@ -161,7 +161,7 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 		}
 		for msgCounter, configs := range pendingDeviceConfigWrites {
 			fmt.Printf("Approving LPC device config write with msgCounter %d for features: ", msgCounter)
-			for _, config := range(configs) {
+			for _, config := range configs {
 				fmt.Printf("%s ", *config.Description.KeyName)
 			}
 			fmt.Print("\n")
@@ -182,7 +182,7 @@ func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 		// get pending writes
 		pendingWrites := h.uccslpp.PendingProductionLimits()
 		pendingDeviceConfigWrites := h.uccslpp.PendingDeviceConfigurations()
-		
+
 		// approve any write
 		for msgCounter, write := range pendingWrites {
 			fmt.Println("Approving LPP limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
@@ -190,7 +190,7 @@ func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 		}
 		for msgCounter, configs := range pendingDeviceConfigWrites {
 			fmt.Printf("Approving LPP device config write with msgCounter %d for features: ", msgCounter)
-			for _, config := range(configs) {
+			for _, config := range configs {
 				fmt.Printf("%s ", *config.Description.KeyName)
 			}
 			fmt.Print("\n")

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/enbility/eebus-go/api"
-	"github.com/enbility/eebus-go/features/server"
 	"github.com/enbility/eebus-go/service"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	"github.com/enbility/eebus-go/usecases/cem/vabd"
@@ -94,7 +93,7 @@ func (h *hems) run() {
 	configuration.SetAlternateIdentifier("Demo-HEMS-123456789")
 
 	h.myService = service.NewService(configuration, h)
-	h.myService.SetLogging(h)
+	//h.myService.SetLogging(h)
 
 	if err = h.myService.Setup(); err != nil {
 		fmt.Println(err)
@@ -161,22 +160,9 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 			h.uccslpc.ApproveOrDenyConsumptionLimit(msgCounter, true, "")
 		}
 		for msgCounter, configs := range pendingDeviceConfigWrites {
-			localEntity := h.myService.LocalDevice().EntityForType(model.EntityTypeTypeCEM)
-			dc, err := server.NewDeviceConfiguration(localEntity)
-			if err != nil {
-				fmt.Println("Not approving LPC device configuration writes because of error:")
-				fmt.Println(err)
-				return
-			}
-			fmt.Printf("Approving LPC device config write with msgCounter %d ", msgCounter)
+			fmt.Printf("Approving LPC device config write with msgCounter %d for features: ", msgCounter)
 			for _, config := range(configs) {
-				description, err := dc.GetKeyValueDescriptionFoKeyId(*config.KeyId)
-				if description == nil || err != nil {
-					fmt.Printf("LPC approving device configuation writes: no device configuration for KeyID %d found\n", *config.KeyId)
-					continue
-				}
-
-				fmt.Printf("including %s ", *description.KeyName)
+				fmt.Printf("%s ", *config.Description.KeyName)
 			}
 			fmt.Print("\n")
 			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
@@ -203,25 +189,12 @@ func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 			h.uccslpp.ApproveOrDenyProductionLimit(msgCounter, true, "")
 		}
 		for msgCounter, configs := range pendingDeviceConfigWrites {
-			localEntity := h.myService.LocalDevice().EntityForType(model.EntityTypeTypeCEM)
-			dc, err := server.NewDeviceConfiguration(localEntity)
-			if err != nil {
-				fmt.Println("Not approving LPC device configuration writes because of error:")
-				fmt.Println(err)
-				return
-			}
-
-			fmt.Printf("Approving LPP device config write with msgCounter %d ", msgCounter)
+			fmt.Printf("Approving LPP device config write with msgCounter %d for features: ", msgCounter)
 			for _, config := range(configs) {
-				description, err := dc.GetKeyValueDescriptionFoKeyId(*config.KeyId)
-				if description == nil || err != nil {
-					fmt.Printf("LPP approving device configuation writes: no device configuration for KeyID %d found\n", *config.KeyId)
-					continue
-				}
-				fmt.Printf("including %s  ", *description.KeyName)
+				fmt.Printf("%s ", *config.Description.KeyName)
 			}
 			fmt.Print("\n")
-			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
+			h.uccslpp.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
 		}
 	case cslpp.DataUpdateLimit:
 		if currentLimit, err := h.uccslpp.ProductionLimit(); err == nil {

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -149,20 +149,26 @@ func (h *hems) run() {
 
 func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	switch event {
-	case cslpc.WriteApprovalRequired:
+	case cslpc.LimitWriteApprovalRequired:
 		// get pending writes
 		pendingWrites := h.uccslpc.PendingConsumptionLimits()
-		pendingDeviceConfigWrites := h.uccslpc.PendingDeviceConfigurations()
 
 		// approve any write
 		for msgCounter, write := range pendingWrites {
 			fmt.Println("Approving LPC limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpc.ApproveOrDenyConsumptionLimit(msgCounter, true, "")
 		}
+	case cslpc.ConfigurationWriteApprovalRequired:
+		pendingDeviceConfigWrites := h.uccslpc.PendingDeviceConfigurations()
+
 		for msgCounter, configs := range pendingDeviceConfigWrites {
 			fmt.Printf("Approving LPC device config write with msgCounter %d for features: ", msgCounter)
 			for _, config := range configs {
-				fmt.Printf("%s ", *config.Description.KeyName)
+				keyName := "nil"
+				if config.Description.KeyName != nil {
+					keyName = string(*config.Description.KeyName)
+				}
+				fmt.Printf("%s ", keyName)
 			}
 			fmt.Print("\n")
 			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
@@ -178,20 +184,28 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 
 func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event api.EventType) {
 	switch event {
-	case cslpp.WriteApprovalRequired:
-		// get pending writes
+	case cslpp.LimitWriteApprovalRequired:
+		// get pending limit writes
 		pendingWrites := h.uccslpp.PendingProductionLimits()
-		pendingDeviceConfigWrites := h.uccslpp.PendingDeviceConfigurations()
 
 		// approve any write
 		for msgCounter, write := range pendingWrites {
 			fmt.Println("Approving LPP limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpp.ApproveOrDenyProductionLimit(msgCounter, true, "")
 		}
+	case cslpp.ConfigurationWriteApprovalRequired:
+		// get pending device config writes
+		pendingDeviceConfigWrites := h.uccslpp.PendingDeviceConfigurations()
+
+		// approve any write
 		for msgCounter, configs := range pendingDeviceConfigWrites {
 			fmt.Printf("Approving LPP device config write with msgCounter %d for features: ", msgCounter)
 			for _, config := range configs {
-				fmt.Printf("%s ", *config.Description.KeyName)
+				keyName := "nil"
+				if config.Description.KeyName != nil {
+					keyName = string(*config.Description.KeyName)
+				}
+				fmt.Printf("%s ", keyName)
 			}
 			fmt.Print("\n")
 			h.uccslpp.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -152,11 +152,16 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 	case cslpc.WriteApprovalRequired:
 		// get pending writes
 		pendingWrites := h.uccslpc.PendingConsumptionLimits()
+		pendingFailsafeWrites := h.uccslpc.PendingFailsafeConsumptionLimits()
 
 		// approve any write
 		for msgCounter, write := range pendingWrites {
-			fmt.Println("Approving LPC write with msgCounter", msgCounter, "and limit", write.Value, "W")
+			fmt.Println("Approving LPC limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpc.ApproveOrDenyConsumptionLimit(msgCounter, true, "")
+		}
+		for msgCounter, write := range pendingFailsafeWrites {
+			fmt.Println("Approving LPC failsafe limit write with msgCounter", msgCounter, "and limit", write.Value.ScaledNumber.GetValue())
+			h.uccslpc.ApproveOrDenyFailsafeConsumptionLimit(msgCounter, true, "")
 		}
 	case cslpc.DataUpdateLimit:
 		if currentLimit, err := h.uccslpc.ConsumptionLimit(); err == nil {
@@ -172,11 +177,16 @@ func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 	case cslpp.WriteApprovalRequired:
 		// get pending writes
 		pendingWrites := h.uccslpp.PendingProductionLimits()
-
+		pendingFailsafeWrites := h.uccslpp.PendingFailsafeProductionLimits()
+		
 		// approve any write
 		for msgCounter, write := range pendingWrites {
-			fmt.Println("Approving LPP write with msgCounter", msgCounter, "and limit", write.Value, "W")
+			fmt.Println("Approving LPP limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpp.ApproveOrDenyProductionLimit(msgCounter, true, "")
+		}
+		for msgCounter, write := range pendingFailsafeWrites {
+			fmt.Println("Approving LPP failsafe limit write with msgCounter", msgCounter, "and limit", write.Value.ScaledNumber.GetValue())
+			h.uccslpp.ApproveOrDenyFailsafeProductionLimit(msgCounter, true, "")
 		}
 	case cslpp.DataUpdateLimit:
 		if currentLimit, err := h.uccslpp.ProductionLimit(); err == nil {

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -152,16 +152,23 @@ func (h *hems) OnLPCEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 	case cslpc.WriteApprovalRequired:
 		// get pending writes
 		pendingWrites := h.uccslpc.PendingConsumptionLimits()
-		pendingFailsafeWrites := h.uccslpc.PendingFailsafeConsumptionLimits()
+		pendingDeviceConfigWrites := h.uccslpc.PendingDeviceConfigurations()
 
 		// approve any write
 		for msgCounter, write := range pendingWrites {
 			fmt.Println("Approving LPC limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpc.ApproveOrDenyConsumptionLimit(msgCounter, true, "")
 		}
-		for msgCounter, write := range pendingFailsafeWrites {
-			fmt.Println("Approving LPC failsafe limit write with msgCounter", msgCounter, "and limit", write.Value.ScaledNumber.GetValue())
-			h.uccslpc.ApproveOrDenyFailsafeConsumptionLimit(msgCounter, true, "")
+		for msgCounter, config := range pendingDeviceConfigWrites {
+			fmt.Print("Approving LPC device config write with msgCounter ", msgCounter)
+			if config.FailsafeDuration != nil {
+				fmt.Printf(" and FailsafeDurationMinimum %s", *config.FailsafeDuration)
+			}
+			if config.FailsafeLimit != nil {
+				fmt.Printf(" and FailsafeConsumptionLimit %f", *config.FailsafeLimit)
+			}
+			fmt.Print("\n")
+			h.uccslpc.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
 		}
 	case cslpc.DataUpdateLimit:
 		if currentLimit, err := h.uccslpc.ConsumptionLimit(); err == nil {
@@ -177,16 +184,23 @@ func (h *hems) OnLPPEvent(ski string, device spineapi.DeviceRemoteInterface, ent
 	case cslpp.WriteApprovalRequired:
 		// get pending writes
 		pendingWrites := h.uccslpp.PendingProductionLimits()
-		pendingFailsafeWrites := h.uccslpp.PendingFailsafeProductionLimits()
+		pendingDeviceConfigWrites := h.uccslpp.PendingDeviceConfigurations()
 		
 		// approve any write
 		for msgCounter, write := range pendingWrites {
 			fmt.Println("Approving LPP limit write with msgCounter", msgCounter, "and limit", write.Value, "W")
 			h.uccslpp.ApproveOrDenyProductionLimit(msgCounter, true, "")
 		}
-		for msgCounter, write := range pendingFailsafeWrites {
-			fmt.Println("Approving LPP failsafe limit write with msgCounter", msgCounter, "and limit", write.Value.ScaledNumber.GetValue())
-			h.uccslpp.ApproveOrDenyFailsafeProductionLimit(msgCounter, true, "")
+		for msgCounter, config := range pendingDeviceConfigWrites {
+			fmt.Print("Approving LPP device config write with msgCounter ", msgCounter)
+			if config.FailsafeDuration != nil {
+				fmt.Printf(" and FailsafeDurationMinimum %s", *config.FailsafeDuration)
+			}
+			if config.FailsafeLimit != nil {
+				fmt.Printf(" and FailsafeProductionLimit %f", *config.FailsafeLimit)
+			}
+			fmt.Print("\n")
+			h.uccslpp.ApproveOrDenyDeviceConfiguration(msgCounter, true, "")
 		}
 	case cslpp.DataUpdateLimit:
 		if currentLimit, err := h.uccslpp.ProductionLimit(); err == nil {

--- a/integration_tests/cs_deviceconfiguration_approval_test.go
+++ b/integration_tests/cs_deviceconfiguration_approval_test.go
@@ -1,0 +1,251 @@
+package integrationtests
+
+import (
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	"github.com/enbility/eebus-go/features/server"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	cslpc "github.com/enbility/eebus-go/usecases/cs/lpc"
+	cslpp "github.com/enbility/eebus-go/usecases/cs/lpp"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/spine"
+	"github.com/enbility/spine-go/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type deviceConfigurationApprovalEvents struct {
+	mux    sync.Mutex
+	events []eebusapi.EventType
+}
+
+func (e *deviceConfigurationApprovalEvents) add(_ string, _ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+
+	e.events = append(e.events, event)
+}
+
+func (e *deviceConfigurationApprovalEvents) contains(event eebusapi.EventType) bool {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+
+	return slices.Contains(e.events, event)
+}
+
+type csDeviceConfigurationApprovalSetup struct {
+	remoteDevice      spineapi.DeviceRemoteInterface
+	remoteEntity      spineapi.EntityRemoteInterface
+	remoteFeature     spineapi.FeatureRemoteInterface
+	localFeature      spineapi.FeatureLocalInterface
+	deviceConfig      *server.DeviceConfiguration
+	failsafeDuration  model.DeviceConfigurationKeyValueDescriptionDataType
+	lpc               *cslpc.LPC
+	lpp               *cslpp.LPP
+	events            *deviceConfigurationApprovalEvents
+	writeMessageCount model.MsgCounterType
+}
+
+func TestCSDeviceConfigurationApprovalRequiresLPCAndLPPForFailsafeDurationMinimum(t *testing.T) {
+	t.Run("notifies both use cases and keeps write pending until both approve", func(t *testing.T) {
+		setup := newCSDeviceConfigurationApprovalSetup(t)
+		newDuration := 4 * time.Hour
+
+		setup.writeFailsafeDurationMinimum(t, newDuration)
+		setup.requireBothUsecasesPendingFailsafeDurationMinimum(t)
+
+		setup.lpc.ApproveOrDenyDeviceConfiguration(setup.writeMessageCount, true, "")
+
+		setup.requireFailsafeDurationMinimumValue(t, 0)
+	})
+
+	t.Run("does not write when one use case denies", func(t *testing.T) {
+		setup := newCSDeviceConfigurationApprovalSetup(t)
+		newDuration := 6 * time.Hour
+
+		setup.writeFailsafeDurationMinimum(t, newDuration)
+		setup.requireBothUsecasesPendingFailsafeDurationMinimum(t)
+
+		setup.lpc.ApproveOrDenyDeviceConfiguration(setup.writeMessageCount, true, "")
+		setup.lpp.ApproveOrDenyDeviceConfiguration(setup.writeMessageCount, false, "denied")
+
+		setup.requireFailsafeDurationMinimumValue(t, 0)
+	})
+
+	t.Run("writes only after both use cases approve", func(t *testing.T) {
+		setup := newCSDeviceConfigurationApprovalSetup(t)
+		newDuration := 8 * time.Hour
+
+		setup.writeFailsafeDurationMinimum(t, newDuration)
+		setup.requireBothUsecasesPendingFailsafeDurationMinimum(t)
+
+		setup.lpc.ApproveOrDenyDeviceConfiguration(setup.writeMessageCount, true, "")
+		setup.requireFailsafeDurationMinimumValue(t, 0)
+
+		setup.lpp.ApproveOrDenyDeviceConfiguration(setup.writeMessageCount, true, "")
+
+		require.Eventually(t, func() bool {
+			return setup.failsafeDurationMinimumValue(t) == newDuration
+		}, time.Second, 10*time.Millisecond)
+	})
+}
+
+func newCSDeviceConfigurationApprovalSetup(t *testing.T) *csDeviceConfigurationApprovalSetup {
+	t.Helper()
+
+	localDevice := spine.NewDeviceLocal(
+		"TestBrandName",
+		"TestDeviceModel",
+		"TestSerialNumber",
+		"TestDeviceCode",
+		"TestDeviceAddress",
+		model.DeviceTypeTypeEnergyManagementSystem,
+		model.NetworkManagementFeatureSetTypeSmart,
+	)
+	localEntity := spine.NewEntityLocal(localDevice, model.EntityTypeTypeCEM, spine.NewAddressEntityType([]uint{1}), time.Second*60)
+	localDevice.AddEntity(localEntity)
+
+	events := &deviceConfigurationApprovalEvents{}
+	lpc := cslpc.NewLPC(localEntity, events.add)
+	lpc.AddFeatures()
+	lpp := cslpp.NewLPP(localEntity, events.add)
+	lpp.AddFeatures()
+
+	localFeature := localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)
+	require.NotNil(t, localFeature)
+
+	deviceConfig, err := server.NewDeviceConfiguration(localEntity)
+	require.NoError(t, err)
+
+	filter := model.DeviceConfigurationKeyValueDescriptionDataType{
+		KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+	}
+	descriptions, err := deviceConfig.GetKeyValueDescriptionsForFilter(filter)
+	require.NoError(t, err)
+	require.Len(t, descriptions, 1)
+	require.NotNil(t, descriptions[0].KeyId)
+
+	writeHandler := &WriteMessageHandler{}
+	_ = localDevice.SetupRemoteDevice("TestRemoteSki", writeHandler)
+	remoteDevice := localDevice.RemoteDeviceForSki("TestRemoteSki")
+	require.NotNil(t, remoteDevice)
+
+	remoteEntity := spine.NewEntityRemote(remoteDevice, model.EntityTypeTypeGridGuard, spine.NewAddressEntityType([]uint{1}))
+	remoteDevice.AddEntity(remoteEntity)
+	remoteFeature := spine.NewFeatureRemote(1, remoteEntity, model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeClient)
+	remoteEntity.AddFeature(remoteFeature)
+
+	return &csDeviceConfigurationApprovalSetup{
+		remoteDevice:      remoteDevice,
+		remoteEntity:      remoteEntity,
+		remoteFeature:     remoteFeature,
+		localFeature:      localFeature,
+		deviceConfig:      deviceConfig,
+		failsafeDuration:  descriptions[0],
+		lpc:               lpc,
+		lpp:               lpp,
+		events:            events,
+		writeMessageCount: model.MsgCounterType(1),
+	}
+}
+
+func (s *csDeviceConfigurationApprovalSetup) writeFailsafeDurationMinimum(t *testing.T, duration time.Duration) {
+	t.Helper()
+
+	msg := &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			AddressSource: &model.FeatureAddressType{
+				Device:  util.Ptr(model.AddressDeviceType("remote")),
+				Entity:  []model.AddressEntityType{1},
+				Feature: util.Ptr(model.AddressFeatureType(1)),
+			},
+			AddressDestination: s.localFeature.Address(),
+			MsgCounter:         util.Ptr(s.writeMessageCount),
+			AckRequest:         util.Ptr(true),
+		},
+		CmdClassifier: model.CmdClassifierTypeWrite,
+		FeatureRemote: s.remoteFeature,
+		DeviceRemote:  s.remoteDevice,
+		EntityRemote:  s.remoteEntity,
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: s.failsafeDuration.KeyId,
+						Value: &model.DeviceConfigurationKeyValueValueType{
+							Duration: model.NewDurationType(duration),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := s.localFeature.HandleMessage(msg)
+	require.Nil(t, err)
+}
+
+func (s *csDeviceConfigurationApprovalSetup) requireBothUsecasesPendingFailsafeDurationMinimum(t *testing.T) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return s.events.contains(cslpc.ConfigurationWriteApprovalRequired) &&
+			s.events.contains(cslpp.ConfigurationWriteApprovalRequired)
+	}, time.Second, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return pendingDeviceConfigurationHasKeyName(
+			s.lpc.PendingDeviceConfigurations(),
+			s.writeMessageCount,
+			model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum,
+		) && pendingDeviceConfigurationHasKeyName(
+			s.lpp.PendingDeviceConfigurations(),
+			s.writeMessageCount,
+			model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum,
+		)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func (s *csDeviceConfigurationApprovalSetup) failsafeDurationMinimumValue(t *testing.T) time.Duration {
+	t.Helper()
+
+	lpcDuration, lpcChangeable, err := s.lpc.FailsafeDurationMinimum()
+	require.NoError(t, err)
+	lppDuration, lppChangeable, err := s.lpp.FailsafeDurationMinimum()
+	require.NoError(t, err)
+
+	assert.Equal(t, lpcDuration, lppDuration)
+	assert.Equal(t, lpcChangeable, lppChangeable)
+
+	return lpcDuration
+}
+
+func (s *csDeviceConfigurationApprovalSetup) requireFailsafeDurationMinimumValue(t *testing.T, expected time.Duration) {
+	t.Helper()
+
+	assert.Equal(t, expected, s.failsafeDurationMinimumValue(t))
+}
+
+func pendingDeviceConfigurationHasKeyName(
+	pending map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration,
+	msgCounter model.MsgCounterType,
+	keyName model.DeviceConfigurationKeyNameType,
+) bool {
+	configs, ok := pending[msgCounter]
+	if !ok {
+		return false
+	}
+
+	for _, config := range configs {
+		if config.KeyName == keyName {
+			return true
+		}
+	}
+
+	return false
+}

--- a/usecases/api/cs_lpc.go
+++ b/usecases/api/cs_lpc.go
@@ -73,7 +73,7 @@ type CsLPCInterface interface {
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
 	// return the currently pending incoming device configuration writes
-	PendingDeviceConfigurations() map[model.MsgCounterType]*DeviceConfigurations
+	PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType
 
 	// accept or deny an incoming device configuration writes
 	//

--- a/usecases/api/cs_lpc.go
+++ b/usecases/api/cs_lpc.go
@@ -72,16 +72,16 @@ type CsLPCInterface interface {
 	//   - changeable: boolean if the client service can change this value
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
-	// return the currently pending incoming failsafe consumption write limits
-	PendingFailsafeConsumptionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType
+	// return the currently pending incoming device configuration writes
+	PendingDeviceConfigurations() map[model.MsgCounterType]*DeviceConfigurations
 
-	// accept or deny an incoming failsafe consumption write limit
+	// accept or deny an incoming device configuration writes
 	//
 	// parameters:
 	//  - msg: the incoming write message
 	//  - approve: if the write limit for msg should be approved or not
 	//  - reason: the reason why the approval is denied, otherwise an empty string
-	ApproveOrDenyFailsafeConsumptionLimit(msgCounter model.MsgCounterType, approve bool, reason string)
+	ApproveOrDenyDeviceConfiguration(msgCounter model.MsgCounterType, approve bool, reason string)
 
 	// Scenario 3
 

--- a/usecases/api/cs_lpc.go
+++ b/usecases/api/cs_lpc.go
@@ -73,7 +73,7 @@ type CsLPCInterface interface {
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
 	// return the currently pending incoming device configuration writes
-	PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType
+	PendingDeviceConfigurations() map[model.MsgCounterType][]PendingDeviceConfiguration
 
 	// accept or deny an incoming device configuration writes
 	//

--- a/usecases/api/cs_lpc.go
+++ b/usecases/api/cs_lpc.go
@@ -72,6 +72,17 @@ type CsLPCInterface interface {
 	//   - changeable: boolean if the client service can change this value
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
+	// return the currently pending incoming failsafe consumption write limits
+	PendingFailsafeConsumptionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType
+
+	// accept or deny an incoming failsafe consumption write limit
+	//
+	// parameters:
+	//  - msg: the incoming write message
+	//  - approve: if the write limit for msg should be approved or not
+	//  - reason: the reason why the approval is denied, otherwise an empty string
+	ApproveOrDenyFailsafeConsumptionLimit(msgCounter model.MsgCounterType, approve bool, reason string)
+
 	// Scenario 3
 
 	// start sending heartbeat from the local entity supporting this usecase

--- a/usecases/api/cs_lpp.go
+++ b/usecases/api/cs_lpp.go
@@ -73,7 +73,7 @@ type CsLPPInterface interface {
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
 	// return the currently pending incoming device configuration writes
-	PendingDeviceConfigurations() map[model.MsgCounterType]*DeviceConfigurations
+	PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType
 
 	// accept or deny an incoming device configuration writes
 	//

--- a/usecases/api/cs_lpp.go
+++ b/usecases/api/cs_lpp.go
@@ -72,16 +72,16 @@ type CsLPPInterface interface {
 	//   - changeable: boolean if the client service can change this value
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
-	// return the currently pending incoming failsafe production write limits
-	PendingFailsafeProductionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType
+	// return the currently pending incoming device configuration writes
+	PendingDeviceConfigurations() map[model.MsgCounterType]*DeviceConfigurations
 
-	// accept or deny an incoming failsafe production write limit
+	// accept or deny an incoming device configuration writes
 	//
 	// parameters:
 	//  - msg: the incoming write message
 	//  - approve: if the write limit for msg should be approved or not
 	//  - reason: the reason why the approval is denied, otherwise an empty string
-	ApproveOrDenyFailsafeProductionLimit(msgCounter model.MsgCounterType, approve bool, reason string)
+	ApproveOrDenyDeviceConfiguration(msgCounter model.MsgCounterType, approve bool, reason string)
 
 	// Scenario 3
 

--- a/usecases/api/cs_lpp.go
+++ b/usecases/api/cs_lpp.go
@@ -72,6 +72,17 @@ type CsLPPInterface interface {
 	//   - changeable: boolean if the client service can change this value
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
+	// return the currently pending incoming failsafe production write limits
+	PendingFailsafeProductionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType
+
+	// accept or deny an incoming failsafe production write limit
+	//
+	// parameters:
+	//  - msg: the incoming write message
+	//  - approve: if the write limit for msg should be approved or not
+	//  - reason: the reason why the approval is denied, otherwise an empty string
+	ApproveOrDenyFailsafeProductionLimit(msgCounter model.MsgCounterType, approve bool, reason string)
+
 	// Scenario 3
 
 	// start sending heartbeat from the local entity supporting this usecase

--- a/usecases/api/cs_lpp.go
+++ b/usecases/api/cs_lpp.go
@@ -73,7 +73,7 @@ type CsLPPInterface interface {
 	SetFailsafeDurationMinimum(duration time.Duration, changeable bool) (resultErr error)
 
 	// return the currently pending incoming device configuration writes
-	PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType
+	PendingDeviceConfigurations() map[model.MsgCounterType][]PendingDeviceConfiguration
 
 	// accept or deny an incoming device configuration writes
 	//

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -168,7 +168,7 @@ type DurationSlotValue struct {
 }
 
 type PendingDeviceConfiguration struct {
-	Description     	*model.DeviceConfigurationKeyValueDescriptionDataType     	`json:"description,omitempty"`
-	Value             	*model.DeviceConfigurationKeyValueValueType 				`json:"value,omitempty"`
-	IsValueChangeable 	*bool                                 						`json:"isValueChangeable,omitempty" eebus:"writecheck"`
+	Description       *model.DeviceConfigurationKeyValueDescriptionDataType `json:"description,omitempty"`
+	Value             *model.DeviceConfigurationKeyValueValueType           `json:"value,omitempty"`
+	IsValueChangeable *bool                                                 `json:"isValueChangeable,omitempty" eebus:"writecheck"`
 }

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -170,5 +170,5 @@ type DurationSlotValue struct {
 type PendingDeviceConfiguration struct {
 	Description       *model.DeviceConfigurationKeyValueDescriptionDataType `json:"description,omitempty"`
 	Value             *model.DeviceConfigurationKeyValueValueType           `json:"value,omitempty"`
-	IsValueChangeable *bool                                                 `json:"isValueChangeable,omitempty" eebus:"writecheck"`
+	IsValueChangeable *bool                                                 `json:"isValueChangeable,omitempty"`
 }

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/enbility/spine-go/model"
+	spineapi "github.com/enbility/spine-go/api"
 )
 
 type EVChargeStateType string
@@ -165,4 +166,11 @@ type IncentiveTariffDescription struct {
 type DurationSlotValue struct {
 	Duration time.Duration // Duration of this slot
 	Value    float64       // Energy Cost or Power Limit
+}
+
+// Contains info on device configurations trying to be set via a write call on device configuration feature
+type DeviceConfigurations struct {
+	FailsafeLimit 		*float64
+	FailsafeDuration 	*time.Duration
+	Msg 				*spineapi.Message
 }

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -168,7 +168,8 @@ type DurationSlotValue struct {
 }
 
 type PendingDeviceConfiguration struct {
-	Description       *model.DeviceConfigurationKeyValueDescriptionDataType `json:"description,omitempty"`
-	Value             *model.DeviceConfigurationKeyValueValueType           `json:"value,omitempty"`
-	IsValueChangeable *bool                                                 `json:"isValueChangeable,omitempty"`
+	Description       model.DeviceConfigurationKeyValueDescriptionDataType `json:"description"`
+	KeyName           model.DeviceConfigurationKeyNameType                 `json:"keyName"`
+	Value             *model.DeviceConfigurationKeyValueValueType          `json:"value,omitempty"`
+	IsValueChangeable *bool                                                `json:"isValueChangeable,omitempty"`
 }

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -166,3 +166,9 @@ type DurationSlotValue struct {
 	Duration time.Duration // Duration of this slot
 	Value    float64       // Energy Cost or Power Limit
 }
+
+type PendingDeviceConfiguration struct {
+	Description     	*model.DeviceConfigurationKeyValueDescriptionDataType     	`json:"description,omitempty"`
+	Value             	*model.DeviceConfigurationKeyValueValueType 				`json:"value,omitempty"`
+	IsValueChangeable 	*bool                                 						`json:"isValueChangeable,omitempty" eebus:"writecheck"`
+}

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/enbility/spine-go/model"
-	spineapi "github.com/enbility/spine-go/api"
 )
 
 type EVChargeStateType string
@@ -166,11 +165,4 @@ type IncentiveTariffDescription struct {
 type DurationSlotValue struct {
 	Duration time.Duration // Duration of this slot
 	Value    float64       // Energy Cost or Power Limit
-}
-
-// Contains info on device configurations trying to be set via a write call on device configuration feature
-type DeviceConfigurations struct {
-	FailsafeLimit 		*float64
-	FailsafeDuration 	*time.Duration
-	Msg 				*spineapi.Message
 }

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -271,11 +271,24 @@ func (e *LPC) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 }
 
 // return the currently pending incoming failsafe consumption limit writes
-func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType]*ucapi.DeviceConfigurations {
+func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType {
+	result := make(map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType)
+	
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
-	
-	return e.pendingDeviceConfigs
+
+	for msgCounter, msg := range e.pendingDeviceConfigs {
+		data := msg.Cmd.DeviceConfigurationKeyValueListData
+		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
+			if _, exists := result[msgCounter]; exists {
+				result[msgCounter] = append(result[msgCounter], configKeyValueData)
+			} else {
+				result[msgCounter] = []model.DeviceConfigurationKeyValueDataType{configKeyValueData}
+			}
+		}
+	}
+
+	return result
 }
 
 // accept or deny an incoming device configuration write
@@ -285,14 +298,13 @@ func (e *LPC) ApproveOrDenyDeviceConfiguration(msgCounter model.MsgCounterType, 
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
-	config, ok := e.pendingDeviceConfigs[msgCounter]
+	msg, ok := e.pendingDeviceConfigs[msgCounter]
 	if !ok {
 		// no pending limit for this msgCounter, this is a caller error
 		return
 	}
 
-	e.approveOrDenyDeviceConfiguration(config.Msg, approve, reason)
-
+	e.approveOrDenyDeviceConfiguration(msg, approve, reason)
 	delete(e.pendingDeviceConfigs, msgCounter)
 }
 

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -270,6 +270,39 @@ func (e *LPC) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 	return dc.UpdateKeyValueDataForFilter(data, nil, filter)
 }
 
+// return the currently pending incoming failsafe consumption write limits
+func (e *LPC) PendingFailsafeConsumptionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType {
+	result := make(map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType)
+
+	e.pendingFailsafeLimitMux.Lock()
+	defer e.pendingFailsafeLimitMux.Unlock()
+
+	for key, msg := range e.pendingFailsafeLimits {
+		// The existance of this value is checked when it is added to the pendingFailsafeLimits map therefore we do not need to check it again
+		result[key] = msg.Cmd.DeviceConfigurationKeyValueListData.DeviceConfigurationKeyValueData[0]
+	}
+
+	return result
+}
+
+// accept or deny an incoming failsafe consumption write limit
+//
+// use PendingFailsafeConusmptionLimits to get the list of currently pending requests
+func (e *LPC) ApproveOrDenyFailsafeConsumptionLimit(msgCounter model.MsgCounterType, approve bool, reason string) {
+	e.pendingFailsafeLimitMux.Lock()
+	defer e.pendingFailsafeLimitMux.Unlock()
+
+	msg, ok := e.pendingFailsafeLimits[msgCounter]
+	if !ok {
+		// no pending limit for this msgCounter, this is a caller error
+		return
+	}
+
+	e.approveOrDenyFailsafeConsumptionLimit(msg, approve, reason)
+
+	delete(e.pendingFailsafeLimits, msgCounter)
+}
+
 // Scenario 3
 
 // start sending heartbeat from the local entity supporting this usecase

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -271,7 +271,7 @@ func (e *LPC) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 	return dc.UpdateKeyValueDataForFilter(data, nil, filter)
 }
 
-// return the currently pending incoming failsafe consumption limit writes
+// return the currently pending incoming device configuration writes
 func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -7,6 +7,7 @@ import (
 	"github.com/enbility/eebus-go/api"
 	"github.com/enbility/eebus-go/features/server"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	"github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 )
@@ -272,38 +273,10 @@ func (e *LPC) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 
 // return the currently pending incoming failsafe consumption limit writes
 func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
-	result := make(map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration)
-
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
-	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
-	if err != nil {
-		return result
-	}
-
-	for msgCounter, msg := range e.pendingDeviceConfigs {
-		data := msg.Cmd.DeviceConfigurationKeyValueListData
-		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
-			description, err := dc.GetKeyValueDescriptionFoKeyId(*configKeyValueData.KeyId)
-			if err != nil {
-				continue
-			}
-
-			pendingConfigData := ucapi.PendingDeviceConfiguration{
-				Description:       description,
-				Value:             configKeyValueData.Value,
-				IsValueChangeable: configKeyValueData.IsValueChangeable,
-			}
-
-			if _, exists := result[msgCounter]; !exists {
-				result[msgCounter] = []ucapi.PendingDeviceConfiguration{pendingConfigData}
-			} else {
-				result[msgCounter] = append(result[msgCounter], pendingConfigData)
-			}
-		}
-	}
-	return result
+	return internal.GroupPendingDeviceConfigurations(e.pendingDeviceConfigs, e.LocalEntity)
 }
 
 // accept or deny an incoming device configuration write

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -270,37 +270,30 @@ func (e *LPC) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 	return dc.UpdateKeyValueDataForFilter(data, nil, filter)
 }
 
-// return the currently pending incoming failsafe consumption write limits
-func (e *LPC) PendingFailsafeConsumptionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType {
-	result := make(map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType)
-
-	e.pendingFailsafeLimitMux.Lock()
-	defer e.pendingFailsafeLimitMux.Unlock()
-
-	for key, msg := range e.pendingFailsafeLimits {
-		// The existance of this value is checked when it is added to the pendingFailsafeLimits map therefore we do not need to check it again
-		result[key] = msg.Cmd.DeviceConfigurationKeyValueListData.DeviceConfigurationKeyValueData[0]
-	}
-
-	return result
+// return the currently pending incoming failsafe consumption limit writes
+func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType]*ucapi.DeviceConfigurations {
+	e.pendingDeviceConfigMux.Lock()
+	defer e.pendingDeviceConfigMux.Unlock()
+	
+	return e.pendingDeviceConfigs
 }
 
-// accept or deny an incoming failsafe consumption write limit
+// accept or deny an incoming device configuration write
 //
-// use PendingFailsafeConusmptionLimits to get the list of currently pending requests
-func (e *LPC) ApproveOrDenyFailsafeConsumptionLimit(msgCounter model.MsgCounterType, approve bool, reason string) {
-	e.pendingFailsafeLimitMux.Lock()
-	defer e.pendingFailsafeLimitMux.Unlock()
+// use PendingDeviceConfigurations to get the list of currently pending requests
+func (e *LPC) ApproveOrDenyDeviceConfiguration(msgCounter model.MsgCounterType, approve bool, reason string) {
+	e.pendingDeviceConfigMux.Lock()
+	defer e.pendingDeviceConfigMux.Unlock()
 
-	msg, ok := e.pendingFailsafeLimits[msgCounter]
+	config, ok := e.pendingDeviceConfigs[msgCounter]
 	if !ok {
 		// no pending limit for this msgCounter, this is a caller error
 		return
 	}
 
-	e.approveOrDenyFailsafeConsumptionLimit(msg, approve, reason)
+	e.approveOrDenyDeviceConfiguration(config.Msg, approve, reason)
 
-	delete(e.pendingFailsafeLimits, msgCounter)
+	delete(e.pendingDeviceConfigs, msgCounter)
 }
 
 // Scenario 3

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -273,7 +273,7 @@ func (e *LPC) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 // return the currently pending incoming failsafe consumption limit writes
 func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
 	result := make(map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration)
-	
+
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
@@ -289,10 +289,10 @@ func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.Pen
 			if err != nil {
 				continue
 			}
-			
+
 			pendingConfigData := ucapi.PendingDeviceConfiguration{
-				Description: description,
-				Value: configKeyValueData.Value,
+				Description:       description,
+				Value:             configKeyValueData.Value,
 				IsValueChangeable: configKeyValueData.IsValueChangeable,
 			}
 

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -271,23 +271,38 @@ func (e *LPC) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 }
 
 // return the currently pending incoming failsafe consumption limit writes
-func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType {
-	result := make(map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType)
+func (e *LPC) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
+	result := make(map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration)
 	
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
+	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
+	if err != nil {
+		return result
+	}
+
 	for msgCounter, msg := range e.pendingDeviceConfigs {
 		data := msg.Cmd.DeviceConfigurationKeyValueListData
 		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
-			if _, exists := result[msgCounter]; exists {
-				result[msgCounter] = append(result[msgCounter], configKeyValueData)
+			description, err := dc.GetKeyValueDescriptionFoKeyId(*configKeyValueData.KeyId)
+			if err != nil {
+				continue
+			}
+			
+			pendingConfigData := ucapi.PendingDeviceConfiguration{
+				Description: description,
+				Value: configKeyValueData.Value,
+				IsValueChangeable: configKeyValueData.IsValueChangeable,
+			}
+
+			if _, exists := result[msgCounter]; !exists {
+				result[msgCounter] = []ucapi.PendingDeviceConfiguration{pendingConfigData}
 			} else {
-				result[msgCounter] = []model.DeviceConfigurationKeyValueDataType{configKeyValueData}
+				result[msgCounter] = append(result[msgCounter], pendingConfigData)
 			}
 		}
 	}
-
 	return result
 }
 

--- a/usecases/cs/lpc/public_test.go
+++ b/usecases/cs/lpc/public_test.go
@@ -170,3 +170,46 @@ func (s *CsLPCSuite) Test_ConsumptionNominalMax() {
 	assert.Equal(s.T(), 10.0, value)
 	assert.Nil(s.T(), err)
 }
+
+func (s *CsLPCSuite) Test_PendingDeviceConfigurations() {
+	data := s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 0, len(data))
+
+	msgCounter := model.MsgCounterType(500)
+
+	msg := &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(msgCounter),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0)),
+						Value: &model.DeviceConfigurationKeyValueValueType{
+							ScaledNumber: model.NewScaledNumberType(1000),
+						},
+						IsValueChangeable: util.Ptr(true),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+
+	s.sut.deviceConfigurationWriteCB(msg)
+
+	data = s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 1, len(data))
+
+	s.sut.ApproveOrDenyDeviceConfiguration(model.MsgCounterType(499), true, "")
+
+	data = s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 1, len(data))
+
+	s.sut.ApproveOrDenyDeviceConfiguration(msgCounter, false, "leave me alone")
+
+	data = s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 0, len(data))
+}

--- a/usecases/cs/lpc/types.go
+++ b/usecases/cs/lpc/types.go
@@ -17,8 +17,10 @@ const (
 
 	// An incoming load control obligation limit needs to be approved or denied
 	//
-	// Use `PendingConsumptionLimits` to get the currently pending write approval requests
-	// and invoke `ApproveOrDenyConsumptionLimit` for each
+	// Use `PendingConsumptionLimits` and `PendingDeviceConfigurations` to get
+	// the currently pending write approval requests and invoke
+	// `ApproveOrDenyConsumptionLimit` or `ApproveOrDenyDeviceConfiguration`
+	// for each
 	//
 	// Use Case LPC, Scenario 1
 	WriteApprovalRequired api.EventType = "cs-lpc-WriteApprovalRequired"

--- a/usecases/cs/lpc/types.go
+++ b/usecases/cs/lpc/types.go
@@ -17,16 +17,16 @@ const (
 
 	// An incoming load control obligation limit needs to be approved or denied
 	//
-	// Use `PendingConsumptionLimits` to get the currently pending limit write
-	// approval requests and invoke `ApproveOrDenyConsumptionLimit` for each
+	// Use `PendingConsumptionLimits` to get the currently pending consumption limits
+	// awaiting approval and invoke `ApproveOrDenyConsumptionLimit` for each
 	//
 	// Use Case LPC, Scenario 1
 	LimitWriteApprovalRequired api.EventType = "cs-lpc-LimitWriteApprovalRequired"
 
 	// An incoming device configuration write needs to be approved or denied
 	//
-	// Use `PendingDeviceConfigurations` to get the currently pending device configuration
-	// write approval requests and invoke `ApproveOrDenyDeviceConfiguration` for each
+	// Use `PendingDeviceConfigurations` to get the currently pending device configurations
+	// awaiting approval and invoke `ApproveOrDenyDeviceConfiguration` for each
 	//
 	// Use Case LPC, Scenario 1
 	ConfigurationWriteApprovalRequired api.EventType = "cs-lpc-ConfigurationWriteApprovalRequired"

--- a/usecases/cs/lpc/types.go
+++ b/usecases/cs/lpc/types.go
@@ -17,13 +17,19 @@ const (
 
 	// An incoming load control obligation limit needs to be approved or denied
 	//
-	// Use `PendingConsumptionLimits` and `PendingDeviceConfigurations` to get
-	// the currently pending write approval requests and invoke
-	// `ApproveOrDenyConsumptionLimit` or `ApproveOrDenyDeviceConfiguration`
-	// for each
+	// Use `PendingConsumptionLimits` to get the currently pending limit write
+	// approval requests and invoke `ApproveOrDenyConsumptionLimit` for each
 	//
 	// Use Case LPC, Scenario 1
-	WriteApprovalRequired api.EventType = "cs-lpc-WriteApprovalRequired"
+	LimitWriteApprovalRequired api.EventType = "cs-lpc-LimitWriteApprovalRequired"
+
+	// An incoming device configuration write needs to be approved or denied
+	//
+	// Use `PendingDeviceConfigurations` to get the currently pending device configuration
+	// write approval requests and invoke `ApproveOrDenyDeviceConfiguration` for each
+	//
+	// Use Case LPC, Scenario 1
+	ConfigurationWriteApprovalRequired api.EventType = "cs-lpc-ConfigurationWriteApprovalRequired"
 
 	// Failsafe limit for the consumed active (real) power of the
 	// Controllable System data update received

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -213,11 +213,13 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		e.pendingDeviceConfigMux.Lock()
 		if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
 			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
+			// Unlock before calling EventCB to avoid deadlock (EventCB will need to read pendingDeviceConfigs)
 			e.pendingDeviceConfigMux.Unlock()
 			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, ConfigurationWriteApprovalRequired)
 			return
 		}
 		e.pendingDeviceConfigMux.Unlock()
+		return
 	}
 
 	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this use case so we accept

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -2,7 +2,6 @@ package lpc
 
 import (
 	"sync"
-	"time"
 
 	"github.com/enbility/eebus-go/api"
 	features "github.com/enbility/eebus-go/features/client"
@@ -24,7 +23,7 @@ type LPC struct {
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
 	pendingDeviceConfigMux		sync.Mutex
-	pendingDeviceConfigs		map[model.MsgCounterType]*ucapi.DeviceConfigurations
+	pendingDeviceConfigs		map[model.MsgCounterType]*spineapi.Message
 
 	heartbeatDiag *features.DeviceDiagnosis
 
@@ -83,7 +82,7 @@ func NewLPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	uc := &LPC{
 		UseCaseBase:   usecase,
 		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
-		pendingDeviceConfigs: make(map[model.MsgCounterType]*ucapi.DeviceConfigurations),
+		pendingDeviceConfigs: make(map[model.MsgCounterType]*spineapi.Message),
 	}
 
 	_ = spine.Events.Subscribe(uc)
@@ -218,49 +217,32 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		return
 	}
 
-	var failsafeLimit *float64 = nil
-	var failsafeDuration *time.Duration = nil
+	configsToApprove := map[model.DeviceConfigurationKeyNameType]struct{}{
+		model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit: {},
+		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum: {},
+	}
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
-
 		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
 		if description == nil || err != nil {
 			logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID %d found")
 			continue
 		}
 
-		// We only care about new values for either FailsafeConsumptionActivePowerLimit or FailsafeDurationMinimum, all other keys are ignored
-		switch *description.KeyName {
-		case model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit:
-			value := deviceKeyValueData.Value.ScaledNumber.GetValue()
-			failsafeLimit = &value
-		case model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:
-			value, err := deviceKeyValueData.Value.Duration.GetTimeDuration()
-			if err == nil {
-				failsafeDuration = &value
-			} else {
-				logging.Log().Debug("LPC deviceConfigurationWriteCB: received invalid or no value as duration while trying to set FailsafeDurationMinimum")
-			}
-		}	
-	}
-
-	// Only ask for write approval if at least one of the configurations we care about is trying to be set
-	if failsafeDuration != nil || failsafeLimit != nil {
-		e.pendingDeviceConfigMux.Lock()
-		if _, ok := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !ok {
-			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = &ucapi.DeviceConfigurations{
-				FailsafeLimit: failsafeLimit,
-				FailsafeDuration: failsafeDuration,
-				Msg: msg,
+		// Only ask for write approval if at least one of the configurations we care about is trying to be set
+		if _, exists := configsToApprove[*description.KeyName]; exists {
+			e.pendingDeviceConfigMux.Lock()
+			if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
+				e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
+				e.pendingDeviceConfigMux.Unlock()
+				e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
+				return
 			}
 			e.pendingDeviceConfigMux.Unlock()
-			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
-			return
-		}
-		e.pendingDeviceConfigMux.Unlock()
-	} else {
-		// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
-		e.approveOrDenyDeviceConfiguration(msg, true, "")
+		} 
 	}
+
+	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+	e.approveOrDenyDeviceConfiguration(msg, true, "")
 }	
 
 func (e *LPC) AddFeatures() {

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -213,7 +213,7 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 			return
 		}
 
-	dcs, err := server.NewDeviceConfiguration(e.LocalEntity)
+	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
 	if err != nil {
 		return
 	}
@@ -222,10 +222,9 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 	var failsafeDuration *time.Duration = nil
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
 
-		description, err := dcs.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
+		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
 		if description == nil || err != nil {
-			logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
-			// if no description is found this write request is presumably for another usecase
+			logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID %d found")
 			continue
 		}
 
@@ -244,6 +243,7 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		}	
 	}
 
+	// Only ask for write approval if at least one of the configurations we care about is trying to be set
 	if failsafeDuration != nil || failsafeLimit != nil {
 		e.pendingDeviceConfigMux.Lock()
 		if _, ok := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !ok {
@@ -258,7 +258,7 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		}
 		e.pendingDeviceConfigMux.Unlock()
 	} else {
-		// As neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+		// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
 		e.approveOrDenyDeviceConfiguration(msg, true, "")
 	}
 }	

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -199,11 +199,6 @@ func (e *LPC) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bo
 // the implementation only considers write messages for this use case and
 // approves all others
 func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
-	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil {
-		logging.Log().Debug("LPC deviceConfigurationWriteCB: invalid message")
-		return
-	}
-
 	configsToApprove := map[model.DeviceConfigurationKeyNameType]struct{}{
 		model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit: {},
 		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:             {},

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -1,6 +1,7 @@
 package lpc
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/enbility/eebus-go/api"
@@ -22,8 +23,8 @@ type LPC struct {
 	pendingMux    sync.Mutex
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
-	pendingDeviceConfigMux		sync.Mutex
-	pendingDeviceConfigs		map[model.MsgCounterType]*spineapi.Message
+	pendingDeviceConfigMux sync.Mutex
+	pendingDeviceConfigs   map[model.MsgCounterType]*spineapi.Message
 
 	heartbeatDiag *features.DeviceDiagnosis
 
@@ -80,8 +81,8 @@ func NewLPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	)
 
 	uc := &LPC{
-		UseCaseBase:   usecase,
-		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
+		UseCaseBase:          usecase,
+		pendingLimits:        make(map[model.MsgCounterType]*spineapi.Message),
 		pendingDeviceConfigs: make(map[model.MsgCounterType]*spineapi.Message),
 	}
 
@@ -200,17 +201,25 @@ func (e *LPC) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bo
 // approves all others
 func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
-	msg.Cmd.DeviceConfigurationKeyValueListData  == nil {
+		msg.Cmd.DeviceConfigurationKeyValueListData == nil {
 		logging.Log().Debug("LPC deviceConfigurationWriteCB: invalid message")
 		return
 	}
 
 	data := msg.Cmd.DeviceConfigurationKeyValueListData
 
-	if len(data.DeviceConfigurationKeyValueData) == 0 || data.DeviceConfigurationKeyValueData[0].KeyId == nil {
-			logging.Log().Debug("LPC deviceConfigurationWriteCB: no data")
-			return
-		}
+	if data == nil || data.DeviceConfigurationKeyValueData == nil || len(data.DeviceConfigurationKeyValueData) == 0 {
+		logging.Log().Debug("LPC deviceConfigurationWriteCB: no data")
+		return
+	}
+
+	// all DeviceConfigurationKeyValueData must have keyId set as primary identifier
+	if slices.ContainsFunc(data.DeviceConfigurationKeyValueData, func(i model.DeviceConfigurationKeyValueDataType) bool {
+		return i.KeyId == nil
+	}) {
+		logging.Log().Debug("LPC deviceConfigurationWriteCB: invalid message")
+		return
+	}
 
 	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
 	if err != nil {
@@ -219,7 +228,7 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 
 	configsToApprove := map[model.DeviceConfigurationKeyNameType]struct{}{
 		model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit: {},
-		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum: {},
+		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:             {},
 	}
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
 		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
@@ -238,12 +247,12 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 				return
 			}
 			e.pendingDeviceConfigMux.Unlock()
-		} 
+		}
 	}
 
 	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
-	e.approveOrDenyDeviceConfiguration(msg, true, "")
-}	
+	go e.approveOrDenyDeviceConfiguration(msg, true, "")
+}
 
 func (e *LPC) AddFeatures() {
 	// client features
@@ -284,7 +293,7 @@ func (e *LPC) AddFeatures() {
 	f.AddFunctionType(model.FunctionTypeDeviceConfigurationKeyValueDescriptionListData, true, false)
 	f.AddFunctionType(model.FunctionTypeDeviceConfigurationKeyValueListData, true, true)
 	_ = f.AddWriteApprovalCallback(e.deviceConfigurationWriteCB)
-	
+
 	if dcs, err := server.NewDeviceConfiguration(e.LocalEntity); err == nil {
 		dcs.AddKeyValueDescription(
 			model.DeviceConfigurationKeyValueDescriptionDataType{

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -22,6 +22,9 @@ type LPC struct {
 	pendingMux    sync.Mutex
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
+	pendingFailsafeLimitMux		sync.Mutex
+	pendingFailsafeLimits		map[model.MsgCounterType]*spineapi.Message
+
 	heartbeatDiag *features.DeviceDiagnosis
 
 	heartbeatKeoWorkaround bool // required because KEO Stack uses multiple identical entities for the same functionality, and it is not clear which to use
@@ -79,6 +82,7 @@ func NewLPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	uc := &LPC{
 		UseCaseBase:   usecase,
 		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
+		pendingFailsafeLimits: make(map[model.MsgCounterType]*spineapi.Message),
 	}
 
 	_ = spine.Events.Subscribe(uc)
@@ -175,6 +179,66 @@ func (e *LPC) loadControlWriteCB(msg *spineapi.Message) {
 	go e.approveOrDenyConsumptionLimit(msg, true, "")
 }
 
+func (e *LPC) approveOrDenyFailsafeConsumptionLimit(msg *spineapi.Message, approve bool, reason string) {
+	f := e.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)
+
+	result := model.ErrorType{
+		ErrorNumber: model.ErrorNumberType(0),
+	}
+
+	if !approve {
+		result.ErrorNumber = model.ErrorNumberType(7)
+		result.Description = util.Ptr(model.DescriptionType(reason))
+	}
+	f.ApproveOrDenyWrite(msg, result)
+}
+
+// callback invoked on incoming write messages to this
+// DeviceConfiguration server feature.
+// the implementation only considers write messages for this use case and
+// approves all others
+func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
+	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
+	msg.Cmd.DeviceConfigurationKeyValueListData  == nil {
+		logging.Log().Debug("LPC deviceConfigurationWriteCB: invalid message")
+		return
+	}
+
+	data := msg.Cmd.DeviceConfigurationKeyValueListData
+
+	if len(data.DeviceConfigurationKeyValueData) == 0 || data.DeviceConfigurationKeyValueData[0].KeyId == nil {
+			logging.Log().Debug("LPC deviceConfigurationWriteCB: no data")
+			return
+		}
+
+	dcs, err := server.NewDeviceConfiguration(e.LocalEntity)
+	if err != nil {
+		return
+	}
+
+	description, err := dcs.GetKeyValueDescriptionFoKeyId(*data.DeviceConfigurationKeyValueData[0].KeyId)
+	if description == nil || err != nil {
+		logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
+		// if no description is found this write request is presumably for another usecase so we accept it
+		go e.approveOrDenyFailsafeConsumptionLimit(msg, true, "")
+		return
+	}
+
+	switch *description.KeyName {
+	case model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit:
+		e.pendingFailsafeLimitMux.Lock()
+		if _, ok := e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter]; !ok {
+			e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter] = msg
+			e.pendingFailsafeLimitMux.Unlock()
+			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
+			return
+		}
+	default:
+		//approve because this is no request for the device configuration key this callback is responsible for
+		go e.approveOrDenyFailsafeConsumptionLimit(msg, true, "")
+	}
+}	
+
 func (e *LPC) AddFeatures() {
 	// client features
 	_ = e.LocalEntity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
@@ -213,7 +277,8 @@ func (e *LPC) AddFeatures() {
 	f = e.LocalEntity.GetOrAddFeature(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)
 	f.AddFunctionType(model.FunctionTypeDeviceConfigurationKeyValueDescriptionListData, true, false)
 	f.AddFunctionType(model.FunctionTypeDeviceConfigurationKeyValueListData, true, true)
-
+	_ = f.AddWriteApprovalCallback(e.deviceConfigurationWriteCB)
+	
 	if dcs, err := server.NewDeviceConfiguration(e.LocalEntity); err == nil {
 		dcs.AddKeyValueDescription(
 			model.DeviceConfigurationKeyValueDescriptionDataType{

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -1,7 +1,6 @@
 package lpc
 
 import (
-	"slices"
 	"sync"
 
 	"github.com/enbility/eebus-go/api"
@@ -170,7 +169,7 @@ func (e *LPC) loadControlWriteCB(msg *spineapi.Message) {
 		if _, ok := e.pendingLimits[*msg.RequestHeader.MsgCounter]; !ok {
 			e.pendingLimits[*msg.RequestHeader.MsgCounter] = msg
 			e.pendingMux.Unlock()
-			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
+			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, LimitWriteApprovalRequired)
 			return
 		}
 	}
@@ -200,29 +199,8 @@ func (e *LPC) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bo
 // the implementation only considers write messages for this use case and
 // approves all others
 func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
-	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
-		msg.Cmd.DeviceConfigurationKeyValueListData == nil {
+	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil {
 		logging.Log().Debug("LPC deviceConfigurationWriteCB: invalid message")
-		return
-	}
-
-	data := msg.Cmd.DeviceConfigurationKeyValueListData
-
-	if data == nil || data.DeviceConfigurationKeyValueData == nil || len(data.DeviceConfigurationKeyValueData) == 0 {
-		logging.Log().Debug("LPC deviceConfigurationWriteCB: no data")
-		return
-	}
-
-	// all DeviceConfigurationKeyValueData must have keyId set as primary identifier
-	if slices.ContainsFunc(data.DeviceConfigurationKeyValueData, func(i model.DeviceConfigurationKeyValueDataType) bool {
-		return i.KeyId == nil
-	}) {
-		logging.Log().Debug("LPC deviceConfigurationWriteCB: invalid message")
-		return
-	}
-
-	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
-	if err != nil {
 		return
 	}
 
@@ -230,27 +208,24 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit: {},
 		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:             {},
 	}
-	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
-		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
-		if description == nil || err != nil {
-			logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID found: ", *deviceKeyValueData.KeyId)
-			continue
-		}
-
-		// Only ask for write approval if at least one of the configurations we care about is trying to be set
-		if _, exists := configsToApprove[*description.KeyName]; exists {
-			e.pendingDeviceConfigMux.Lock()
-			if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
-				e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
-				e.pendingDeviceConfigMux.Unlock()
-				e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
-				return
-			}
-			e.pendingDeviceConfigMux.Unlock()
-		}
+	approvalRequired, err := internal.ConfigurationWriteRequiresApproval(msg, e.LocalEntity, configsToApprove)
+	if err != nil {
+		logging.Log().Errorf("LPC deviceConfigurationWriteCB: %s", err.Error())
+		return
 	}
 
-	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+	if approvalRequired {
+		e.pendingDeviceConfigMux.Lock()
+		if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
+			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
+			e.pendingDeviceConfigMux.Unlock()
+			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, ConfigurationWriteApprovalRequired)
+			return
+		}
+		e.pendingDeviceConfigMux.Unlock()
+	}
+
+	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this use case so we accept
 	go e.approveOrDenyDeviceConfiguration(msg, true, "")
 }
 

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -2,6 +2,7 @@ package lpc
 
 import (
 	"sync"
+	"time"
 
 	"github.com/enbility/eebus-go/api"
 	features "github.com/enbility/eebus-go/features/client"
@@ -22,8 +23,8 @@ type LPC struct {
 	pendingMux    sync.Mutex
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
-	pendingFailsafeLimitMux		sync.Mutex
-	pendingFailsafeLimits		map[model.MsgCounterType]*spineapi.Message
+	pendingDeviceConfigMux		sync.Mutex
+	pendingDeviceConfigs		map[model.MsgCounterType]*ucapi.DeviceConfigurations
 
 	heartbeatDiag *features.DeviceDiagnosis
 
@@ -82,7 +83,7 @@ func NewLPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	uc := &LPC{
 		UseCaseBase:   usecase,
 		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
-		pendingFailsafeLimits: make(map[model.MsgCounterType]*spineapi.Message),
+		pendingDeviceConfigs: make(map[model.MsgCounterType]*ucapi.DeviceConfigurations),
 	}
 
 	_ = spine.Events.Subscribe(uc)
@@ -179,7 +180,7 @@ func (e *LPC) loadControlWriteCB(msg *spineapi.Message) {
 	go e.approveOrDenyConsumptionLimit(msg, true, "")
 }
 
-func (e *LPC) approveOrDenyFailsafeConsumptionLimit(msg *spineapi.Message, approve bool, reason string) {
+func (e *LPC) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bool, reason string) {
 	f := e.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)
 
 	result := model.ErrorType{
@@ -190,6 +191,7 @@ func (e *LPC) approveOrDenyFailsafeConsumptionLimit(msg *spineapi.Message, appro
 		result.ErrorNumber = model.ErrorNumberType(7)
 		result.Description = util.Ptr(model.DescriptionType(reason))
 	}
+
 	f.ApproveOrDenyWrite(msg, result)
 }
 
@@ -216,26 +218,48 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		return
 	}
 
-	description, err := dcs.GetKeyValueDescriptionFoKeyId(*data.DeviceConfigurationKeyValueData[0].KeyId)
-	if description == nil || err != nil {
-		logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
-		// if no description is found this write request is presumably for another usecase so we accept it
-		go e.approveOrDenyFailsafeConsumptionLimit(msg, true, "")
-		return
+	var failsafeLimit *float64 = nil
+	var failsafeDuration *time.Duration = nil
+	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
+
+		description, err := dcs.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
+		if description == nil || err != nil {
+			logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
+			// if no description is found this write request is presumably for another usecase
+			continue
+		}
+
+		// We only care about new values for either FailsafeConsumptionActivePowerLimit or FailsafeDurationMinimum, all other keys are ignored
+		switch *description.KeyName {
+		case model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit:
+			value := deviceKeyValueData.Value.ScaledNumber.GetValue()
+			failsafeLimit = &value
+		case model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:
+			value, err := deviceKeyValueData.Value.Duration.GetTimeDuration()
+			if err == nil {
+				failsafeDuration = &value
+			} else {
+				logging.Log().Debug("LPC deviceConfigurationWriteCB: received invalid or no value as duration while trying to set FailsafeDurationMinimum")
+			}
+		}	
 	}
 
-	switch *description.KeyName {
-	case model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit:
-		e.pendingFailsafeLimitMux.Lock()
-		if _, ok := e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter]; !ok {
-			e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter] = msg
-			e.pendingFailsafeLimitMux.Unlock()
+	if failsafeDuration != nil || failsafeLimit != nil {
+		e.pendingDeviceConfigMux.Lock()
+		if _, ok := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !ok {
+			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = &ucapi.DeviceConfigurations{
+				FailsafeLimit: failsafeLimit,
+				FailsafeDuration: failsafeDuration,
+				Msg: msg,
+			}
+			e.pendingDeviceConfigMux.Unlock()
 			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
 			return
 		}
-	default:
-		//approve because this is no request for the device configuration key this callback is responsible for
-		go e.approveOrDenyFailsafeConsumptionLimit(msg, true, "")
+		e.pendingDeviceConfigMux.Unlock()
+	} else {
+		// As neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+		e.approveOrDenyDeviceConfiguration(msg, true, "")
 	}
 }	
 

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -233,7 +233,7 @@ func (e *LPC) deviceConfigurationWriteCB(msg *spineapi.Message) {
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
 		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
 		if description == nil || err != nil {
-			logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID %d found")
+			logging.Log().Debug("LPC deviceConfigurationWriteCB: no device configuration for KeyID found: ", *deviceKeyValueData.KeyId)
 			continue
 		}
 

--- a/usecases/cs/lpc/usecase_test.go
+++ b/usecases/cs/lpc/usecase_test.go
@@ -135,6 +135,94 @@ func (s *CsLPCSuite) Test_loadControlWriteCB() {
 	s.eventCalled = false
 }
 
+func (s *CsLPCSuite) Test_deviceConfigurationWriteCB() {
+	// Header missing
+	msg := &spineapi.Message{}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// MsgCounter missing
+	msg = &spineapi.Message{RequestHeader: &model.HeaderType{}}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// Message is invalid (DeviceConfigurationKeyValueData missing)
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(600)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// Unrelated KeyId
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(603)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(2)),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// Failsafe consumption active power limit write -> approval required.
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(603)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0)),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.True(s.T(), s.eventCalled)
+	s.eventCalled = false
+
+	// Failsafe duration minimum write -> approval required.
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(604)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(1)),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.True(s.T(), s.eventCalled)
+	s.eventCalled = false
+}
+
 func (s *CsLPCSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -273,11 +273,24 @@ func (e *LPP) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 }
 
 // return the currently pending incoming failsafe consumption limit writes
-func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType]*ucapi.DeviceConfigurations {
+func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType {
+	result := make(map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType)
+	
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
-	
-	return e.pendingDeviceConfigs
+
+	for msgCounter, msg := range e.pendingDeviceConfigs {
+		data := msg.Cmd.DeviceConfigurationKeyValueListData
+		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
+			if _, exists := result[msgCounter]; exists {
+				result[msgCounter] = append(result[msgCounter], configKeyValueData)
+			} else {
+				result[msgCounter] = []model.DeviceConfigurationKeyValueDataType{configKeyValueData}
+			}
+		}
+	}
+
+	return result
 }
 
 // accept or deny an incoming device configuration write
@@ -287,13 +300,13 @@ func (e *LPP) ApproveOrDenyDeviceConfiguration(msgCounter model.MsgCounterType, 
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
-	config, ok := e.pendingDeviceConfigs[msgCounter]
+	msg, ok := e.pendingDeviceConfigs[msgCounter]
 	if !ok {
 		// no pending limit for this msgCounter, this is a caller error
 		return
 	}
 
-	e.approveOrDenyDeviceConfiguration(config.Msg, approve, reason)
+	e.approveOrDenyDeviceConfiguration(msg, approve, reason)
 
 	delete(e.pendingDeviceConfigs, msgCounter)
 }

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -7,6 +7,7 @@ import (
 	"github.com/enbility/eebus-go/api"
 	"github.com/enbility/eebus-go/features/server"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	"github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 )
@@ -272,40 +273,12 @@ func (e *LPP) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 	return dc.UpdateKeyValueDataForFilter(data, nil, filter)
 }
 
-// return the currently pending incoming failsafe consumption limit writes
+// return the currently pending incoming failsafe production limit writes
 func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
-	result := make(map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration)
-
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
-	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
-	if err != nil {
-		return result
-	}
-
-	for msgCounter, msg := range e.pendingDeviceConfigs {
-		data := msg.Cmd.DeviceConfigurationKeyValueListData
-		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
-			description, err := dc.GetKeyValueDescriptionFoKeyId(*configKeyValueData.KeyId)
-			if err != nil {
-				continue
-			}
-
-			pendingConfigData := ucapi.PendingDeviceConfiguration{
-				Description:       description,
-				Value:             configKeyValueData.Value,
-				IsValueChangeable: configKeyValueData.IsValueChangeable,
-			}
-
-			if _, exists := result[msgCounter]; !exists {
-				result[msgCounter] = []ucapi.PendingDeviceConfiguration{pendingConfigData}
-			} else {
-				result[msgCounter] = append(result[msgCounter], pendingConfigData)
-			}
-		}
-	}
-	return result
+	return internal.GroupPendingDeviceConfigurations(e.pendingDeviceConfigs, e.LocalEntity)
 }
 
 // accept or deny an incoming device configuration write

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -272,6 +272,39 @@ func (e *LPP) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 	return dc.UpdateKeyValueDataForFilter(data, nil, filter)
 }
 
+// return the currently pending incoming failsafe consumption write limits
+func (e *LPP) PendingFailsafeProductionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType {
+	result := make(map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType)
+
+	e.pendingFailsafeLimitMux.Lock()
+	defer e.pendingFailsafeLimitMux.Unlock()
+
+	for key, msg := range e.pendingFailsafeLimits {
+		// The existance of this value is checked when it is added to the pendingFailsafeLimits map therefore we do not need to check it again
+		result[key] = msg.Cmd.DeviceConfigurationKeyValueListData.DeviceConfigurationKeyValueData[0]
+	}
+
+	return result
+}
+
+// accept or deny an incoming failsafe consumption write limit
+//
+// use PendingFailsafeConusmptionLimits to get the list of currently pending requests
+func (e *LPP) ApproveOrDenyFailsafeProductionLimit(msgCounter model.MsgCounterType, approve bool, reason string) {
+	e.pendingFailsafeLimitMux.Lock()
+	defer e.pendingFailsafeLimitMux.Unlock()
+
+	msg, ok := e.pendingFailsafeLimits[msgCounter]
+	if !ok {
+		// no pending limit for this msgCounter, this is a caller error
+		return
+	}
+
+	e.approveOrDenyFailsafeProductionLimit(msg, approve, reason)
+
+	delete(e.pendingFailsafeLimits, msgCounter)
+}
+
 // Scenario 3
 
 // start sending heartbeat from the local entity supporting this usecase

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -273,23 +273,38 @@ func (e *LPP) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 }
 
 // return the currently pending incoming failsafe consumption limit writes
-func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType {
-	result := make(map[model.MsgCounterType][]model.DeviceConfigurationKeyValueDataType)
+func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
+	result := make(map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration)
 	
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
+	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
+	if err != nil {
+		return result
+	}
+
 	for msgCounter, msg := range e.pendingDeviceConfigs {
 		data := msg.Cmd.DeviceConfigurationKeyValueListData
 		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
-			if _, exists := result[msgCounter]; exists {
-				result[msgCounter] = append(result[msgCounter], configKeyValueData)
+			description, err := dc.GetKeyValueDescriptionFoKeyId(*configKeyValueData.KeyId)
+			if err != nil {
+				continue
+			}
+			
+			pendingConfigData := ucapi.PendingDeviceConfiguration{
+				Description: description,
+				Value: configKeyValueData.Value,
+				IsValueChangeable: configKeyValueData.IsValueChangeable,
+			}
+
+			if _, exists := result[msgCounter]; !exists {
+				result[msgCounter] = []ucapi.PendingDeviceConfiguration{pendingConfigData}
 			} else {
-				result[msgCounter] = []model.DeviceConfigurationKeyValueDataType{configKeyValueData}
+				result[msgCounter] = append(result[msgCounter], pendingConfigData)
 			}
 		}
 	}
-
 	return result
 }
 

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -273,7 +273,7 @@ func (e *LPP) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 	return dc.UpdateKeyValueDataForFilter(data, nil, filter)
 }
 
-// return the currently pending incoming failsafe production limit writes
+// return the currently pending incoming device configuration writes
 func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -275,7 +275,7 @@ func (e *LPP) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 // return the currently pending incoming failsafe consumption limit writes
 func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
 	result := make(map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration)
-	
+
 	e.pendingDeviceConfigMux.Lock()
 	defer e.pendingDeviceConfigMux.Unlock()
 
@@ -291,10 +291,10 @@ func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType][]ucapi.Pen
 			if err != nil {
 				continue
 			}
-			
+
 			pendingConfigData := ucapi.PendingDeviceConfiguration{
-				Description: description,
-				Value: configKeyValueData.Value,
+				Description:       description,
+				Value:             configKeyValueData.Value,
 				IsValueChangeable: configKeyValueData.IsValueChangeable,
 			}
 

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -272,37 +272,30 @@ func (e *LPP) SetFailsafeDurationMinimum(duration time.Duration, changeable bool
 	return dc.UpdateKeyValueDataForFilter(data, nil, filter)
 }
 
-// return the currently pending incoming failsafe consumption write limits
-func (e *LPP) PendingFailsafeProductionLimits() map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType {
-	result := make(map[model.MsgCounterType]model.DeviceConfigurationKeyValueDataType)
-
-	e.pendingFailsafeLimitMux.Lock()
-	defer e.pendingFailsafeLimitMux.Unlock()
-
-	for key, msg := range e.pendingFailsafeLimits {
-		// The existance of this value is checked when it is added to the pendingFailsafeLimits map therefore we do not need to check it again
-		result[key] = msg.Cmd.DeviceConfigurationKeyValueListData.DeviceConfigurationKeyValueData[0]
-	}
-
-	return result
+// return the currently pending incoming failsafe consumption limit writes
+func (e *LPP) PendingDeviceConfigurations() map[model.MsgCounterType]*ucapi.DeviceConfigurations {
+	e.pendingDeviceConfigMux.Lock()
+	defer e.pendingDeviceConfigMux.Unlock()
+	
+	return e.pendingDeviceConfigs
 }
 
-// accept or deny an incoming failsafe consumption write limit
+// accept or deny an incoming device configuration write
 //
-// use PendingFailsafeConusmptionLimits to get the list of currently pending requests
-func (e *LPP) ApproveOrDenyFailsafeProductionLimit(msgCounter model.MsgCounterType, approve bool, reason string) {
-	e.pendingFailsafeLimitMux.Lock()
-	defer e.pendingFailsafeLimitMux.Unlock()
+// use PendingDeviceConfigurations to get the list of currently pending requests
+func (e *LPP) ApproveOrDenyDeviceConfiguration(msgCounter model.MsgCounterType, approve bool, reason string) {
+	e.pendingDeviceConfigMux.Lock()
+	defer e.pendingDeviceConfigMux.Unlock()
 
-	msg, ok := e.pendingFailsafeLimits[msgCounter]
+	config, ok := e.pendingDeviceConfigs[msgCounter]
 	if !ok {
 		// no pending limit for this msgCounter, this is a caller error
 		return
 	}
 
-	e.approveOrDenyFailsafeProductionLimit(msg, approve, reason)
+	e.approveOrDenyDeviceConfiguration(config.Msg, approve, reason)
 
-	delete(e.pendingFailsafeLimits, msgCounter)
+	delete(e.pendingDeviceConfigs, msgCounter)
 }
 
 // Scenario 3

--- a/usecases/cs/lpp/public_test.go
+++ b/usecases/cs/lpp/public_test.go
@@ -169,3 +169,46 @@ func (s *CsLPPSuite) Test_ContractualProductionNominalMax() {
 	assert.Equal(s.T(), 10.0, value)
 	assert.Nil(s.T(), err)
 }
+
+func (s *CsLPPSuite) Test_PendingDeviceConfigurations() {
+	data := s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 0, len(data))
+
+	msgCounter := model.MsgCounterType(500)
+
+	msg := &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(msgCounter),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0)),
+						Value: &model.DeviceConfigurationKeyValueValueType{
+							ScaledNumber: model.NewScaledNumberType(1000),
+						},
+						IsValueChangeable: util.Ptr(true),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+
+	s.sut.deviceConfigurationWriteCB(msg)
+
+	data = s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 1, len(data))
+
+	s.sut.ApproveOrDenyDeviceConfiguration(model.MsgCounterType(499), true, "")
+
+	data = s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 1, len(data))
+
+	s.sut.ApproveOrDenyDeviceConfiguration(msgCounter, false, "leave me alone")
+
+	data = s.sut.PendingDeviceConfigurations()
+	assert.Equal(s.T(), 0, len(data))
+}

--- a/usecases/cs/lpp/types.go
+++ b/usecases/cs/lpp/types.go
@@ -17,13 +17,19 @@ const (
 
 	// An incoming load control obligation limit needs to be approved or denied
 	//
-	// Use `PendingProductionLimits` and `PendingDeviceConfigurations` to get
-	// the currently pending write approval requests and invoke
-	// `ApproveOrDenyProductionLimit` or `ApproveOrDenyDeviceConfiguration` for
-	// each
+	// Use `PendingProductionLimits` to get the currently pending limit write
+	// approval requests and invoke `ApproveOrDenyProductionLimit` for each
 	//
 	// Use Case LPP, Scenario 1
-	WriteApprovalRequired api.EventType = "cs-lpp-WriteApprovalRequired"
+	LimitWriteApprovalRequired api.EventType = "cs-lpp-LimitWriteApprovalRequired"
+
+	// An incoming device configuration write needs to be approved or denied
+	//
+	// Use `PendingDeviceConfigurations` to get the currently pending device configuration
+	// write approval requests and invoke `ApproveOrDenyDeviceConfiguration` for each
+	//
+	// Use Case LPP, Scenario 1
+	ConfigurationWriteApprovalRequired api.EventType = "cs-lpp-ConfigurationWriteApprovalRequired"
 
 	// Failsafe limit for the produced active (real) power of the
 	// Controllable System data update received

--- a/usecases/cs/lpp/types.go
+++ b/usecases/cs/lpp/types.go
@@ -17,16 +17,16 @@ const (
 
 	// An incoming load control obligation limit needs to be approved or denied
 	//
-	// Use `PendingProductionLimits` to get the currently pending limit write
-	// approval requests and invoke `ApproveOrDenyProductionLimit` for each
+	// Use `PendingProductionLimits` to get the currently pending produciton limits
+	// awaiting approval and invoke `ApproveOrDenyProductionLimit` for each
 	//
 	// Use Case LPP, Scenario 1
 	LimitWriteApprovalRequired api.EventType = "cs-lpp-LimitWriteApprovalRequired"
 
 	// An incoming device configuration write needs to be approved or denied
 	//
-	// Use `PendingDeviceConfigurations` to get the currently pending device configuration
-	// write approval requests and invoke `ApproveOrDenyDeviceConfiguration` for each
+	// Use `PendingDeviceConfigurations` to get the currently pending device configurations
+	// awaiting approval and invoke `ApproveOrDenyDeviceConfiguration` for each
 	//
 	// Use Case LPP, Scenario 1
 	ConfigurationWriteApprovalRequired api.EventType = "cs-lpp-ConfigurationWriteApprovalRequired"

--- a/usecases/cs/lpp/types.go
+++ b/usecases/cs/lpp/types.go
@@ -12,15 +12,17 @@ const (
 	//
 	// Use `ProductionLimit` to get the current data
 	//
-	// Use Case LPC, Scenario 1
+	// Use Case LPP, Scenario 1
 	DataUpdateLimit api.EventType = "cs-lpp-DataUpdateLimit"
 
 	// An incoming load control obligation limit needs to be approved or denied
 	//
-	// Use `PendingProductionLimits` to get the currently pending write approval requests
-	// and invoke `ApproveOrDenyProductionLimit` for each
+	// Use `PendingProductionLimits` and `PendingDeviceConfigurations` to get
+	// the currently pending write approval requests and invoke
+	// `ApproveOrDenyProductionLimit` or `ApproveOrDenyDeviceConfiguration` for
+	// each
 	//
-	// Use Case LPC, Scenario 1
+	// Use Case LPP, Scenario 1
 	WriteApprovalRequired api.EventType = "cs-lpp-WriteApprovalRequired"
 
 	// Failsafe limit for the produced active (real) power of the
@@ -28,7 +30,7 @@ const (
 	//
 	// Use `FailsafeProductionActivePowerLimit` to get the current data
 	//
-	// Use Case LPC, Scenario 2
+	// Use Case LPP, Scenario 2
 	DataUpdateFailsafeProductionActivePowerLimit api.EventType = "cs-lpp-DataUpdateFailsafeProductionActivePowerLimit"
 
 	// Minimum time the Controllable System remains in "failsafe state" unless conditions
@@ -36,7 +38,7 @@ const (
 	//
 	// Use `FailsafeDurationMinimum` to get the current data
 	//
-	// Use Case LPC, Scenario 2
+	// Use Case LPP, Scenario 2
 	DataUpdateFailsafeDurationMinimum api.EventType = "cs-lpp-DataUpdateFailsafeDurationMinimum"
 
 	// Indicates a notify heartbeat event the application should care of.

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -2,7 +2,6 @@ package lpp
 
 import (
 	"sync"
-	"time"
 
 	"github.com/enbility/eebus-go/api"
 	features "github.com/enbility/eebus-go/features/client"
@@ -24,7 +23,7 @@ type LPP struct {
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
 	pendingDeviceConfigMux		sync.Mutex
-	pendingDeviceConfigs		map[model.MsgCounterType]*ucapi.DeviceConfigurations
+	pendingDeviceConfigs		map[model.MsgCounterType]*spineapi.Message
 
 	heartbeatDiag *features.DeviceDiagnosis
 
@@ -82,7 +81,7 @@ func NewLPP(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	uc := &LPP{
 		UseCaseBase:   usecase,
 		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
-		pendingDeviceConfigs: make(map[model.MsgCounterType]*ucapi.DeviceConfigurations),
+		pendingDeviceConfigs: make(map[model.MsgCounterType]*spineapi.Message),
 	}
 
 	_ = spine.Events.Subscribe(uc)
@@ -217,9 +216,10 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 	if err != nil {
 		return
 	}
-
-	var failsafeLimit *float64 = nil
-	var failsafeDuration *time.Duration = nil
+	configsToApprove := map[model.DeviceConfigurationKeyNameType]struct{}{
+		model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit: {},
+		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum: {},
+	}
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
 
 		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
@@ -228,39 +228,21 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 			continue
 		}
 
-		// We only care about new values for either FailsafeProductionActivePowerLimit or FailsafeDurationMinimum, all other keys are ignored
-		switch *description.KeyName {
-		case model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit:
-			value := deviceKeyValueData.Value.ScaledNumber.GetValue()
-			failsafeLimit = &value
-		case model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:
-			value, err := deviceKeyValueData.Value.Duration.GetTimeDuration()
-			if err == nil {
-				failsafeDuration = &value
-			} else {
-				logging.Log().Debug("LPP deviceConfigurationWriteCB: received invalid or no value as duration while trying to set FailsafeDurationMinimum")
-			}
-		}	
-	}
-
-	// Only ask for write approval if at least one of the configurations we care about is trying to be set
-	if failsafeDuration != nil || failsafeLimit != nil {
-		e.pendingDeviceConfigMux.Lock()
-		if _, ok := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !ok {
-			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = &ucapi.DeviceConfigurations{
-				FailsafeLimit: failsafeLimit,
-				FailsafeDuration: failsafeDuration,
-				Msg: msg,
+		// Only ask for write approval if at least one of the configurations we care about is trying to be set
+		if _, exists := configsToApprove[*description.KeyName]; exists {
+			e.pendingDeviceConfigMux.Lock()
+			if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
+				e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
+				e.pendingDeviceConfigMux.Unlock()
+				e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
+				return
 			}
 			e.pendingDeviceConfigMux.Unlock()
-			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
-			return
-		}
-		e.pendingDeviceConfigMux.Unlock()
-	} else {
-		// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
-		e.approveOrDenyDeviceConfiguration(msg, true, "")
+		} 
 	}
+
+	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+	e.approveOrDenyDeviceConfiguration(msg, true, "")
 }		
 
 func (e *LPP) AddFeatures() {

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -213,7 +213,7 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 			return
 		}
 
-	dcs, err := server.NewDeviceConfiguration(e.LocalEntity)
+	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
 	if err != nil {
 		return
 	}
@@ -222,10 +222,9 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 	var failsafeDuration *time.Duration = nil
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
 
-		description, err := dcs.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
+		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
 		if description == nil || err != nil {
-			logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
-			// if no description is found this write request is presumably for another usecase
+			logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID %d found")
 			continue
 		}
 
@@ -244,6 +243,7 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		}	
 	}
 
+	// Only ask for write approval if at least one of the configurations we care about is trying to be set
 	if failsafeDuration != nil || failsafeLimit != nil {
 		e.pendingDeviceConfigMux.Lock()
 		if _, ok := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !ok {
@@ -258,7 +258,7 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		}
 		e.pendingDeviceConfigMux.Unlock()
 	} else {
-		// As neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+		// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
 		e.approveOrDenyDeviceConfiguration(msg, true, "")
 	}
 }		

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -213,11 +213,13 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		e.pendingDeviceConfigMux.Lock()
 		if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
 			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
+			// Unlock before calling EventCB to avoid deadlock (EventCB will need to read pendingDeviceConfigs)
 			e.pendingDeviceConfigMux.Unlock()
 			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, ConfigurationWriteApprovalRequired)
 			return
 		}
 		e.pendingDeviceConfigMux.Unlock()
+		return
 	}
 
 	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this use case so we accept

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -1,7 +1,6 @@
 package lpp
 
 import (
-	"slices"
 	"sync"
 
 	"github.com/enbility/eebus-go/api"
@@ -169,7 +168,7 @@ func (e *LPP) loadControlWriteCB(msg *spineapi.Message) {
 		if _, ok := e.pendingLimits[*msg.RequestHeader.MsgCounter]; !ok {
 			e.pendingLimits[*msg.RequestHeader.MsgCounter] = msg
 			e.pendingMux.Unlock()
-			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
+			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, LimitWriteApprovalRequired)
 			return
 		}
 	}
@@ -200,29 +199,8 @@ func (e *LPP) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bo
 // the implementation only considers write messages for this use case and
 // approves all others
 func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
-	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
-		msg.Cmd.DeviceConfigurationKeyValueListData == nil {
+	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil {
 		logging.Log().Debug("LPP deviceConfigurationWriteCB: invalid message")
-		return
-	}
-
-	data := msg.Cmd.DeviceConfigurationKeyValueListData
-
-	if data == nil || data.DeviceConfigurationKeyValueData == nil || len(data.DeviceConfigurationKeyValueData) == 0 {
-		logging.Log().Debug("LPP deviceConfigurationWriteCB: no data")
-		return
-	}
-
-	// all DeviceConfigurationKeyValueData must have keyId set as primary identifier
-	if slices.ContainsFunc(data.DeviceConfigurationKeyValueData, func(i model.DeviceConfigurationKeyValueDataType) bool {
-		return i.KeyId == nil
-	}) {
-		logging.Log().Debug("LPP deviceConfigurationWriteCB: invalid message")
-		return
-	}
-
-	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
-	if err != nil {
 		return
 	}
 
@@ -230,27 +208,24 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit: {},
 		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:            {},
 	}
-	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
-		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
-		if description == nil || err != nil {
-			logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID found: ", *deviceKeyValueData.KeyId)
-			continue
-		}
-
-		// Only ask for write approval if at least one of the configurations we care about is trying to be set
-		if _, exists := configsToApprove[*description.KeyName]; exists {
-			e.pendingDeviceConfigMux.Lock()
-			if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
-				e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
-				e.pendingDeviceConfigMux.Unlock()
-				e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
-				return
-			}
-			e.pendingDeviceConfigMux.Unlock()
-		}
+	approvalRequired, err := internal.ConfigurationWriteRequiresApproval(msg, e.LocalEntity, configsToApprove)
+	if err != nil {
+		logging.Log().Errorf("LPP deviceConfigurationWriteCB: %s", err.Error())
+		return
 	}
 
-	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+	if approvalRequired {
+		e.pendingDeviceConfigMux.Lock()
+		if _, exists := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !exists {
+			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = msg
+			e.pendingDeviceConfigMux.Unlock()
+			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, ConfigurationWriteApprovalRequired)
+			return
+		}
+		e.pendingDeviceConfigMux.Unlock()
+	}
+
+	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this use case so we accept
 	go e.approveOrDenyDeviceConfiguration(msg, true, "")
 }
 

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -2,6 +2,7 @@ package lpp
 
 import (
 	"sync"
+	"time"
 
 	"github.com/enbility/eebus-go/api"
 	features "github.com/enbility/eebus-go/features/client"
@@ -22,8 +23,8 @@ type LPP struct {
 	pendingMux    sync.Mutex
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
-	pendingFailsafeLimitMux		sync.Mutex
-	pendingFailsafeLimits		map[model.MsgCounterType]*spineapi.Message
+	pendingDeviceConfigMux		sync.Mutex
+	pendingDeviceConfigs		map[model.MsgCounterType]*ucapi.DeviceConfigurations
 
 	heartbeatDiag *features.DeviceDiagnosis
 
@@ -81,7 +82,7 @@ func NewLPP(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	uc := &LPP{
 		UseCaseBase:   usecase,
 		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
-		pendingFailsafeLimits: make(map[model.MsgCounterType]*spineapi.Message),
+		pendingDeviceConfigs: make(map[model.MsgCounterType]*ucapi.DeviceConfigurations),
 	}
 
 	_ = spine.Events.Subscribe(uc)
@@ -179,7 +180,7 @@ func (e *LPP) loadControlWriteCB(msg *spineapi.Message) {
 	go e.approveOrDenyProductionLimit(msg, true, "")
 }
 
-func (e *LPP) approveOrDenyFailsafeProductionLimit(msg *spineapi.Message, approve bool, reason string) {
+func (e *LPP) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bool, reason string) {
 	f := e.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)
 
 	result := model.ErrorType{
@@ -190,6 +191,7 @@ func (e *LPP) approveOrDenyFailsafeProductionLimit(msg *spineapi.Message, approv
 		result.ErrorNumber = model.ErrorNumberType(7)
 		result.Description = util.Ptr(model.DescriptionType(reason))
 	}
+
 	f.ApproveOrDenyWrite(msg, result)
 }
 
@@ -216,28 +218,50 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 		return
 	}
 
-	description, err := dcs.GetKeyValueDescriptionFoKeyId(*data.DeviceConfigurationKeyValueData[0].KeyId)
-	if description == nil || err != nil {
-		logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
-		// if no description is found this write request is presumably for another usecase so we accept it
-		go e.approveOrDenyFailsafeProductionLimit(msg, true, "")
-		return
+	var failsafeLimit *float64 = nil
+	var failsafeDuration *time.Duration = nil
+	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
+
+		description, err := dcs.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
+		if description == nil || err != nil {
+			logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
+			// if no description is found this write request is presumably for another usecase
+			continue
+		}
+
+		// We only care about new values for either FailsafeProductionActivePowerLimit or FailsafeDurationMinimum, all other keys are ignored
+		switch *description.KeyName {
+		case model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit:
+			value := deviceKeyValueData.Value.ScaledNumber.GetValue()
+			failsafeLimit = &value
+		case model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:
+			value, err := deviceKeyValueData.Value.Duration.GetTimeDuration()
+			if err == nil {
+				failsafeDuration = &value
+			} else {
+				logging.Log().Debug("LPP deviceConfigurationWriteCB: received invalid or no value as duration while trying to set FailsafeDurationMinimum")
+			}
+		}	
 	}
 
-	switch *description.KeyName {
-	case model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit:
-		e.pendingFailsafeLimitMux.Lock()
-		if _, ok := e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter]; !ok {
-			e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter] = msg
-			e.pendingFailsafeLimitMux.Unlock()
+	if failsafeDuration != nil || failsafeLimit != nil {
+		e.pendingDeviceConfigMux.Lock()
+		if _, ok := e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter]; !ok {
+			e.pendingDeviceConfigs[*msg.RequestHeader.MsgCounter] = &ucapi.DeviceConfigurations{
+				FailsafeLimit: failsafeLimit,
+				FailsafeDuration: failsafeDuration,
+				Msg: msg,
+			}
+			e.pendingDeviceConfigMux.Unlock()
 			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
 			return
 		}
-	default:
-		//approve because this is no request for the device configuration key this callback is responsible for
-		go e.approveOrDenyFailsafeProductionLimit(msg, true, "")
+		e.pendingDeviceConfigMux.Unlock()
+	} else {
+		// As neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
+		e.approveOrDenyDeviceConfiguration(msg, true, "")
 	}
-}	
+}		
 
 func (e *LPP) AddFeatures() {
 	// client features

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -199,11 +199,6 @@ func (e *LPP) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bo
 // the implementation only considers write messages for this use case and
 // approves all others
 func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
-	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil {
-		logging.Log().Debug("LPP deviceConfigurationWriteCB: invalid message")
-		return
-	}
-
 	configsToApprove := map[model.DeviceConfigurationKeyNameType]struct{}{
 		model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit: {},
 		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:            {},

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -22,6 +22,9 @@ type LPP struct {
 	pendingMux    sync.Mutex
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
+	pendingFailsafeLimitMux		sync.Mutex
+	pendingFailsafeLimits		map[model.MsgCounterType]*spineapi.Message
+
 	heartbeatDiag *features.DeviceDiagnosis
 
 	heartbeatKeoWorkaround bool // required because KEO Stack uses multiple identical entities for the same functionality, and it is not clear which to use
@@ -29,7 +32,7 @@ type LPP struct {
 
 var _ ucapi.CsLPPInterface = (*LPP)(nil)
 
-// Add support for the Limitation of Power Production (LPC) use case
+// Add support for the Limitation of Power Production (LPP) use case
 // as a Controllable System actor
 //
 // Note: if the Monitoring of Power Consumption (MPC) or Monitoring of Grid Connection Point (MGCP) will be supported, add them first
@@ -78,6 +81,7 @@ func NewLPP(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	uc := &LPP{
 		UseCaseBase:   usecase,
 		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
+		pendingFailsafeLimits: make(map[model.MsgCounterType]*spineapi.Message),
 	}
 
 	_ = spine.Events.Subscribe(uc)
@@ -175,6 +179,66 @@ func (e *LPP) loadControlWriteCB(msg *spineapi.Message) {
 	go e.approveOrDenyProductionLimit(msg, true, "")
 }
 
+func (e *LPP) approveOrDenyFailsafeProductionLimit(msg *spineapi.Message, approve bool, reason string) {
+	f := e.LocalEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)
+
+	result := model.ErrorType{
+		ErrorNumber: model.ErrorNumberType(0),
+	}
+
+	if !approve {
+		result.ErrorNumber = model.ErrorNumberType(7)
+		result.Description = util.Ptr(model.DescriptionType(reason))
+	}
+	f.ApproveOrDenyWrite(msg, result)
+}
+
+// callback invoked on incoming write messages to this
+// DeviceConfiguration server feature.
+// the implementation only considers write messages for this use case and
+// approves all others
+func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
+	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
+	msg.Cmd.DeviceConfigurationKeyValueListData  == nil {
+		logging.Log().Debug("LPP deviceConfigurationWriteCB: invalid message")
+		return
+	}
+
+	data := msg.Cmd.DeviceConfigurationKeyValueListData
+
+	if len(data.DeviceConfigurationKeyValueData) == 0 || data.DeviceConfigurationKeyValueData[0].KeyId == nil {
+			logging.Log().Debug("LPP deviceConfigurationWriteCB: no data")
+			return
+		}
+
+	dcs, err := server.NewDeviceConfiguration(e.LocalEntity)
+	if err != nil {
+		return
+	}
+
+	description, err := dcs.GetKeyValueDescriptionFoKeyId(*data.DeviceConfigurationKeyValueData[0].KeyId)
+	if description == nil || err != nil {
+		logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID %d found on this usecase, possibly write message for other usecase")
+		// if no description is found this write request is presumably for another usecase so we accept it
+		go e.approveOrDenyFailsafeProductionLimit(msg, true, "")
+		return
+	}
+
+	switch *description.KeyName {
+	case model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit:
+		e.pendingFailsafeLimitMux.Lock()
+		if _, ok := e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter]; !ok {
+			e.pendingFailsafeLimits[*msg.RequestHeader.MsgCounter] = msg
+			e.pendingFailsafeLimitMux.Unlock()
+			e.EventCB(msg.DeviceRemote.Ski(), msg.DeviceRemote, msg.EntityRemote, WriteApprovalRequired)
+			return
+		}
+	default:
+		//approve because this is no request for the device configuration key this callback is responsible for
+		go e.approveOrDenyFailsafeProductionLimit(msg, true, "")
+	}
+}	
+
 func (e *LPP) AddFeatures() {
 	// client features
 	_ = e.LocalEntity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
@@ -213,6 +277,7 @@ func (e *LPP) AddFeatures() {
 	f = e.LocalEntity.GetOrAddFeature(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer)
 	f.AddFunctionType(model.FunctionTypeDeviceConfigurationKeyValueDescriptionListData, true, false)
 	f.AddFunctionType(model.FunctionTypeDeviceConfigurationKeyValueListData, true, true)
+	_ = f.AddWriteApprovalCallback(e.deviceConfigurationWriteCB)
 
 	if dcs, err := server.NewDeviceConfiguration(e.LocalEntity); err == nil {
 		dcs.AddKeyValueDescription(

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -233,7 +233,7 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
 		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
 		if description == nil || err != nil {
-			logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID %d found")
+			logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID found: ", *deviceKeyValueData.KeyId)
 			continue
 		}
 

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -1,6 +1,7 @@
 package lpp
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/enbility/eebus-go/api"
@@ -22,8 +23,8 @@ type LPP struct {
 	pendingMux    sync.Mutex
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
-	pendingDeviceConfigMux		sync.Mutex
-	pendingDeviceConfigs		map[model.MsgCounterType]*spineapi.Message
+	pendingDeviceConfigMux sync.Mutex
+	pendingDeviceConfigs   map[model.MsgCounterType]*spineapi.Message
 
 	heartbeatDiag *features.DeviceDiagnosis
 
@@ -79,8 +80,8 @@ func NewLPP(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 	)
 
 	uc := &LPP{
-		UseCaseBase:   usecase,
-		pendingLimits: make(map[model.MsgCounterType]*spineapi.Message),
+		UseCaseBase:          usecase,
+		pendingLimits:        make(map[model.MsgCounterType]*spineapi.Message),
 		pendingDeviceConfigs: make(map[model.MsgCounterType]*spineapi.Message),
 	}
 
@@ -200,28 +201,36 @@ func (e *LPP) approveOrDenyDeviceConfiguration(msg *spineapi.Message, approve bo
 // approves all others
 func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
-	msg.Cmd.DeviceConfigurationKeyValueListData  == nil {
+		msg.Cmd.DeviceConfigurationKeyValueListData == nil {
 		logging.Log().Debug("LPP deviceConfigurationWriteCB: invalid message")
 		return
 	}
 
 	data := msg.Cmd.DeviceConfigurationKeyValueListData
 
-	if len(data.DeviceConfigurationKeyValueData) == 0 || data.DeviceConfigurationKeyValueData[0].KeyId == nil {
-			logging.Log().Debug("LPP deviceConfigurationWriteCB: no data")
-			return
-		}
+	if data == nil || data.DeviceConfigurationKeyValueData == nil || len(data.DeviceConfigurationKeyValueData) == 0 {
+		logging.Log().Debug("LPP deviceConfigurationWriteCB: no data")
+		return
+	}
+
+	// all DeviceConfigurationKeyValueData must have keyId set as primary identifier
+	if slices.ContainsFunc(data.DeviceConfigurationKeyValueData, func(i model.DeviceConfigurationKeyValueDataType) bool {
+		return i.KeyId == nil
+	}) {
+		logging.Log().Debug("LPP deviceConfigurationWriteCB: invalid message")
+		return
+	}
 
 	dc, err := server.NewDeviceConfiguration(e.LocalEntity)
 	if err != nil {
 		return
 	}
+
 	configsToApprove := map[model.DeviceConfigurationKeyNameType]struct{}{
 		model.DeviceConfigurationKeyNameTypeFailsafeProductionActivePowerLimit: {},
-		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum: {},
+		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:            {},
 	}
 	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
-
 		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
 		if description == nil || err != nil {
 			logging.Log().Debug("LPP deviceConfigurationWriteCB: no device configuration for KeyID %d found")
@@ -238,12 +247,12 @@ func (e *LPP) deviceConfigurationWriteCB(msg *spineapi.Message) {
 				return
 			}
 			e.pendingDeviceConfigMux.Unlock()
-		} 
+		}
 	}
 
 	// If neither a failsafe duration nor a failsafe limit were set this message does not pertain to this callback so we accept
-	e.approveOrDenyDeviceConfiguration(msg, true, "")
-}		
+	go e.approveOrDenyDeviceConfiguration(msg, true, "")
+}
 
 func (e *LPP) AddFeatures() {
 	// client features

--- a/usecases/cs/lpp/usecase_test.go
+++ b/usecases/cs/lpp/usecase_test.go
@@ -78,6 +78,94 @@ func (s *CsLPPSuite) Test_loadControlWriteCB() {
 	s.sut.loadControlWriteCB(msg)
 }
 
+func (s *CsLPPSuite) Test_deviceConfigurationWriteCB() {
+	// Header missing
+	msg := &spineapi.Message{}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// MsgCounter missing
+	msg = &spineapi.Message{RequestHeader: &model.HeaderType{}}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// Message is invalid (DeviceConfigurationKeyValueData missing)
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(600)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// Unrelated KeyId
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(603)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(2)),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.False(s.T(), s.eventCalled)
+
+	// Failsafe production active power limit write -> approval required.
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(603)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0)),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.True(s.T(), s.eventCalled)
+	s.eventCalled = false
+
+	// Failsafe duration minimum write -> approval required.
+	msg = &spineapi.Message{
+		RequestHeader: &model.HeaderType{
+			MsgCounter: util.Ptr(model.MsgCounterType(604)),
+		},
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: &model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{
+						KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(1)),
+					},
+				},
+			},
+		},
+		DeviceRemote: s.remoteDevice,
+		EntityRemote: s.monitoredEntity,
+	}
+	s.sut.deviceConfigurationWriteCB(msg)
+	assert.True(s.T(), s.eventCalled)
+	s.eventCalled = false
+}
+
 func (s *CsLPPSuite) Test_UpdateUseCaseAvailability() {
 	s.sut.UpdateUseCaseAvailability(true)
 }

--- a/usecases/internal/deviceconfiguration.go
+++ b/usecases/internal/deviceconfiguration.go
@@ -67,24 +67,24 @@ func GroupPendingDeviceConfigurations(pendingDeviceConfigs map[model.MsgCounterT
 	}
 
 	for msgCounter, msg := range pendingDeviceConfigs {
-		data := msg.Cmd.DeviceConfigurationKeyValueListData
-		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
+		if msg.Cmd.DeviceConfigurationKeyValueListData == nil {
+			continue
+		}
+		for _, configKeyValueData := range msg.Cmd.DeviceConfigurationKeyValueListData.DeviceConfigurationKeyValueData {
+			if configKeyValueData.KeyId == nil {
+				continue
+			}
 			description, err := dc.GetKeyValueDescriptionFoKeyId(*configKeyValueData.KeyId)
-			if err != nil {
+			if err != nil || description == nil || description.KeyName == nil {
 				continue
 			}
 
-			pendingConfigData := ucapi.PendingDeviceConfiguration{
-				Description:       description,
+			result[msgCounter] = append(result[msgCounter], ucapi.PendingDeviceConfiguration{
+				Description:       *description,
+				KeyName:           *description.KeyName,
 				Value:             configKeyValueData.Value,
 				IsValueChangeable: configKeyValueData.IsValueChangeable,
-			}
-
-			if _, exists := result[msgCounter]; !exists {
-				result[msgCounter] = []ucapi.PendingDeviceConfiguration{pendingConfigData}
-			} else {
-				result[msgCounter] = append(result[msgCounter], pendingConfigData)
-			}
+			})
 		}
 	}
 	return result

--- a/usecases/internal/deviceconfiguration.go
+++ b/usecases/internal/deviceconfiguration.go
@@ -62,7 +62,7 @@ func GroupPendingDeviceConfigurations(pendingDeviceConfigs map[model.MsgCounterT
 
 	dc, err := server.NewDeviceConfiguration(localEntity)
 	if err != nil {
-		logging.Log().Debugf("AggregatePendingDeviceConfigurations: Error occurred when getting device configuration: %s", err.Error())
+		logging.Log().Debugf("GroupPendingDeviceConfigurations: Error occurred when getting device configuration: %s", err.Error())
 		return result
 	}
 

--- a/usecases/internal/deviceconfiguration.go
+++ b/usecases/internal/deviceconfiguration.go
@@ -1,0 +1,91 @@
+package internal
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/enbility/eebus-go/features/server"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	"github.com/enbility/ship-go/logging"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+// Check if an incoming device configuration write requires write approval, if yes return `true` otherwise `false`
+func ConfigurationWriteRequiresApproval(msg *spineapi.Message, localEntity spineapi.EntityLocalInterface, configsToApprove map[model.DeviceConfigurationKeyNameType]struct{}) (bool, error) {
+	if msg.RequestHeader == nil || msg.RequestHeader.MsgCounter == nil ||
+		msg.Cmd.DeviceConfigurationKeyValueListData == nil {
+		return false, fmt.Errorf("invalid message")
+	}
+
+	data := msg.Cmd.DeviceConfigurationKeyValueListData
+
+	if len(data.DeviceConfigurationKeyValueData) == 0 {
+		return false, fmt.Errorf("no data")
+	}
+
+	// all DeviceConfigurationKeyValueData must have keyId set as primary identifier
+	if slices.ContainsFunc(data.DeviceConfigurationKeyValueData, func(i model.DeviceConfigurationKeyValueDataType) bool {
+		return i.KeyId == nil
+	}) {
+		return false, fmt.Errorf("invalid message")
+	}
+
+	dc, err := server.NewDeviceConfiguration(localEntity)
+	if err != nil {
+		return false, err
+	}
+
+	for _, deviceKeyValueData := range data.DeviceConfigurationKeyValueData {
+		description, err := dc.GetKeyValueDescriptionFoKeyId(*deviceKeyValueData.KeyId)
+		if description == nil || err != nil {
+			logging.Log().Debug("ConfigurationWriteRequiresApproval: no device configuration for KeyID found: ", *deviceKeyValueData.KeyId)
+			continue
+		}
+
+		if description.KeyName == nil {
+			logging.Log().Debugf("ConfigurationWriteRequiresApproval: invalid internal data (KeyName not set on DeviceConfigurationKeyValueDescriptionDataType with key %s)", *deviceKeyValueData.KeyId)
+			continue
+		}
+
+		// Only ask for write approval if at least one of the configurations we care about is trying to be set
+		if _, exists := configsToApprove[*description.KeyName]; exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Extract the device configuration writes from each pending message and return them grouped in a map by msgCounter
+func GroupPendingDeviceConfigurations(pendingDeviceConfigs map[model.MsgCounterType]*spineapi.Message, localEntity spineapi.EntityLocalInterface) map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration {
+	result := make(map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration)
+
+	dc, err := server.NewDeviceConfiguration(localEntity)
+	if err != nil {
+		logging.Log().Debugf("AggregatePendingDeviceConfigurations: Error occurred when getting device configuration: %s", err.Error())
+		return result
+	}
+
+	for msgCounter, msg := range pendingDeviceConfigs {
+		data := msg.Cmd.DeviceConfigurationKeyValueListData
+		for _, configKeyValueData := range data.DeviceConfigurationKeyValueData {
+			description, err := dc.GetKeyValueDescriptionFoKeyId(*configKeyValueData.KeyId)
+			if err != nil {
+				continue
+			}
+
+			pendingConfigData := ucapi.PendingDeviceConfiguration{
+				Description:       description,
+				Value:             configKeyValueData.Value,
+				IsValueChangeable: configKeyValueData.IsValueChangeable,
+			}
+
+			if _, exists := result[msgCounter]; !exists {
+				result[msgCounter] = []ucapi.PendingDeviceConfiguration{pendingConfigData}
+			} else {
+				result[msgCounter] = append(result[msgCounter], pendingConfigData)
+			}
+		}
+	}
+	return result
+}

--- a/usecases/internal/deviceconfiguration_test.go
+++ b/usecases/internal/deviceconfiguration_test.go
@@ -4,10 +4,12 @@ import (
 	"github.com/enbility/eebus-go/features/server"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (s *InternalSuite) Test_ConfigurationWriteRequiresApproval() {
@@ -87,54 +89,31 @@ func (s *InternalSuite) Test_GroupPendingDeviceConfigurations() {
 		KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit),
 		ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeScaledNumber),
 		Unit:      util.Ptr(model.UnitOfMeasurementTypeW),
-		KeyId:     util.Ptr(model.DeviceConfigurationKeyIdType(0)),
 	}
 	failsafeDurationMinDesc := model.DeviceConfigurationKeyValueDescriptionDataType{
 		KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
 		ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeDuration),
-		KeyId:     util.Ptr(model.DeviceConfigurationKeyIdType(1)),
-	}
-	if dcs, err := server.NewDeviceConfiguration(s.localEntity); err == nil {
-		dcs.AddKeyValueDescription(failsafeLimitDesc)
-
-		// only add if it doesn't exist yet
-		filter := model.DeviceConfigurationKeyValueDescriptionDataType{
-			KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
-		}
-		if data, err := dcs.GetKeyValueDescriptionsForFilter(filter); err == nil && len(data) == 0 {
-			dcs.AddKeyValueDescription(failsafeDurationMinDesc)
-		}
-
-		value := &model.DeviceConfigurationKeyValueValueType{
-			ScaledNumber: model.NewScaledNumberType(0),
-		}
-		_ = dcs.UpdateKeyValueDataForFilter(
-			model.DeviceConfigurationKeyValueDataType{
-				Value:             value,
-				IsValueChangeable: util.Ptr(true),
-			},
-			nil,
-			model.DeviceConfigurationKeyValueDescriptionDataType{
-				KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit),
-			},
-		)
-
-		value = &model.DeviceConfigurationKeyValueValueType{
-			Duration: model.NewDurationType(0),
-		}
-		_ = dcs.UpdateKeyValueDataForFilter(
-			model.DeviceConfigurationKeyValueDataType{
-				Value:             value,
-				IsValueChangeable: util.Ptr(true),
-			},
-			nil,
-			model.DeviceConfigurationKeyValueDescriptionDataType{
-				KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
-			},
-		)
 	}
 
-	deviceConfigList := []model.DeviceConfigurationKeyValueDataType{{KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0))}, {KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(1))}, {KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(2))}}
+	dcs, err := server.NewDeviceConfiguration(s.localEntity)
+	require.NoError(s.T(), err)
+	failsafeLimitDesc.KeyId = dcs.AddKeyValueDescription(failsafeLimitDesc)
+	require.NotNil(s.T(), failsafeLimitDesc.KeyId)
+	failsafeDurationMinDesc.KeyId = dcs.AddKeyValueDescription(failsafeDurationMinDesc)
+	require.NotNil(s.T(), failsafeDurationMinDesc.KeyId)
+
+	value := &model.DeviceConfigurationKeyValueValueType{
+		ScaledNumber: model.NewScaledNumberType(0),
+	}
+	deviceConfigList := []model.DeviceConfigurationKeyValueDataType{
+		{
+			KeyId:             failsafeLimitDesc.KeyId,
+			Value:             value,
+			IsValueChangeable: util.Ptr(true),
+		},
+		{KeyId: failsafeDurationMinDesc.KeyId},
+		{KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(100))},
+	}
 	cmd := model.CmdType{DeviceConfigurationKeyValueListData: util.Ptr(model.DeviceConfigurationKeyValueListDataType{DeviceConfigurationKeyValueData: deviceConfigList})}
 	msg := spineapi.Message{Cmd: cmd}
 	pendingDeviceConfigs := map[model.MsgCounterType]*spineapi.Message{model.MsgCounterType(1): &msg}
@@ -142,10 +121,88 @@ func (s *InternalSuite) Test_GroupPendingDeviceConfigurations() {
 	// For one of the KeyIds no corresponding device configuration exists, that element should thus be skipped
 	expected := map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration{
 		model.MsgCounterType(1): {
-			{Description: &failsafeLimitDesc},
-			{Description: &failsafeDurationMinDesc},
+			{
+				Description:       failsafeLimitDesc,
+				KeyName:           model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit,
+				Value:             value,
+				IsValueChangeable: util.Ptr(true),
+			},
+			{
+				Description: failsafeDurationMinDesc,
+				KeyName:     model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum,
+			},
 		},
 	}
-	assert.Equal(s.T(), groupedConfigurations, expected)
+	assert.Equal(s.T(), expected, groupedConfigurations)
+}
 
+func (s *InternalSuite) Test_GroupPendingDeviceConfigurations_SkipsInvalidEntries() {
+	descriptionWithoutKeyName := model.DeviceConfigurationKeyValueDescriptionDataType{
+		ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeString),
+	}
+	validDescription := model.DeviceConfigurationKeyValueDescriptionDataType{
+		KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit),
+		ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeScaledNumber),
+	}
+
+	dcs, err := server.NewDeviceConfiguration(s.localEntity)
+	require.NoError(s.T(), err)
+	descriptionWithoutKeyName.KeyId = dcs.AddKeyValueDescription(descriptionWithoutKeyName)
+	require.NotNil(s.T(), descriptionWithoutKeyName.KeyId)
+	validDescription.KeyId = dcs.AddKeyValueDescription(validDescription)
+	require.NotNil(s.T(), validDescription.KeyId)
+
+	msgWithoutDeviceConfigurationData := spineapi.Message{}
+	msgWithInvalidEntries := spineapi.Message{
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: util.Ptr(model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{},
+					{KeyId: descriptionWithoutKeyName.KeyId},
+					{KeyId: validDescription.KeyId},
+				},
+			}),
+		},
+	}
+	pendingDeviceConfigs := map[model.MsgCounterType]*spineapi.Message{
+		model.MsgCounterType(1): &msgWithoutDeviceConfigurationData,
+		model.MsgCounterType(2): &msgWithInvalidEntries,
+	}
+
+	groupedConfigurations := GroupPendingDeviceConfigurations(pendingDeviceConfigs, s.localEntity)
+
+	expected := map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration{
+		model.MsgCounterType(2): {
+			{
+				Description: validDescription,
+				KeyName:     model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit,
+			},
+		},
+	}
+	assert.Equal(s.T(), expected, groupedConfigurations)
+}
+
+func (s *InternalSuite) Test_GroupPendingDeviceConfigurations_ReturnsEmptyResultWhenDeviceConfigurationFeatureIsMissing() {
+	localEntity := spinemocks.NewEntityLocalInterface(s.T())
+	localEntity.EXPECT().Device().Return(nil)
+	localEntity.EXPECT().
+		FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceConfiguration, model.RoleTypeServer).
+		Return(nil)
+
+	msg := spineapi.Message{
+		Cmd: model.CmdType{
+			DeviceConfigurationKeyValueListData: util.Ptr(model.DeviceConfigurationKeyValueListDataType{
+				DeviceConfigurationKeyValueData: []model.DeviceConfigurationKeyValueDataType{
+					{KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0))},
+				},
+			}),
+		},
+	}
+	pendingDeviceConfigs := map[model.MsgCounterType]*spineapi.Message{
+		model.MsgCounterType(1): &msg,
+	}
+
+	groupedConfigurations := GroupPendingDeviceConfigurations(pendingDeviceConfigs, localEntity)
+
+	assert.Empty(s.T(), groupedConfigurations)
 }

--- a/usecases/internal/deviceconfiguration_test.go
+++ b/usecases/internal/deviceconfiguration_test.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"github.com/enbility/eebus-go/features/server"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *InternalSuite) Test_ConfigurationWriteRequiresApproval() {
+	msg := spineapi.Message{}
+	configsToApprove := map[model.DeviceConfigurationKeyNameType]struct{}{
+		model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit: {},
+		model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum:             {},
+	}
+	// Header missing
+	_, err := ConfigurationWriteRequiresApproval(&msg, s.localEntity, configsToApprove)
+	assert.NotNil(s.T(), err)
+
+	// MsgCounter missing
+	header := model.HeaderType{}
+	msg = spineapi.Message{RequestHeader: &header}
+	_, err = ConfigurationWriteRequiresApproval(&msg, s.localEntity, configsToApprove)
+	assert.NotNil(s.T(), err)
+
+	// DeviceConfigurationKeyValueListData missing
+	header = model.HeaderType{MsgCounter: util.Ptr(model.MsgCounterType(1))}
+	msg = spineapi.Message{RequestHeader: &header}
+	_, err = ConfigurationWriteRequiresApproval(&msg, s.localEntity, configsToApprove)
+	assert.NotNil(s.T(), err)
+
+	// DeviceConfigurationKeyValueListData.DeviceConfigurationKeyValueData is nil/length of 0
+	cmd := model.CmdType{DeviceConfigurationKeyValueListData: util.Ptr(model.DeviceConfigurationKeyValueListDataType{})}
+	msg = spineapi.Message{RequestHeader: &header, Cmd: cmd}
+	_, err = ConfigurationWriteRequiresApproval(&msg, s.localEntity, configsToApprove)
+	assert.NotNil(s.T(), err)
+
+	// Not all elements in slice of DeviceConfigurationKeyValueDataType have KeyId set
+	deviceConfigList := []model.DeviceConfigurationKeyValueDataType{{KeyId: nil}}
+	cmd = model.CmdType{DeviceConfigurationKeyValueListData: util.Ptr(model.DeviceConfigurationKeyValueListDataType{DeviceConfigurationKeyValueData: deviceConfigList})}
+	msg = spineapi.Message{RequestHeader: &header, Cmd: cmd}
+	_, err = ConfigurationWriteRequiresApproval(&msg, s.localEntity, configsToApprove)
+	assert.NotNil(s.T(), err)
+
+	// Valid message but not a KeyId we care about => no approval required
+	deviceConfigList = []model.DeviceConfigurationKeyValueDataType{{KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0))}}
+	cmd = model.CmdType{DeviceConfigurationKeyValueListData: util.Ptr(model.DeviceConfigurationKeyValueListDataType{DeviceConfigurationKeyValueData: deviceConfigList})}
+	msg = spineapi.Message{RequestHeader: &header, Cmd: cmd}
+	approvalRequired, err := ConfigurationWriteRequiresApproval(&msg, s.localEntity, configsToApprove)
+	assert.Nil(s.T(), err)
+	assert.False(s.T(), approvalRequired)
+
+	// Valid message with KeyId we care about => approval required
+	if dcs, err := server.NewDeviceConfiguration(s.localEntity); err == nil {
+		dcs.AddKeyValueDescription(
+			model.DeviceConfigurationKeyValueDescriptionDataType{
+				KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit),
+				ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeScaledNumber),
+				Unit:      util.Ptr(model.UnitOfMeasurementTypeW),
+			},
+		)
+
+		value := &model.DeviceConfigurationKeyValueValueType{
+			ScaledNumber: model.NewScaledNumberType(0),
+		}
+		_ = dcs.UpdateKeyValueDataForFilter(
+			model.DeviceConfigurationKeyValueDataType{
+				Value:             value,
+				IsValueChangeable: util.Ptr(true),
+			},
+			nil,
+			model.DeviceConfigurationKeyValueDescriptionDataType{
+				KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit),
+			},
+		)
+	}
+	approvalRequired, err = ConfigurationWriteRequiresApproval(&msg, s.localEntity, configsToApprove)
+	assert.Nil(s.T(), err)
+	assert.True(s.T(), approvalRequired)
+}
+
+func (s *InternalSuite) Test_GroupPendingDeviceConfigurations() {
+	failsafeLimitDesc := model.DeviceConfigurationKeyValueDescriptionDataType{
+		KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit),
+		ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeScaledNumber),
+		Unit:      util.Ptr(model.UnitOfMeasurementTypeW),
+		KeyId:     util.Ptr(model.DeviceConfigurationKeyIdType(0)),
+	}
+	failsafeDurationMinDesc := model.DeviceConfigurationKeyValueDescriptionDataType{
+		KeyName:   util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+		ValueType: util.Ptr(model.DeviceConfigurationKeyValueTypeTypeDuration),
+		KeyId:     util.Ptr(model.DeviceConfigurationKeyIdType(1)),
+	}
+	if dcs, err := server.NewDeviceConfiguration(s.localEntity); err == nil {
+		dcs.AddKeyValueDescription(failsafeLimitDesc)
+
+		// only add if it doesn't exist yet
+		filter := model.DeviceConfigurationKeyValueDescriptionDataType{
+			KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+		}
+		if data, err := dcs.GetKeyValueDescriptionsForFilter(filter); err == nil && len(data) == 0 {
+			dcs.AddKeyValueDescription(failsafeDurationMinDesc)
+		}
+
+		value := &model.DeviceConfigurationKeyValueValueType{
+			ScaledNumber: model.NewScaledNumberType(0),
+		}
+		_ = dcs.UpdateKeyValueDataForFilter(
+			model.DeviceConfigurationKeyValueDataType{
+				Value:             value,
+				IsValueChangeable: util.Ptr(true),
+			},
+			nil,
+			model.DeviceConfigurationKeyValueDescriptionDataType{
+				KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeConsumptionActivePowerLimit),
+			},
+		)
+
+		value = &model.DeviceConfigurationKeyValueValueType{
+			Duration: model.NewDurationType(0),
+		}
+		_ = dcs.UpdateKeyValueDataForFilter(
+			model.DeviceConfigurationKeyValueDataType{
+				Value:             value,
+				IsValueChangeable: util.Ptr(true),
+			},
+			nil,
+			model.DeviceConfigurationKeyValueDescriptionDataType{
+				KeyName: util.Ptr(model.DeviceConfigurationKeyNameTypeFailsafeDurationMinimum),
+			},
+		)
+	}
+
+	deviceConfigList := []model.DeviceConfigurationKeyValueDataType{{KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(0))}, {KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(1))}, {KeyId: util.Ptr(model.DeviceConfigurationKeyIdType(2))}}
+	cmd := model.CmdType{DeviceConfigurationKeyValueListData: util.Ptr(model.DeviceConfigurationKeyValueListDataType{DeviceConfigurationKeyValueData: deviceConfigList})}
+	msg := spineapi.Message{Cmd: cmd}
+	pendingDeviceConfigs := map[model.MsgCounterType]*spineapi.Message{model.MsgCounterType(1): &msg}
+	groupedConfigurations := GroupPendingDeviceConfigurations(pendingDeviceConfigs, s.localEntity)
+	// For one of the KeyIds no corresponding device configuration exists, that element should thus be skipped
+	expected := map[model.MsgCounterType][]ucapi.PendingDeviceConfiguration{
+		model.MsgCounterType(1): {
+			{Description: &failsafeLimitDesc},
+			{Description: &failsafeDurationMinDesc},
+		},
+	}
+	assert.Equal(s.T(), groupedConfigurations, expected)
+
+}


### PR DESCRIPTION
This is a work-in-progress proposal for adding write approval callbacks for the failsafe values of the CS-LPC usecase.

Code changes should be functional, but are not yet final. Cleanup and thorough testing may still be required.

Fixes/updates from our side should come when I can find the time to do so. If someone wants to use/update this in the meantime, feel free.

Comments/fixes etc are welcome.