### PR TITLE
[lpc/lpp eg] subscription and read request for scenario 4

### DIFF
--- a/usecases/eg/lpc/events.go
+++ b/usecases/eg/lpc/events.go
@@ -102,6 +102,23 @@ func (e *LPC) connected(entity spineapi.EntityRemoteInterface) {
 			logging.Log().Debug(err)
 		}
 	}
+
+	if electricalConnection, err := client.NewElectricalConnection(e.LocalEntity, entity); err == nil {
+		if !electricalConnection.HasSubscription() {
+			if _, err := electricalConnection.Subscribe(); err != nil {
+				logging.Log().Debug(err)
+			}
+		}
+
+		// get characteristics
+		selector := &model.ElectricalConnectionCharacteristicListDataSelectorsType{
+			CharacteristicContext: util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
+			CharacteristicType:    util.Ptr(e.characteristicType(entity)),
+		}
+		if _, err := electricalConnection.RequestCharacteristics(selector, nil); err != nil {
+			logging.Log().Debug(err)
+		}
+	}
 }
 
 // the load control limit description data was updated

--- a/usecases/eg/lpc/testhelper_test.go
+++ b/usecases/eg/lpc/testhelper_test.go
@@ -63,6 +63,7 @@ func (s *EgLPCSuite) BeforeTest(suiteName, testName string) {
 	mockRemoteFeature := spinemocks.NewFeatureRemoteInterface(s.T())
 	mockRemoteDevice.EXPECT().FeatureByEntityTypeAndRole(mock.Anything, mock.Anything, mock.Anything).Return(mockRemoteFeature).Maybe()
 	mockRemoteDevice.EXPECT().Ski().Return(remoteSki).Maybe()
+	mockRemoteDevice.EXPECT().DeviceType().Return(util.Ptr(model.DeviceTypeTypeChargingStation)).Maybe()
 	s.mockRemoteEntity.EXPECT().Device().Return(mockRemoteDevice).Maybe()
 	s.mockRemoteEntity.EXPECT().EntityType().Return(mock.Anything).Maybe()
 	entityAddress := &model.EntityAddressType{}

--- a/usecases/eg/lpp/events.go
+++ b/usecases/eg/lpp/events.go
@@ -103,6 +103,23 @@ func (e *LPP) connected(entity spineapi.EntityRemoteInterface) {
 			logging.Log().Debug(err)
 		}
 	}
+
+	if electricalConnection, err := client.NewElectricalConnection(e.LocalEntity, entity); err == nil {
+		if !electricalConnection.HasSubscription() {
+			if _, err := electricalConnection.Subscribe(); err != nil {
+				logging.Log().Debug(err)
+			}
+		}
+
+		// get characteristics
+		selector := &model.ElectricalConnectionCharacteristicListDataSelectorsType{
+			CharacteristicContext: util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
+			CharacteristicType:    util.Ptr(e.characteristicType(entity)),
+		}
+		if _, err := electricalConnection.RequestCharacteristics(selector, nil); err != nil {
+			logging.Log().Debug(err)
+		}
+	}
 }
 
 // the load control limit description data was updated

--- a/usecases/eg/lpp/testhelper_test.go
+++ b/usecases/eg/lpp/testhelper_test.go
@@ -63,6 +63,7 @@ func (s *EgLPPSuite) BeforeTest(suiteName, testName string) {
 	mockRemoteFeature := spinemocks.NewFeatureRemoteInterface(s.T())
 	mockRemoteDevice.EXPECT().FeatureByEntityTypeAndRole(mock.Anything, mock.Anything, mock.Anything).Return(mockRemoteFeature).Maybe()
 	mockRemoteDevice.EXPECT().Ski().Return(remoteSki).Maybe()
+	mockRemoteDevice.EXPECT().DeviceType().Return(util.Ptr(model.DeviceTypeTypeChargingStation)).Maybe()
 	s.mockRemoteEntity.EXPECT().Device().Return(mockRemoteDevice).Maybe()
 	s.mockRemoteEntity.EXPECT().EntityType().Return(mock.Anything).Maybe()
 	entityAddress := &model.EntityAddressType{}


### PR DESCRIPTION
This PR adds missing pre-scenario and initial scenario communication for LPC/LPP EnergyGuard scenario 4, which requires to subscribe on ElectricalConnection feature and trigger a read request for electricalConnectionCharacteristicListData.