### PR TITLE
Fix possible crash when deleting remote usecases

### DIFF
--- a/usecases/usecase/testhelper_test.go
+++ b/usecases/usecase/testhelper_test.go
@@ -151,6 +151,18 @@ func setupDevices(
 	f.AddFunctionType(model.FunctionTypeDeviceClassificationUserData, true, true)
 	localEntity.AddFeature(f)
 
+	remoteDeviceName := "remote"
+
+	remoteDevice, entities := addRemoteDevice(remoteDeviceName, remoteSki, localDevice, t)
+
+	localDevice.AddRemoteDeviceForSki(remoteSki, remoteDevice)
+
+	return localEntity, remoteDevice, entities
+}
+
+func addRemoteDevice(remoteDeviceName, remoteDeviceSki string, localDevice spineapi.DeviceLocalInterface, t *testing.T) (
+	spineapi.DeviceRemoteInterface,
+	[]spineapi.EntityRemoteInterface) {
 	writeHandler := shipmocks.NewShipConnectionDataWriterInterface(t)
 	writeHandler.EXPECT().WriteShipMessageWithPayload(mock.Anything).Return().Maybe()
 	sender := spine.NewSender(writeHandler)
@@ -198,8 +210,6 @@ func setupDevices(
 			},
 		},
 	}
-
-	remoteDeviceName := "remote"
 
 	var featureInformations []model.NodeManagementDetailedDiscoveryFeatureInformationType
 	for index, feature := range remoteFeatures {
@@ -270,7 +280,7 @@ func setupDevices(
 		entity.UpdateDeviceAddress(*remoteDevice.Address())
 	}
 
-	localDevice.AddRemoteDeviceForSki(remoteSki, remoteDevice)
+	localDevice.AddRemoteDeviceForSki(remoteDeviceSki, remoteDevice)
 
-	return localEntity, remoteDevice, entities
+	return remoteDevice, entities
 }

--- a/usecases/usecase/usecase.go
+++ b/usecases/usecase/usecase.go
@@ -223,8 +223,8 @@ func (u *UseCaseBase) updateRemoteEntityScenarios(
 func (u *UseCaseBase) removeDeviceFromAvailableEntityScenarios(device spineapi.DeviceRemoteInterface) {
 	indicies := u.entityScenarioIndicesOfDevice(device)
 
-	for _, i := range indicies {
-		u.removeEntityIndexFromAvailableEntityScenarios(i)
+	for i := len(indicies) - 1; i >= 0; i-- {
+		u.removeEntityIndexFromAvailableEntityScenarios(indicies[i])
 	}
 
 	if u.EventCB != nil && len(indicies) > 0 {

--- a/usecases/usecase/usecase_test.go
+++ b/usecases/usecase/usecase_test.go
@@ -44,6 +44,15 @@ func (s *UseCaseSuite) Test() {
 }
 
 func (s *UseCaseSuite) Test_RemoveDeviceScenarios() {
+	remoteDevice2Ski := "remoteDevice2Ski"
+	localDevice := s.localEntity.Device()
+	remoteDevice2, remoteEntities2 := addRemoteDevice("remoteDevice2", remoteDevice2Ski, localDevice, s.T())
+
+	localDevice.AddRemoteDeviceForSki(remoteDevice2Ski, remoteDevice2)
+
+	entity1 := remoteEntities2[0]
+	entity2 := remoteEntities2[1]
+
 	result := s.uc.RemoteEntitiesScenarios()
 	assert.Equal(s.T(), 0, len(result))
 
@@ -53,7 +62,25 @@ func (s *UseCaseSuite) Test_RemoveDeviceScenarios() {
 	ok := s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1)
 	assert.False(s.T(), ok)
 
+	s.uc.updateRemoteEntityScenarios(entity1, []model.UseCaseScenarioSupportType{1, 2, 3, 4})
+
+	result = s.uc.RemoteEntitiesScenarios()
+	assert.Equal(s.T(), 1, len(result))
+
 	s.uc.updateRemoteEntityScenarios(s.monitoredEntity, []model.UseCaseScenarioSupportType{1, 2, 3})
+
+	result = s.uc.RemoteEntitiesScenarios()
+	assert.Equal(s.T(), 2, len(result))
+
+	scenarios = s.uc.AvailableScenariosForEntity(s.monitoredEntity)
+	assert.Equal(s.T(), 3, len(scenarios))
+
+	s.uc.updateRemoteEntityScenarios(entity2, []model.UseCaseScenarioSupportType{1, 2})
+
+	result = s.uc.RemoteEntitiesScenarios()
+	assert.Equal(s.T(), 3, len(result))
+
+	s.uc.removeDeviceFromAvailableEntityScenarios(entity2.Device())
 
 	result = s.uc.RemoteEntitiesScenarios()
 	assert.Equal(s.T(), 1, len(result))
@@ -61,12 +88,7 @@ func (s *UseCaseSuite) Test_RemoveDeviceScenarios() {
 	scenarios = s.uc.AvailableScenariosForEntity(s.monitoredEntity)
 	assert.Equal(s.T(), 3, len(scenarios))
 
-	s.uc.removeDeviceFromAvailableEntityScenarios(s.monitoredEntity.Device())
-
-	result = s.uc.RemoteEntitiesScenarios()
-	assert.Equal(s.T(), 0, len(result))
-
-	scenarios = s.uc.AvailableScenariosForEntity(s.monitoredEntity)
+	scenarios = s.uc.AvailableScenariosForEntity(entity2)
 	assert.Equal(s.T(), 0, len(scenarios))
 }
 


### PR DESCRIPTION
When deleting a remote devices usecases, deletion for the internal data structure should be done in reverse order as indices are used. Otherwise deleting multiple elements could result in a crash.