### PR TITLE
Set IsActive to false when received limit duration is 0

### DIFF
--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -47,6 +47,7 @@ func (e *LPC) ConsumptionLimit() (limit ucapi.LoadLimit, resultErr error) {
 		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
 			if limit.Duration == 0 {
+				// according to EEBus UC Implementation Guideline for LPC v1.0.0 section 2.2 item 1
 				limit.IsActive = false
 			}
 		}

--- a/usecases/cs/lpc/public.go
+++ b/usecases/cs/lpc/public.go
@@ -46,6 +46,9 @@ func (e *LPC) ConsumptionLimit() (limit ucapi.LoadLimit, resultErr error) {
 	if value.TimePeriod != nil && value.TimePeriod.EndTime != nil {
 		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
+			if limit.Duration == 0 {
+				limit.IsActive = false
+			}
 		}
 	}
 

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -46,6 +46,9 @@ func (e *LPP) ProductionLimit() (limit ucapi.LoadLimit, resultErr error) {
 	if value.TimePeriod != nil && value.TimePeriod.EndTime != nil {
 		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
+			if limit.Duration == 0 {
+				limit.IsActive = false
+			}
 		}
 	}
 

--- a/usecases/cs/lpp/public.go
+++ b/usecases/cs/lpp/public.go
@@ -47,6 +47,8 @@ func (e *LPP) ProductionLimit() (limit ucapi.LoadLimit, resultErr error) {
 		if duration, err := value.TimePeriod.GetDuration(); err == nil {
 			limit.Duration = duration
 			if limit.Duration == 0 {
+				// according to EEBus UC Implementation Guideline for LPC v1.0.0 section 2.2 item 1
+				// no IG exists for LPP at the moment, we assume the same should be valid here as well
 				limit.IsActive = false
 			}
 		}


### PR DESCRIPTION
According to the EEBus UC Implementation Guideline for LPC v1.0.0 section 2.2 1):
If Actor Controllable System receives an Active Power Consumption Limit with a duration set to "0", the limit SHALL immediately be deactivated by the Controllable System (see [LPC-007]). If the received write command contains a duration set to "0" AND also a request to set the Active Power Consumption Limit to "activated", the Actor Controllable System SHALL ignore the request

This has the added effect for us, that previously in the CS-LPC/CS-LPP API it was next to impossible to differentiate between a limit without a duration (active forever), and a limit with a 0 duration.