### PR TITLE
Report per phase measurements for correct phase

### DIFF
--- a/usecases/api/cem_evcem.go
+++ b/usecases/api/cem_evcem.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/enbility/eebus-go/api"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
 )
 
 // Actor: Customer Energy Management
@@ -22,7 +23,7 @@ type CemEVCEMInterface interface {
 	//
 	// parameters:
 	//   - entity: the entity of the EV
-	CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error)
+	CurrentPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error)
 
 	// Scenario 2
 
@@ -30,7 +31,7 @@ type CemEVCEMInterface interface {
 	//
 	// parameters:
 	//   - entity: the entity of the EV
-	PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error)
+	PowerPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error)
 
 	// Scenario 3
 

--- a/usecases/api/ma_mgcp.go
+++ b/usecases/api/ma_mgcp.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/enbility/eebus-go/api"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
 )
 
 // Actor: Monitoring Appliance
@@ -66,7 +67,7 @@ type MaMGCPInterface interface {
 	// return values:
 	//   - positive values are used for consumption
 	//   - negative values are used for production
-	CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error)
+	CurrentPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error)
 
 	// Scenario 6
 
@@ -74,7 +75,7 @@ type MaMGCPInterface interface {
 	//
 	// parameters:
 	//   - entity: the entity of the device (e.g. SMGW)
-	VoltagePerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error)
+	VoltagePerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error)
 
 	// Scenario 7
 

--- a/usecases/api/ma_mpc.go
+++ b/usecases/api/ma_mpc.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/enbility/eebus-go/api"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
 )
 
 // Actor: Monitoring Appliance
@@ -30,7 +31,7 @@ type MaMPCInterface interface {
 	// possible errors:
 	//   - ErrDataNotAvailable if no such limit is (yet) available
 	//   - and others
-	PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error)
+	PowerPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error)
 
 	// Scenario 2
 
@@ -61,7 +62,7 @@ type MaMPCInterface interface {
 	// return values
 	//   - positive values are used for consumption
 	//   - negative values are used for production
-	CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error)
+	CurrentPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error)
 
 	// Scenario 4
 
@@ -69,7 +70,7 @@ type MaMPCInterface interface {
 	//
 	// parameters:
 	//   - entity: the entity of the device (e.g. EVSE)
-	VoltagePerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error)
+	VoltagePerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error)
 
 	// Scenario 5
 

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -19,12 +19,12 @@ const (
 
 type OptionalPowerConsumptionInfo struct {
 	PowerSequenceId model.PowerSequenceIdType
-	Power 			*float64
-	MaxPower 		*float64
-	State 			model.PowerSequenceStateType
-	IsPausable 		bool
-	IsStoppable 	bool
-	StartTime 		*time.Time
+	Power           *float64
+	MaxPower        *float64
+	State           model.PowerSequenceStateType
+	IsPausable      bool
+	IsStoppable     bool
+	StartTime       *time.Time
 }
 
 // manufacturer data type

--- a/usecases/cem/evcem/public.go
+++ b/usecases/cem/evcem/public.go
@@ -40,7 +40,7 @@ func (e *EVCEM) PhasesConnected(entity spineapi.EntityRemoteInterface) (uint, er
 // possible errors:
 //   - ErrDataNotAvailable if no such measurement is (yet) available
 //   - and others
-func (e *EVCEM) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+func (e *EVCEM) CurrentPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity
 	}
@@ -61,7 +61,7 @@ func (e *EVCEM) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float6
 		return nil, api.ErrDataNotAvailable
 	}
 
-	var result []float64
+	result := make(map[model.ElectricalConnectionPhaseNameType]float64)
 
 	for _, phase := range ucapi.PhaseNameMapping {
 		for _, item := range data {
@@ -73,13 +73,11 @@ func (e *EVCEM) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float6
 				MeasurementId: item.MeasurementId,
 			}
 			elParam, err := evElectricalConnection.GetParameterDescriptionsForFilter(filter)
-			if err != nil || len(elParam) == 0 ||
-				elParam[0].AcMeasuredPhases == nil || *elParam[0].AcMeasuredPhases != phase {
+			if err != nil || len(elParam) == 0 || elParam[0].AcMeasuredPhases == nil || *elParam[0].AcMeasuredPhases != phase {
 				continue
 			}
 
-			phaseValue := item.Value.GetValue()
-			result = append(result, phaseValue)
+			result[phase] = item.Value.GetValue()
 		}
 	}
 
@@ -91,7 +89,7 @@ func (e *EVCEM) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float6
 // possible errors:
 //   - ErrDataNotAvailable if no such measurement is (yet) available
 //   - and others
-func (e *EVCEM) PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+func (e *EVCEM) PowerPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity
 	}
@@ -115,7 +113,7 @@ func (e *EVCEM) PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64,
 		return nil, api.ErrDataNotAvailable
 	}
 
-	var result []float64
+	result := make(map[model.ElectricalConnectionPhaseNameType]float64)
 
 	for _, phase := range ucapi.PhaseNameMapping {
 		for _, item := range data {
@@ -133,8 +131,7 @@ func (e *EVCEM) PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64,
 				continue
 			}
 
-			phaseValue := item.Value.GetValue()
-			result = append(result, phaseValue)
+			result[phase] = item.Value.GetValue()
 		}
 	}
 

--- a/usecases/cem/evcem/public_test.go
+++ b/usecases/cem/evcem/public_test.go
@@ -112,7 +112,7 @@ func (s *CemEVCEMSuite) Test_EVCurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.evEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 10.0, data[0])
+	assert.Equal(s.T(), 10.0, data[model.ElectricalConnectionPhaseNameTypeA])
 
 	now := time.Now().Add(-50 * time.Second)
 
@@ -131,7 +131,7 @@ func (s *CemEVCEMSuite) Test_EVCurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.evEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 10.0, data[0])
+	assert.Equal(s.T(), 10.0, data[model.ElectricalConnectionPhaseNameTypeA])
 
 	now = now.Add(-1 * time.Hour)
 	measData = &model.MeasurementListDataType{
@@ -149,7 +149,7 @@ func (s *CemEVCEMSuite) Test_EVCurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.evEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 10.0, data[0])
+	assert.Equal(s.T(), 10.0, data[model.ElectricalConnectionPhaseNameTypeA])
 
 	now = now.Add(-1 * time.Hour)
 	measData = &model.MeasurementListDataType{
@@ -167,7 +167,7 @@ func (s *CemEVCEMSuite) Test_EVCurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.evEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 10.0, data[0])
+	assert.Equal(s.T(), 10.0, data[model.ElectricalConnectionPhaseNameTypeA])
 }
 
 func (s *CemEVCEMSuite) Test_EVCurrentPerPhase_AudiConnect() {
@@ -275,7 +275,7 @@ func (s *CemEVCEMSuite) Test_EVCurrentPerPhase_AudiConnect() {
 
 	data, err = s.sut.CurrentPerPhase(s.evEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 10.0, data[0])
+	assert.Equal(s.T(), 10.0, data[model.ElectricalConnectionPhaseNameTypeA])
 
 	now := time.Now().Add(-50 * time.Second)
 
@@ -308,7 +308,7 @@ func (s *CemEVCEMSuite) Test_EVCurrentPerPhase_AudiConnect() {
 	data, err = s.sut.CurrentPerPhase(s.evEntity)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 1, len(data))
-	assert.Equal(s.T(), 10.0, data[0])
+	assert.Equal(s.T(), 10.0, data[model.ElectricalConnectionPhaseNameTypeA])
 }
 
 func (s *CemEVCEMSuite) Test_EVPowerPerPhase_Power() {
@@ -373,7 +373,7 @@ func (s *CemEVCEMSuite) Test_EVPowerPerPhase_Power() {
 
 	data, err = s.sut.PowerPerPhase(s.evEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 80.0, data[0])
+	assert.Equal(s.T(), 80.0, data[model.ElectricalConnectionPhaseNameTypeA])
 }
 
 func (s *CemEVCEMSuite) Test_EVPowerPerPhase_Current() {
@@ -551,6 +551,152 @@ func (s *CemEVCEMSuite) Test_EVPowerPerPhase_Current() {
 	data, err = s.sut.PowerPerPhase(s.evEntity)
 	assert.NotNil(s.T(), err)
 	assert.Equal(s.T(), 0, len(data))
+}
+
+func (s *CemEVCEMSuite) Test_EVPerPhaseMapsPhases() {
+	paramDesc := &model.ElectricalConnectionParameterDescriptionListDataType{
+		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(0)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(12)),
+				ScopeType:              util.Ptr(model.ScopeTypeTypeACCurrent),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(1)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(10)),
+				ScopeType:              util.Ptr(model.ScopeTypeTypeACCurrent),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(2)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(11)),
+				ScopeType:              util.Ptr(model.ScopeTypeTypeACCurrent),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeC),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(3)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(22)),
+				ScopeType:              util.Ptr(model.ScopeTypeTypeACPower),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(4)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(20)),
+				ScopeType:              util.Ptr(model.ScopeTypeTypeACPower),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(5)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(21)),
+				ScopeType:              util.Ptr(model.ScopeTypeTypeACPower),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeC),
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.evEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+	_, fErr := rFeature.UpdateData(true, model.FunctionTypeElectricalConnectionParameterDescriptionListData, paramDesc, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	measDesc := &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(12)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(10)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(11)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypeCurrent),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACCurrent),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(22)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(20)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+			},
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(21)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+			},
+		},
+	}
+
+	rFeature = s.remoteDevice.FeatureByEntityTypeAndRole(s.evEntity, model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, measDesc, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	measData := &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(20)),
+				Value:         model.NewScaledNumberType(220),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(10)),
+				Value:         model.NewScaledNumberType(10),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(22)),
+				Value:         model.NewScaledNumberType(120),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(12)),
+				Value:         model.NewScaledNumberType(12),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(21)),
+				Value:         model.NewScaledNumberType(321),
+			},
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(11)),
+				Value:         model.NewScaledNumberType(11),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	currentData, err := s.sut.CurrentPerPhase(s.evEntity)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{
+		model.ElectricalConnectionPhaseNameTypeA: 12,
+		model.ElectricalConnectionPhaseNameTypeB: 10,
+		model.ElectricalConnectionPhaseNameTypeC: 11,
+	}, currentData)
+
+	powerData, err := s.sut.PowerPerPhase(s.evEntity)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{
+		model.ElectricalConnectionPhaseNameTypeA: 120,
+		model.ElectricalConnectionPhaseNameTypeB: 220,
+		model.ElectricalConnectionPhaseNameTypeC: 321,
+	}, powerData)
 }
 
 func (s *CemEVCEMSuite) Test_EVChargedEnergy() {

--- a/usecases/cem/ohpcf/public.go
+++ b/usecases/cem/ohpcf/public.go
@@ -33,7 +33,7 @@ func (o *OHPCF) OptionalPowerConsumption(entity spineapi.EntityRemoteInterface) 
 	if len(alt[0].PowerSequence) == 0 {
 		return nil, fmt.Errorf("%s(alternative attribute present but no power sequence defined)", remoteDataStructureError)
 	}
-	
+
 	seq := alt[0].PowerSequence[0]
 	if seq.Description == nil || seq.Description.SequenceId == nil {
 		return nil, fmt.Errorf("%s(alternative attribute present but no power sequenceId defined)", remoteDataStructureError)
@@ -42,7 +42,7 @@ func (o *OHPCF) OptionalPowerConsumption(entity spineapi.EntityRemoteInterface) 
 	if seq.State == nil || seq.State.State == nil {
 		return nil, fmt.Errorf("%s(alternative attribute present but no power sequence state defined)", remoteDataStructureError)
 	}
-	
+
 	if seq.OperatingConstraintsInterrupt == nil {
 		return nil, fmt.Errorf("%s(alternative attribute present but no power sequence operating interrupt constraints defined)", remoteDataStructureError)
 	}
@@ -91,18 +91,17 @@ func (o *OHPCF) OptionalPowerConsumption(entity spineapi.EntityRemoteInterface) 
 	}
 
 	info := ucapi.OptionalPowerConsumptionInfo{
-		PowerSequenceId: 	seqId,
-		Power: 				power,
-		MaxPower: 			maxPower,
-		State: 				*seq.State.State, // safe to dereference because we validate above
-		IsPausable: 		isPausable,
-		IsStoppable:		isStoppable,
-		StartTime: 			startTime,
+		PowerSequenceId: seqId,
+		Power:           power,
+		MaxPower:        maxPower,
+		State:           *seq.State.State, // safe to dereference because we validate above
+		IsPausable:      isPausable,
+		IsStoppable:     isStoppable,
+		StartTime:       startTime,
 	}
 
 	return &info, nil
 }
-
 
 // The availability of an optional consumption of power [OHPCF-011/1].
 //
@@ -322,7 +321,7 @@ func (o *OHPCF) AbortPowerConsumptionProcess(entity spineapi.EntityRemoteInterfa
 	if err != nil {
 		return nil, err
 	}
-	
+
 	data := &model.SmartEnergyManagementPsDataType{
 		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
 			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{
@@ -368,7 +367,7 @@ func (o *OHPCF) ResumePowerConsumptionProcess(entity spineapi.EntityRemoteInterf
 	if err != nil {
 		return nil, err
 	}
-	
+
 	data := &model.SmartEnergyManagementPsDataType{
 		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
 			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -29,20 +29,31 @@ func MeasurementPhaseSpecificDataForFilter(
 	}
 
 	var result []float64
+	if validPhaseNameTypes != nil {
+		// pre-allocate result array for each possible phase so we can add phases to it in arbitrary order
+		result = make([]float64, len(validPhaseNameTypes))
+	}
 
 	for _, item := range data {
 		if item.Value == nil || item.MeasurementId == nil {
 			continue
 		}
 
+		phaseIndex := -1
 		if validPhaseNameTypes != nil {
 			filter := model.ElectricalConnectionParameterDescriptionDataType{
 				MeasurementId: item.MeasurementId,
 			}
 			param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
-			if err != nil || len(param) == 0 ||
-				param[0].AcMeasuredPhases == nil ||
-				!slices.Contains(validPhaseNameTypes, *param[0].AcMeasuredPhases) {
+			if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
+				// error getting parameter description
+				continue
+			}
+
+			// calculate the offset into result for the measured phase
+			phaseIndex = slices.Index(validPhaseNameTypes, *param[0].AcMeasuredPhases)
+			if phaseIndex == -1 {
+				// ignore phase measurements not specified in validPhaseNameTypes
 				continue
 			}
 		}
@@ -70,7 +81,13 @@ func MeasurementPhaseSpecificDataForFilter(
 
 		value := item.Value.GetValue()
 
-		result = append(result, value)
+		if validPhaseNameTypes == nil {
+			// measurement is not for a specific phase
+			result = append(result, value)
+		} else {
+			// measurement is for a specific phase, store the value at the corresponding phaseIndex
+			result[phaseIndex] = value
+		}
 	}
 
 	return result, nil

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -16,7 +16,7 @@ func MeasurementPhaseSpecificDataForFilter(
 	measurementFilter model.MeasurementDescriptionDataType,
 	energyDirection model.EnergyDirectionType,
 	validPhaseNameTypes []model.ElectricalConnectionPhaseNameType,
-) ([]float64, error) {
+) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	measurement, err := client.NewMeasurement(localEntity, remoteEntity)
 	electricalConnection, err1 := client.NewElectricalConnection(localEntity, remoteEntity)
 	if err != nil || err1 != nil {
@@ -28,34 +28,28 @@ func MeasurementPhaseSpecificDataForFilter(
 		return nil, api.ErrDataNotAvailable
 	}
 
-	var result []float64
-	if validPhaseNameTypes != nil {
-		// pre-allocate result array for each possible phase so we can add phases to it in arbitrary order
-		result = make([]float64, len(validPhaseNameTypes))
-	}
+	result := make(map[model.ElectricalConnectionPhaseNameType]float64, len(validPhaseNameTypes))
 
 	for _, item := range data {
 		if item.Value == nil || item.MeasurementId == nil {
 			continue
 		}
 
-		phaseIndex := -1
-		if validPhaseNameTypes != nil {
-			filter := model.ElectricalConnectionParameterDescriptionDataType{
-				MeasurementId: item.MeasurementId,
-			}
-			param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
-			if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
-				// error getting parameter description
-				continue
-			}
+		filter := model.ElectricalConnectionParameterDescriptionDataType{
+			MeasurementId: item.MeasurementId,
+		}
+		param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
+		if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
+			// error getting parameter description
+			continue
+		}
 
-			// calculate the offset into result for the measured phase
-			phaseIndex = slices.Index(validPhaseNameTypes, *param[0].AcMeasuredPhases)
-			if phaseIndex == -1 {
-				// ignore phase measurements not specified in validPhaseNameTypes
-				continue
-			}
+		// calculate the offset into result for the measured phase
+		phaseName := *param[0].AcMeasuredPhases
+		if validPhaseNameTypes != nil &&
+			!slices.Contains(validPhaseNameTypes, phaseName) {
+			// ignore phase measurements not specified in validPhaseNameTypes
+			continue
 		}
 
 		if energyDirection != "" {
@@ -81,13 +75,7 @@ func MeasurementPhaseSpecificDataForFilter(
 
 		value := item.Value.GetValue()
 
-		if validPhaseNameTypes == nil {
-			// measurement is not for a specific phase
-			result = append(result, value)
-		} else {
-			// measurement is for a specific phase, store the value at the corresponding phaseIndex
-			result[phaseIndex] = value
-		}
+		result[phaseName] = value
 	}
 
 	return result, nil

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -39,13 +39,22 @@ func MeasurementPhaseSpecificDataForFilter(
 			MeasurementId: item.MeasurementId,
 		}
 		param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
-		if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
+		if err != nil || len(param) == 0 {
 			// error getting parameter description
 			continue
 		}
 
-		// calculate the offset into result for the measured phase
-		phaseName := *param[0].AcMeasuredPhases
+		var phaseName model.ElectricalConnectionPhaseNameType
+		if param[0].AcMeasuredPhases != nil {
+			phaseName = *param[0].AcMeasuredPhases
+		} else if validPhaseNameTypes == nil {
+			// if we're not filtering by valid phase names, allow acMeasuredPhases to be unset
+			phaseName = model.ElectricalConnectionPhaseNameTypeNone
+		} else {
+			// error getting parameter description
+			continue
+		}
+
 		if validPhaseNameTypes != nil &&
 			!slices.Contains(validPhaseNameTypes, phaseName) {
 			// ignore phase measurements not specified in validPhaseNameTypes

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -34,20 +34,31 @@ func MeasurementPhaseSpecificDataForFilter(
 	}
 
 	var result []float64
+	if validPhaseNameTypes != nil {
+		// pre-allocate result array for each possible phase so we can add phases to it in arbitrary order
+		result = make([]float64, len(validPhaseNameTypes))
+	}
 
 	for _, item := range data {
 		if item.Value == nil || item.MeasurementId == nil {
 			continue
 		}
 
+		phaseIndex := -1
 		if validPhaseNameTypes != nil {
 			filter := model.ElectricalConnectionParameterDescriptionDataType{
 				MeasurementId: item.MeasurementId,
 			}
 			param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
-			if err != nil || len(param) == 0 ||
-				param[0].AcMeasuredPhases == nil ||
-				!slices.Contains(validPhaseNameTypes, *param[0].AcMeasuredPhases) {
+			if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
+				// error getting parameter description
+				continue
+			}
+
+			// calculate the offset into result for the measured phase
+			phaseIndex = slices.Index(validPhaseNameTypes, *param[0].AcMeasuredPhases)
+			if phaseIndex == -1 {
+				// ignore phase measurements not specified in validPhaseNameTypes
 				continue
 			}
 		}
@@ -75,7 +86,13 @@ func MeasurementPhaseSpecificDataForFilter(
 
 		value := item.Value.GetValue()
 
-		result = append(result, value)
+		if validPhaseNameTypes == nil {
+			// measurement is not for a specific phase
+			result = append(result, value)
+		} else {
+			// measurement is for a specific phase, store the value at the corresponding phaseIndex
+			result[phaseIndex] = value
+		}
 	}
 
 	return result, nil

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -49,13 +49,8 @@ func MeasurementPhaseSpecificDataForFilter(
 			continue
 		}
 
-		var phaseName model.ElectricalConnectionPhaseNameType
-		if param[0].AcMeasuredPhases != nil {
-			phaseName = *param[0].AcMeasuredPhases
-		} else if validPhaseNameTypes == nil {
-			// if we're not filtering by valid phase names, allow acMeasuredPhases to be unset
-			phaseName = model.ElectricalConnectionPhaseNameTypeNone
-		} else {
+		phaseName, ok := phaseNameFromParameterDescription(param[0], validPhaseNameTypes == nil)
+		if !ok {
 			// error getting parameter description
 			continue
 		}
@@ -119,4 +114,61 @@ func GetPowerTotalMeasurementId(localEntity spineapi.EntityLocalInterface) model
 	}
 
 	return *MeasurementDescriptionData[0].MeasurementId
+}
+
+func phaseNameFromParameterDescription(
+	param model.ElectricalConnectionParameterDescriptionDataType,
+	allowUnset bool,
+) (model.ElectricalConnectionPhaseNameType, bool) {
+	if param.AcMeasuredPhases == nil {
+		if allowUnset {
+			return model.ElectricalConnectionPhaseNameTypeNone, true
+		}
+		return "", false
+	}
+
+	phaseName := *param.AcMeasuredPhases
+	if param.AcMeasuredInReferenceTo == nil {
+		return phaseName, true
+	}
+
+	referencePhaseName := *param.AcMeasuredInReferenceTo
+	if referencePhaseName == phaseName ||
+		referencePhaseName == model.ElectricalConnectionPhaseNameTypeNeutral ||
+		referencePhaseName == model.ElectricalConnectionPhaseNameTypeGround ||
+		referencePhaseName == model.ElectricalConnectionPhaseNameTypeNone {
+		return phaseName, true
+	}
+
+	if combinedPhaseName, ok := phasePairName(phaseName, referencePhaseName); ok {
+		return combinedPhaseName, true
+	}
+
+	return phaseName, true
+}
+
+func phasePairName(
+	phaseName model.ElectricalConnectionPhaseNameType,
+	referencePhaseName model.ElectricalConnectionPhaseNameType,
+) (model.ElectricalConnectionPhaseNameType, bool) {
+	switch {
+	case isPhasePair(phaseName, referencePhaseName, model.ElectricalConnectionPhaseNameTypeA, model.ElectricalConnectionPhaseNameTypeB):
+		return model.ElectricalConnectionPhaseNameTypeAb, true
+	case isPhasePair(phaseName, referencePhaseName, model.ElectricalConnectionPhaseNameTypeB, model.ElectricalConnectionPhaseNameTypeC):
+		return model.ElectricalConnectionPhaseNameTypeBc, true
+	case isPhasePair(phaseName, referencePhaseName, model.ElectricalConnectionPhaseNameTypeA, model.ElectricalConnectionPhaseNameTypeC):
+		return model.ElectricalConnectionPhaseNameTypeAc, true
+	default:
+		return "", false
+	}
+}
+
+func isPhasePair(
+	phaseName model.ElectricalConnectionPhaseNameType,
+	referencePhaseName model.ElectricalConnectionPhaseNameType,
+	first model.ElectricalConnectionPhaseNameType,
+	second model.ElectricalConnectionPhaseNameType,
+) bool {
+	return (phaseName == first && referencePhaseName == second) ||
+		(phaseName == second && referencePhaseName == first)
 }

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -21,7 +21,7 @@ func MeasurementPhaseSpecificDataForFilter(
 	measurementFilter model.MeasurementDescriptionDataType,
 	energyDirection model.EnergyDirectionType,
 	validPhaseNameTypes []model.ElectricalConnectionPhaseNameType,
-) ([]float64, error) {
+) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	measurement, err := client.NewMeasurement(localEntity, remoteEntity)
 	electricalConnection, err1 := client.NewElectricalConnection(localEntity, remoteEntity)
 	if err != nil || err1 != nil {
@@ -33,34 +33,28 @@ func MeasurementPhaseSpecificDataForFilter(
 		return nil, api.ErrDataNotAvailable
 	}
 
-	var result []float64
-	if validPhaseNameTypes != nil {
-		// pre-allocate result array for each possible phase so we can add phases to it in arbitrary order
-		result = make([]float64, len(validPhaseNameTypes))
-	}
+	result := make(map[model.ElectricalConnectionPhaseNameType]float64, len(validPhaseNameTypes))
 
 	for _, item := range data {
 		if item.Value == nil || item.MeasurementId == nil {
 			continue
 		}
 
-		phaseIndex := -1
-		if validPhaseNameTypes != nil {
-			filter := model.ElectricalConnectionParameterDescriptionDataType{
-				MeasurementId: item.MeasurementId,
-			}
-			param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
-			if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
-				// error getting parameter description
-				continue
-			}
+		filter := model.ElectricalConnectionParameterDescriptionDataType{
+			MeasurementId: item.MeasurementId,
+		}
+		param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
+		if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
+			// error getting parameter description
+			continue
+		}
 
-			// calculate the offset into result for the measured phase
-			phaseIndex = slices.Index(validPhaseNameTypes, *param[0].AcMeasuredPhases)
-			if phaseIndex == -1 {
-				// ignore phase measurements not specified in validPhaseNameTypes
-				continue
-			}
+		// calculate the offset into result for the measured phase
+		phaseName := *param[0].AcMeasuredPhases
+		if validPhaseNameTypes != nil &&
+			!slices.Contains(validPhaseNameTypes, phaseName) {
+			// ignore phase measurements not specified in validPhaseNameTypes
+			continue
 		}
 
 		if energyDirection != "" {
@@ -86,13 +80,7 @@ func MeasurementPhaseSpecificDataForFilter(
 
 		value := item.Value.GetValue()
 
-		if validPhaseNameTypes == nil {
-			// measurement is not for a specific phase
-			result = append(result, value)
-		} else {
-			// measurement is for a specific phase, store the value at the corresponding phaseIndex
-			result[phaseIndex] = value
-		}
+		result[phaseName] = value
 	}
 
 	return result, nil

--- a/usecases/internal/measurement.go
+++ b/usecases/internal/measurement.go
@@ -44,13 +44,22 @@ func MeasurementPhaseSpecificDataForFilter(
 			MeasurementId: item.MeasurementId,
 		}
 		param, err := electricalConnection.GetParameterDescriptionsForFilter(filter)
-		if err != nil || len(param) == 0 || param[0].AcMeasuredPhases == nil {
+		if err != nil || len(param) == 0 {
 			// error getting parameter description
 			continue
 		}
 
-		// calculate the offset into result for the measured phase
-		phaseName := *param[0].AcMeasuredPhases
+		var phaseName model.ElectricalConnectionPhaseNameType
+		if param[0].AcMeasuredPhases != nil {
+			phaseName = *param[0].AcMeasuredPhases
+		} else if validPhaseNameTypes == nil {
+			// if we're not filtering by valid phase names, allow acMeasuredPhases to be unset
+			phaseName = model.ElectricalConnectionPhaseNameTypeNone
+		} else {
+			// error getting parameter description
+			continue
+		}
+
 		if validPhaseNameTypes != nil &&
 			!slices.Contains(validPhaseNameTypes, phaseName) {
 			// ignore phase measurements not specified in validPhaseNameTypes

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -114,7 +114,7 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 0, len(data))
+	assert.Equal(s.T(), []float64{0, 0, 0}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -196,3 +196,82 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 	assert.NotNil(s.T(), err)
 	assert.Nil(s.T(), data)
 }
+
+func (s *InternalSuite) Test_MeasurementSinglePhaseSpecificDataForFilter() {
+	measurementType := model.MeasurementTypeTypePower
+	commodityType := model.CommodityTypeTypeElectricity
+	scopeType := model.ScopeTypeTypeACPower
+	energyDirection := model.EnergyDirectionTypeConsume
+
+	filter := model.MeasurementDescriptionDataType{
+		MeasurementType: &measurementType,
+		CommodityType:   &commodityType,
+		ScopeType:       &scopeType,
+	}
+
+	// set up ElectricalConnection
+	elDescData := &model.ElectricalConnectionDescriptionListDataType{
+		ElectricalConnectionDescriptionData: []model.ElectricalConnectionDescriptionDataType{
+			{
+				ElectricalConnectionId:  util.Ptr(model.ElectricalConnectionIdType(0)),
+				PositiveEnergyDirection: util.Ptr(model.EnergyDirectionTypeConsume),
+			},
+		},
+	}
+
+	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
+		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+			},
+		},
+	}
+
+	rElFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+
+	_, fErr := rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionDescriptionListData, elDescData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	_, fErr = rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionParameterDescriptionListData, elParamData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	descData := &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, descData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	measData := &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err := MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		ucapi.PhaseNameMapping,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), []float64{0, 10, 0}, data)
+
+}

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -114,7 +114,7 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 0, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -160,7 +160,7 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{10, 10, 10}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"a": 10, "b": 10, "c": 10}, data)
 
 	measData = &model.MeasurementListDataType{
 		MeasurementData: []model.MeasurementDataType{
@@ -272,6 +272,95 @@ func (s *InternalSuite) Test_MeasurementSinglePhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 10, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"b": 10}, data)
+
+	data, err = MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		nil,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"b": 10}, data)
+
+}
+
+func (s *InternalSuite) Test_MeasurementTotalPhaseSpecificDataForFilter() {
+	measurementType := model.MeasurementTypeTypePower
+	commodityType := model.CommodityTypeTypeElectricity
+	scopeType := model.ScopeTypeTypeACPowerTotal
+	energyDirection := model.EnergyDirectionTypeConsume
+
+	filter := model.MeasurementDescriptionDataType{
+		MeasurementType: &measurementType,
+		CommodityType:   &commodityType,
+		ScopeType:       &scopeType,
+	}
+
+	// set up ElectricalConnection
+	elDescData := &model.ElectricalConnectionDescriptionListDataType{
+		ElectricalConnectionDescriptionData: []model.ElectricalConnectionDescriptionDataType{
+			{
+				ElectricalConnectionId:  util.Ptr(model.ElectricalConnectionIdType(0)),
+				PositiveEnergyDirection: util.Ptr(model.EnergyDirectionTypeConsume),
+			},
+		},
+	}
+
+	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
+		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeAbc),
+			},
+		},
+	}
+
+	rElFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+
+	_, fErr := rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionDescriptionListData, elDescData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	_, fErr = rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionParameterDescriptionListData, elParamData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	descData := &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
+				MeasurementType: &measurementType,
+				CommodityType:   &commodityType,
+				ScopeType:       &scopeType,
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, descData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	measData := &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err := MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		nil,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"abc": 10}, data)
 
 }

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -115,7 +115,7 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 0, len(data))
+	assert.Equal(s.T(), []float64{0, 0, 0}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -403,6 +403,40 @@ func (s *InternalSuite) Test_MeasurementSinglePhaseSpecificDataForFilter() {
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"b": 10}, data)
 
+	elParamData = &model.ElectricalConnectionParameterDescriptionListDataType{
+		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+			},
+		},
+	}
+
+	_, fErr = rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionParameterDescriptionListData, elParamData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err = MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		ucapi.PhaseNameMapping,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
+
+	data, err = MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		nil,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{
+		model.ElectricalConnectionPhaseNameTypeNone: 10,
+	}, data)
+
 }
 
 func (s *InternalSuite) Test_MeasurementTotalPhaseSpecificDataForFilter() {

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -115,7 +115,7 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 0, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -161,7 +161,7 @@ func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{10, 10, 10}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"a": 10, "b": 10, "c": 10}, data)
 
 	measData = &model.MeasurementListDataType{
 		MeasurementData: []model.MeasurementDataType{
@@ -391,6 +391,95 @@ func (s *InternalSuite) Test_MeasurementSinglePhaseSpecificDataForFilter() {
 		ucapi.PhaseNameMapping,
 	)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 10, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"b": 10}, data)
+
+	data, err = MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		nil,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"b": 10}, data)
+
+}
+
+func (s *InternalSuite) Test_MeasurementTotalPhaseSpecificDataForFilter() {
+	measurementType := model.MeasurementTypeTypePower
+	commodityType := model.CommodityTypeTypeElectricity
+	scopeType := model.ScopeTypeTypeACPowerTotal
+	energyDirection := model.EnergyDirectionTypeConsume
+
+	filter := model.MeasurementDescriptionDataType{
+		MeasurementType: &measurementType,
+		CommodityType:   &commodityType,
+		ScopeType:       &scopeType,
+	}
+
+	// set up ElectricalConnection
+	elDescData := &model.ElectricalConnectionDescriptionListDataType{
+		ElectricalConnectionDescriptionData: []model.ElectricalConnectionDescriptionDataType{
+			{
+				ElectricalConnectionId:  util.Ptr(model.ElectricalConnectionIdType(0)),
+				PositiveEnergyDirection: util.Ptr(model.EnergyDirectionTypeConsume),
+			},
+		},
+	}
+
+	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
+		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeAbc),
+			},
+		},
+	}
+
+	rElFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+
+	_, fErr := rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionDescriptionListData, elDescData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	_, fErr = rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionParameterDescriptionListData, elParamData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	descData := &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
+				MeasurementType: &measurementType,
+				CommodityType:   &commodityType,
+				ScopeType:       &scopeType,
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, descData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	measData := &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err := MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		nil,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"abc": 10}, data)
 
 }

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -1,12 +1,97 @@
 package internal
 
 import (
+	"testing"
+
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/spine"
 	"github.com/enbility/spine-go/util"
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_PhaseNameFromParameterDescription(t *testing.T) {
+	tests := []struct {
+		name       string
+		param      model.ElectricalConnectionParameterDescriptionDataType
+		allowUnset bool
+		want       model.ElectricalConnectionPhaseNameType
+		wantOK     bool
+	}{
+		{
+			name:       "unset phase allowed",
+			allowUnset: true,
+			want:       model.ElectricalConnectionPhaseNameTypeNone,
+			wantOK:     true,
+		},
+		{
+			name:       "unset phase rejected",
+			allowUnset: false,
+			wantOK:     false,
+		},
+		{
+			name: "phase without reference",
+			param: model.ElectricalConnectionParameterDescriptionDataType{
+				AcMeasuredPhases: util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+			},
+			want:   model.ElectricalConnectionPhaseNameTypeA,
+			wantOK: true,
+		},
+		{
+			name: "phase to neutral",
+			param: model.ElectricalConnectionParameterDescriptionDataType{
+				AcMeasuredPhases:        util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+				AcMeasuredInReferenceTo: util.Ptr(model.ElectricalConnectionPhaseNameTypeNeutral),
+			},
+			want:   model.ElectricalConnectionPhaseNameTypeA,
+			wantOK: true,
+		},
+		{
+			name: "phase a to phase b",
+			param: model.ElectricalConnectionParameterDescriptionDataType{
+				AcMeasuredPhases:        util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+				AcMeasuredInReferenceTo: util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+			},
+			want:   model.ElectricalConnectionPhaseNameTypeAb,
+			wantOK: true,
+		},
+		{
+			name: "phase b to phase a",
+			param: model.ElectricalConnectionParameterDescriptionDataType{
+				AcMeasuredPhases:        util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+				AcMeasuredInReferenceTo: util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+			},
+			want:   model.ElectricalConnectionPhaseNameTypeAb,
+			wantOK: true,
+		},
+		{
+			name: "phase b to phase c",
+			param: model.ElectricalConnectionParameterDescriptionDataType{
+				AcMeasuredPhases:        util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+				AcMeasuredInReferenceTo: util.Ptr(model.ElectricalConnectionPhaseNameTypeC),
+			},
+			want:   model.ElectricalConnectionPhaseNameTypeBc,
+			wantOK: true,
+		},
+		{
+			name: "phase a to phase c",
+			param: model.ElectricalConnectionParameterDescriptionDataType{
+				AcMeasuredPhases:        util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+				AcMeasuredInReferenceTo: util.Ptr(model.ElectricalConnectionPhaseNameTypeC),
+			},
+			want:   model.ElectricalConnectionPhaseNameTypeAc,
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := phaseNameFromParameterDescription(tt.param, tt.allowUnset)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func (s *InternalSuite) Test_MeasurementPhaseSpecificDataForFilter() {
 	measurementType := model.MeasurementTypeTypePower

--- a/usecases/internal/measurement_test.go
+++ b/usecases/internal/measurement_test.go
@@ -315,3 +315,82 @@ func (s *InternalSuite) Test_GetPowerTotalMeasurementId() {
 	measurementId = GetPowerTotalMeasurementId(testEntity)
 	assert.Equal(s.T(), defaultPowerTotalMeasurementId, measurementId)
 }
+
+func (s *InternalSuite) Test_MeasurementSinglePhaseSpecificDataForFilter() {
+	measurementType := model.MeasurementTypeTypePower
+	commodityType := model.CommodityTypeTypeElectricity
+	scopeType := model.ScopeTypeTypeACPower
+	energyDirection := model.EnergyDirectionTypeConsume
+
+	filter := model.MeasurementDescriptionDataType{
+		MeasurementType: &measurementType,
+		CommodityType:   &commodityType,
+		ScopeType:       &scopeType,
+	}
+
+	// set up ElectricalConnection
+	elDescData := &model.ElectricalConnectionDescriptionListDataType{
+		ElectricalConnectionDescriptionData: []model.ElectricalConnectionDescriptionDataType{
+			{
+				ElectricalConnectionId:  util.Ptr(model.ElectricalConnectionIdType(0)),
+				PositiveEnergyDirection: util.Ptr(model.EnergyDirectionTypeConsume),
+			},
+		},
+	}
+
+	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
+		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+			},
+		},
+	}
+
+	rElFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+
+	_, fErr := rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionDescriptionListData, elDescData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	_, fErr = rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionParameterDescriptionListData, elParamData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	descData := &model.MeasurementDescriptionListDataType{
+		MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{
+				MeasurementId:   util.Ptr(model.MeasurementIdType(0)),
+				MeasurementType: util.Ptr(model.MeasurementTypeTypePower),
+				CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
+				ScopeType:       util.Ptr(model.ScopeTypeTypeACPower),
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeMeasurement, model.RoleTypeServer)
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementDescriptionListData, descData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	measData := &model.MeasurementListDataType{
+		MeasurementData: []model.MeasurementDataType{
+			{
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				Value:         model.NewScaledNumberType(10),
+			},
+		},
+	}
+
+	_, fErr = rFeature.UpdateData(true, model.FunctionTypeMeasurementListData, measData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	data, err := MeasurementPhaseSpecificDataForFilter(
+		s.localEntity,
+		s.monitoredEntity,
+		filter,
+		energyDirection,
+		ucapi.PhaseNameMapping,
+	)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), []float64{0, 10, 0}, data)
+
+}

--- a/usecases/ma/mgcp/public.go
+++ b/usecases/ma/mgcp/public.go
@@ -78,7 +78,13 @@ func (e *MGCP) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
 		return 0, api.ErrDataNotAvailable
 	}
 
-	return data[0], nil
+	for _, k := range data {
+		// If the Monitored Unit is connected to less than three phases, one of the other combinations like "a" or "ab" are allowed instead of "abc".
+		// The values "a", "b", and "c" are permitted if and only if only one
+		return k, nil
+	}
+	// unreachable
+	return 0, api.ErrDataNotAvailable
 }
 
 // Scenario 3
@@ -170,7 +176,7 @@ func (e *MGCP) EnergyConsumed(entity spineapi.EntityRemoteInterface) (float64, e
 //   - ErrDataNotAvailable if no such value is (yet) available
 //   - ErrDataInvalid if the currently available data is invalid and should be ignored
 //   - and others
-func (e *MGCP) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+func (e *MGCP) CurrentPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity
 	}
@@ -191,7 +197,7 @@ func (e *MGCP) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64
 //   - ErrDataNotAvailable if no such value is (yet) available
 //   - ErrDataInvalid if the currently available data is invalid and should be ignored
 //   - and others
-func (e *MGCP) VoltagePerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+func (e *MGCP) VoltagePerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity
 	}

--- a/usecases/ma/mgcp/public.go
+++ b/usecases/ma/mgcp/public.go
@@ -80,7 +80,7 @@ func (e *MGCP) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
 
 	for _, k := range data {
 		// If the Monitored Unit is connected to less than three phases, one of the other combinations like "a" or "ab" are allowed instead of "abc".
-		// The values "a", "b", and "c" are permitted if and only if only one
+		// The values "a", "b", and "c" are permitted if and only if only one phase is connected
 		return k, nil
 	}
 	// unreachable

--- a/usecases/ma/mgcp/public.go
+++ b/usecases/ma/mgcp/public.go
@@ -206,7 +206,8 @@ func (e *MGCP) VoltagePerPhase(entity spineapi.EntityRemoteInterface) (map[model
 		CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
 		ScopeType:       util.Ptr(model.ScopeTypeTypeACVoltage),
 	}
-	return internal.MeasurementPhaseSpecificDataForFilter(e.LocalEntity, entity, filter, "", ucapi.PhaseNameMapping)
+	validPhaseNames := append(ucapi.PhaseNameMapping, model.ElectricalConnectionPhaseNameTypeAb, model.ElectricalConnectionPhaseNameTypeAc, model.ElectricalConnectionPhaseNameTypeBc)
+	return internal.MeasurementPhaseSpecificDataForFilter(e.LocalEntity, entity, filter, "", validPhaseNames)
 }
 
 // Scenario 7

--- a/usecases/ma/mgcp/public.go
+++ b/usecases/ma/mgcp/public.go
@@ -79,8 +79,7 @@ func (e *MGCP) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
 	}
 
 	for _, k := range data {
-		// If the Monitored Unit is connected to less than three phases, one of the other combinations like "a" or "ab" are allowed instead of "abc".
-		// The values "a", "b", and "c" are permitted if and only if only one phase is connected
+		// Return first element of map (instead of accessing phase mapping "abc" directly) because only 1 ("a", "b", "c") or 2 ("ab", "bc" "ac") phases may be connected
 		return k, nil
 	}
 	// unreachable

--- a/usecases/ma/mgcp/public_test.go
+++ b/usecases/ma/mgcp/public_test.go
@@ -118,6 +118,7 @@ func (s *GcpMGCPSuite) Test_Power() {
 			{
 				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
 				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
 			},
 		},
 	}
@@ -316,7 +317,7 @@ func (s *GcpMGCPSuite) Test_CurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.smgwEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 0, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -356,7 +357,7 @@ func (s *GcpMGCPSuite) Test_CurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.smgwEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{10, 10, 10}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"a": 10, "b": 10, "c": 10}, data)
 }
 
 func (s *GcpMGCPSuite) Test_VoltagePerPhase() {
@@ -421,7 +422,7 @@ func (s *GcpMGCPSuite) Test_VoltagePerPhase() {
 
 	data, err = s.sut.VoltagePerPhase(s.smgwEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 0, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -449,7 +450,7 @@ func (s *GcpMGCPSuite) Test_VoltagePerPhase() {
 
 	data, err = s.sut.VoltagePerPhase(s.smgwEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{230, 230, 230}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"a": 230, "b": 230, "c": 230}, data)
 }
 
 func (s *GcpMGCPSuite) Test_Frequency() {

--- a/usecases/ma/mgcp/public_test.go
+++ b/usecases/ma/mgcp/public_test.go
@@ -316,7 +316,7 @@ func (s *GcpMGCPSuite) Test_CurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.smgwEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 0, len(data))
+	assert.Equal(s.T(), []float64{0, 0, 0}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -421,7 +421,7 @@ func (s *GcpMGCPSuite) Test_VoltagePerPhase() {
 
 	data, err = s.sut.VoltagePerPhase(s.smgwEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 0, len(data))
+	assert.Equal(s.T(), []float64{0, 0, 0}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{

--- a/usecases/ma/mpc/public.go
+++ b/usecases/ma/mpc/public.go
@@ -36,7 +36,13 @@ func (e *MPC) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
 		return 0, api.ErrDataNotAvailable
 	}
 
-	return values[0], nil
+	for _, k := range values {
+		// If the Monitored Unit is connected to less than three phases, one of the other combinations like "a" or "ab" are allowed instead of "abc".
+		// The values "a", "b", and "c" are permitted if and only if only one
+		return k, nil
+	}
+	// unreachable
+	return 0, api.ErrDataNotAvailable
 }
 
 // return the momentary active phase specific power consumption or production per phase
@@ -45,7 +51,7 @@ func (e *MPC) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
 //   - ErrDataNotAvailable if no such value is (yet) available
 //   - ErrDataInvalid if the currently available data is invalid and should be ignored
 //   - and others
-func (e *MPC) PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+func (e *MPC) PowerPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity
 	}
@@ -157,7 +163,7 @@ func (e *MPC) EnergyProduced(entity spineapi.EntityRemoteInterface) (float64, er
 //   - ErrDataNotAvailable if no such value is (yet) available
 //   - ErrDataInvalid if the currently available data is invalid and should be ignored
 //   - and others
-func (e *MPC) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+func (e *MPC) CurrentPerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity
 	}
@@ -178,7 +184,7 @@ func (e *MPC) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64,
 //   - ErrDataNotAvailable if no such value is (yet) available
 //   - ErrDataInvalid if the currently available data is invalid and should be ignored
 //   - and others
-func (e *MPC) VoltagePerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+func (e *MPC) VoltagePerPhase(entity spineapi.EntityRemoteInterface) (map[model.ElectricalConnectionPhaseNameType]float64, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity
 	}

--- a/usecases/ma/mpc/public.go
+++ b/usecases/ma/mpc/public.go
@@ -28,6 +28,7 @@ func (e *MPC) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
 		CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
 		ScopeType:       util.Ptr(model.ScopeTypeTypeACPowerTotal),
 	}
+	// acMeasuredPhases is optional for total active power, therefore we pass nil for validPhaseNameTypes
 	values, err := internal.MeasurementPhaseSpecificDataForFilter(e.LocalEntity, entity, filter, model.EnergyDirectionTypeConsume, nil)
 	if err != nil {
 		return 0, err
@@ -38,7 +39,7 @@ func (e *MPC) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
 
 	for _, k := range values {
 		// If the Monitored Unit is connected to less than three phases, one of the other combinations like "a" or "ab" are allowed instead of "abc".
-		// The values "a", "b", and "c" are permitted if and only if only one
+		// The values "a", "b", and "c" are permitted if and only if only one phase is connected
 		return k, nil
 	}
 	// unreachable

--- a/usecases/ma/mpc/public.go
+++ b/usecases/ma/mpc/public.go
@@ -195,7 +195,8 @@ func (e *MPC) VoltagePerPhase(entity spineapi.EntityRemoteInterface) (map[model.
 		CommodityType:   util.Ptr(model.CommodityTypeTypeElectricity),
 		ScopeType:       util.Ptr(model.ScopeTypeTypeACVoltage),
 	}
-	return internal.MeasurementPhaseSpecificDataForFilter(e.LocalEntity, entity, filter, "", ucapi.PhaseNameMapping)
+	validPhaseNames := append(ucapi.PhaseNameMapping, model.ElectricalConnectionPhaseNameTypeAb, model.ElectricalConnectionPhaseNameTypeAc, model.ElectricalConnectionPhaseNameTypeBc)
+	return internal.MeasurementPhaseSpecificDataForFilter(e.LocalEntity, entity, filter, "", validPhaseNames)
 }
 
 // Scenario 5

--- a/usecases/ma/mpc/public_test.go
+++ b/usecases/ma/mpc/public_test.go
@@ -146,7 +146,7 @@ func (s *MaMPCSuite) Test_PowerPerPhase() {
 
 	data, err = s.sut.PowerPerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 0, len(data))
+	assert.Equal(s.T(), []float64{0, 0, 0}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -405,7 +405,7 @@ func (s *MaMPCSuite) Test_CurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 0, len(data))
+	assert.Equal(s.T(), []float64{0, 0, 0}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -510,7 +510,7 @@ func (s *MaMPCSuite) Test_VoltagePerPhase() {
 
 	data, err = s.sut.VoltagePerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), 0, len(data))
+	assert.Equal(s.T(), []float64{0, 0, 0}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{

--- a/usecases/ma/mpc/public_test.go
+++ b/usecases/ma/mpc/public_test.go
@@ -72,6 +72,7 @@ func (s *MaMPCSuite) Test_Power() {
 			{
 				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
 				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeAbc),
 			},
 		},
 	}
@@ -146,7 +147,7 @@ func (s *MaMPCSuite) Test_PowerPerPhase() {
 
 	data, err = s.sut.PowerPerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 0, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -186,7 +187,7 @@ func (s *MaMPCSuite) Test_PowerPerPhase() {
 
 	data, err = s.sut.PowerPerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{10, 10, 10}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"a": 10, "b": 10, "c": 10}, data)
 }
 
 func (s *MaMPCSuite) Test_EnergyConsumed() {
@@ -405,7 +406,7 @@ func (s *MaMPCSuite) Test_CurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 0, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -445,7 +446,7 @@ func (s *MaMPCSuite) Test_CurrentPerPhase() {
 
 	data, err = s.sut.CurrentPerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{10, 10, 10}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"a": 10, "b": 10, "c": 10}, data)
 }
 
 func (s *MaMPCSuite) Test_VoltagePerPhase() {
@@ -510,7 +511,7 @@ func (s *MaMPCSuite) Test_VoltagePerPhase() {
 
 	data, err = s.sut.VoltagePerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{0, 0, 0}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{}, data)
 
 	elParamData := &model.ElectricalConnectionParameterDescriptionListDataType{
 		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
@@ -538,7 +539,7 @@ func (s *MaMPCSuite) Test_VoltagePerPhase() {
 
 	data, err = s.sut.VoltagePerPhase(s.monitoredEntity)
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), []float64{230, 230, 230}, data)
+	assert.Equal(s.T(), map[model.ElectricalConnectionPhaseNameType]float64{"a": 230, "b": 230, "c": 230}, data)
 }
 
 func (s *MaMPCSuite) Test_Frequency() {


### PR DESCRIPTION
If/when a device registers PhaseSpecific measurements only for one specific phase (or registers them for all phases but only provides measurements for one of them), MeasurementPhaseSpecificDataForFilter() returns a []float64 containing only 1 value with no way for the API user to know for which phase the measurement was meant. This is an issue in e.g. ma/mpc's PowerPerPhase which would then return an array with less than 3 members and callers would then not know to which phase the measurement corresponds.

This PR changes the return type of MeasurementPhaseSpecificDataForFilter to always contain one entry per phase so that for a device which only reports data on phase B, it would return []float64{0, 10, 0} instead of []float64{10}. The advantage of this approach is that it doesn't change the return type of MeasurementPhaseSpecificDataForFilter or any of its callers, the downside is that callers can't (easily) distinguish devices that are reporting 0 for a phase and devices that aren't reporting a phase at all. The alternative would be to change the return type from []float64 to map[ElectricalConnectionPhaseNameType]float64 and then going through all the callers to make them use/return that as well.

I'm not particular to either approach so I picked the one that changed the surface API less.