### PR TITLE
Defer use case connection setup until scenario verification (#190, #198)

### DIFF
--- a/usecases/cem/cevc/events.go
+++ b/usecases/cem/cevc/events.go
@@ -2,7 +2,6 @@ package cevc
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	"github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/ship-go/logging"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -17,13 +16,12 @@ func (e *CEVC) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.evConnected(payload.Entity)
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
 
-	if payload.EventType != spineapi.EventTypeDataChange ||
-		payload.ChangeType != spineapi.ElementChangeUpdate {
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/cem/cevc/events_test.go
+++ b/usecases/cem/cevc/events_test.go
@@ -29,6 +29,14 @@ func (s *CemCEVCSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.TimeSeriesDescriptionListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.TimeSeriesDescriptionListDataType{})
@@ -172,4 +180,37 @@ func (s *CemCEVCSuite) Test_evTimeSeriesDescriptionDataUpdate() {
 
 	s.sut.evTimeSeriesDescriptionDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemCEVCSuite) Test_evConnected() {
+	s.sut.evConnected(s.evEntity)
+}
+
+func (s *CemCEVCSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.evEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		model.UseCaseNameTypeCoordinatedEVCharging,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4, 6, 8})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.evEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cem/cevc/usecase.go
+++ b/usecases/cem/cevc/usecase.go
@@ -76,6 +76,10 @@ func NewCEVC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventC
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.evConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cem/evcc/events.go
+++ b/usecases/cem/evcc/events.go
@@ -17,16 +17,17 @@ func (e *EVCC) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.evConnected(payload)
-		return
-	} else if internal.IsEntityRemoved(payload) {
+	if internal.IsEntityRemoved(payload) {
 		e.evDisconnected(payload)
 		return
 	}
 
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
+		return
+	}
+
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 
@@ -55,9 +56,9 @@ func (e *EVCC) HandleEvent(payload spineapi.EventPayload) {
 }
 
 // an EV was connected
-func (e *EVCC) evConnected(payload spineapi.EventPayload) {
+func (e *EVCC) evConnected(entity spineapi.EntityRemoteInterface) {
 	// initialise features, e.g. subscriptions, descriptions
-	if evDeviceClassification, err := client.NewDeviceClassification(e.LocalEntity, payload.Entity); err == nil {
+	if evDeviceClassification, err := client.NewDeviceClassification(e.LocalEntity, entity); err == nil {
 		if !evDeviceClassification.HasSubscription() {
 			if _, err := evDeviceClassification.Subscribe(); err != nil {
 				logging.Log().Debug(err)
@@ -70,7 +71,7 @@ func (e *EVCC) evConnected(payload spineapi.EventPayload) {
 		}
 	}
 
-	if evDeviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, payload.Entity); err == nil {
+	if evDeviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		if !evDeviceConfiguration.HasSubscription() {
 			if _, err := evDeviceConfiguration.Subscribe(); err != nil {
 				logging.Log().Debug(err)
@@ -83,7 +84,7 @@ func (e *EVCC) evConnected(payload spineapi.EventPayload) {
 		}
 	}
 
-	if evDeviceDiagnosis, err := client.NewDeviceDiagnosis(e.LocalEntity, payload.Entity); err == nil {
+	if evDeviceDiagnosis, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
 		if !evDeviceDiagnosis.HasSubscription() {
 			if _, err := evDeviceDiagnosis.Subscribe(); err != nil {
 				logging.Log().Debug(err)
@@ -96,7 +97,7 @@ func (e *EVCC) evConnected(payload spineapi.EventPayload) {
 		}
 	}
 
-	if evElectricalConnection, err := client.NewElectricalConnection(e.LocalEntity, payload.Entity); err == nil {
+	if evElectricalConnection, err := client.NewElectricalConnection(e.LocalEntity, entity); err == nil {
 		if !evElectricalConnection.HasSubscription() {
 			if _, err := evElectricalConnection.Subscribe(); err != nil {
 				logging.Log().Debug(err)
@@ -114,7 +115,7 @@ func (e *EVCC) evConnected(payload spineapi.EventPayload) {
 		}
 	}
 
-	if evIdentification, err := client.NewIdentification(e.LocalEntity, payload.Entity); err == nil {
+	if evIdentification, err := client.NewIdentification(e.LocalEntity, entity); err == nil {
 		if !evIdentification.HasSubscription() {
 			if _, err := evIdentification.Subscribe(); err != nil {
 				logging.Log().Debug(err)
@@ -128,7 +129,7 @@ func (e *EVCC) evConnected(payload spineapi.EventPayload) {
 	}
 
 	if e.EventCB != nil {
-		e.EventCB(payload.Ski, payload.Device, payload.Entity, EvConnected)
+		e.EventCB(entity.Device().Ski(), entity.Device(), entity, EvConnected)
 	}
 }
 

--- a/usecases/cem/evcc/events_test.go
+++ b/usecases/cem/evcc/events_test.go
@@ -35,6 +35,14 @@ func (s *CemEVCCSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.DeviceConfigurationKeyValueDescriptionListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.DeviceConfigurationKeyValueDescriptionListDataType{})
@@ -64,10 +72,7 @@ func (s *CemEVCCSuite) Test_Events() {
 }
 
 func (s *CemEVCCSuite) Test_Failures() {
-	payload := spineapi.EventPayload{
-		Entity: s.mockRemoteEntity,
-	}
-	s.sut.evConnected(payload)
+	s.sut.evConnected(s.mockRemoteEntity)
 
 	s.sut.evConfigurationDescriptionDataUpdate(s.mockRemoteEntity)
 
@@ -278,4 +283,37 @@ func (s *CemEVCCSuite) Test_evElectricalPermittedValuesUpdate() {
 	payload.Data = permData
 	s.sut.evElectricalPermittedValuesUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemEVCCSuite) Test_evConnected() {
+	s.sut.evConnected(s.evEntity)
+}
+
+func (s *CemEVCCSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.evEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		model.UseCaseNameTypeEVCommissioningAndConfiguration,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4, 5, 6, 7, 8})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.evEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cem/evcc/usecase.go
+++ b/usecases/cem/evcc/usecase.go
@@ -90,6 +90,10 @@ func NewEVCC(
 		service:     service,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.evConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cem/evcem/events.go
+++ b/usecases/cem/evcem/events.go
@@ -2,7 +2,6 @@ package evcem
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	internal "github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/ship-go/logging"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -17,15 +16,15 @@ func (e *EVCEM) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.evConnected(payload.Entity)
-		return
-	}
-
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
+
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
+		return
+	}
+
 	switch payload.Data.(type) {
 	case *model.ElectricalConnectionDescriptionListDataType:
 		e.evElectricalConnectionDescriptionDataUpdate(payload)

--- a/usecases/cem/evcem/events_test.go
+++ b/usecases/cem/evcem/events_test.go
@@ -27,6 +27,14 @@ func (s *CemEVCEMSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.ElectricalConnectionDescriptionListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.ElectricalConnectionDescriptionListDataType{})
@@ -142,4 +150,37 @@ func (s *CemEVCEMSuite) Test_evMeasurementDataUpdate() {
 
 	s.sut.evMeasurementDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemEVCEMSuite) Test_evConnected() {
+	s.sut.evConnected(s.evEntity)
+}
+
+func (s *CemEVCEMSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.evEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		model.UseCaseNameTypeMeasurementOfElectricityDuringEVCharging,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.evEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cem/evcem/usecase.go
+++ b/usecases/cem/evcem/usecase.go
@@ -76,6 +76,10 @@ func NewEVCEM(
 		service:     service,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.evConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cem/evsecc/events.go
+++ b/usecases/cem/evsecc/events.go
@@ -15,16 +15,17 @@ func (e *EVSECC) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.evseConnected(payload)
-		return
-	} else if internal.IsEntityRemoved(payload) {
+	if internal.IsEntityRemoved(payload) {
 		e.evseDisconnected(payload)
 		return
 	}
 
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
+		return
+	}
+
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 
@@ -38,17 +39,17 @@ func (e *EVSECC) HandleEvent(payload spineapi.EventPayload) {
 }
 
 // an EVSE was connected
-func (e *EVSECC) evseConnected(payload spineapi.EventPayload) {
-	if evseDeviceClassification, err := client.NewDeviceClassification(e.LocalEntity, payload.Entity); err == nil {
+func (e *EVSECC) evseConnected(entity spineapi.EntityRemoteInterface) {
+	if evseDeviceClassification, err := client.NewDeviceClassification(e.LocalEntity, entity); err == nil {
 		_, _ = evseDeviceClassification.RequestManufacturerDetails()
 	}
 
-	if evseDeviceDiagnosis, err := client.NewDeviceDiagnosis(e.LocalEntity, payload.Entity); err == nil {
+	if evseDeviceDiagnosis, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
 		_, _ = evseDeviceDiagnosis.RequestState()
 	}
 
 	if e.EventCB != nil {
-		e.EventCB(payload.Ski, payload.Device, payload.Entity, EvseConnected)
+		e.EventCB(entity.Device().Ski(), entity.Device(), entity, EvseConnected)
 	}
 }
 

--- a/usecases/cem/evsecc/events_test.go
+++ b/usecases/cem/evsecc/events_test.go
@@ -35,6 +35,14 @@ func (s *CemEVSECCSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.DeviceClassificationManufacturerDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.DeviceClassificationManufacturerDataType{})
@@ -95,4 +103,37 @@ func (s *CemEVSECCSuite) Test_evseStateUpdate() {
 
 	s.sut.evseStateUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemEVSECCSuite) Test_evseConnected() {
+	s.sut.evseConnected(s.evseEntity)
+}
+
+func (s *CemEVSECCSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.evseEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEVSE,
+		model.UseCaseNameTypeEVSECommissioningAndConfiguration,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.evseEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cem/evsecc/usecase.go
+++ b/usecases/cem/evsecc/usecase.go
@@ -57,6 +57,10 @@ func NewEVSECC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEven
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.evseConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cem/evsoc/events.go
+++ b/usecases/cem/evsoc/events.go
@@ -2,7 +2,6 @@ package evsoc
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	internal "github.com/enbility/eebus-go/usecases/internal"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
@@ -16,13 +15,12 @@ func (e *EVSOC) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.evConnected(payload.Entity)
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
 
-	if payload.EventType != spineapi.EventTypeDataChange ||
-		payload.ChangeType != spineapi.ElementChangeUpdate {
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/cem/evsoc/events_test.go
+++ b/usecases/cem/evsoc/events_test.go
@@ -27,6 +27,14 @@ func (s *CemEVSOCSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.MeasurementListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.MeasurementListDataType{})
@@ -102,4 +110,37 @@ func (s *CemEVSOCSuite) Test_evMeasurementDataUpdate() {
 
 	s.sut.evMeasurementDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemEVSOCSuite) Test_evConnected() {
+	s.sut.evConnected(s.evEntity)
+}
+
+func (s *CemEVSOCSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.evEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		model.UseCaseNameTypeEVStateOfCharge,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.evEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cem/evsoc/usecase.go
+++ b/usecases/cem/evsoc/usecase.go
@@ -53,6 +53,10 @@ func NewEVSOC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEvent
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.evConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cem/opev/events.go
+++ b/usecases/cem/opev/events.go
@@ -2,7 +2,6 @@ package opev
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	"github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/ship-go/logging"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -17,13 +16,12 @@ func (e *OPEV) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.evConnected(payload.Entity)
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
 
-	if payload.EventType != spineapi.EventTypeDataChange ||
-		payload.ChangeType != spineapi.ElementChangeUpdate {
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/cem/opev/events_test.go
+++ b/usecases/cem/opev/events_test.go
@@ -27,6 +27,14 @@ func (s *CemOPEVSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.ElectricalConnectionPermittedValueSetListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.ElectricalConnectionPermittedValueSetListDataType{})
@@ -180,4 +188,37 @@ func (s *CemOPEVSuite) Test_evLoadControlLimitDataUpdate() {
 
 	s.sut.evLoadControlLimitDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemOPEVSuite) Test_evConnected() {
+	s.sut.evConnected(s.evEntity)
+}
+
+func (s *CemOPEVSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.evEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		model.UseCaseNameTypeOverloadProtectionByEVChargingCurrentCurtailment,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.evEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cem/opev/usecase.go
+++ b/usecases/cem/opev/usecase.go
@@ -64,6 +64,10 @@ func NewOPEV(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventC
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.evConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cem/oscev/events.go
+++ b/usecases/cem/oscev/events.go
@@ -21,6 +21,10 @@ func (e *OSCEV) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
+		return
+	}
+
 	switch payload.Data.(type) {
 	case *model.ElectricalConnectionPermittedValueSetListDataType:
 		e.evElectricalPermittedValuesUpdate(payload)

--- a/usecases/cem/oscev/events_test.go
+++ b/usecases/cem/oscev/events_test.go
@@ -27,6 +27,14 @@ func (s *CemOSCEVSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.ElectricalConnectionPermittedValueSetListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.ElectricalConnectionPermittedValueSetListDataType{})
@@ -171,4 +179,33 @@ func (s *CemOSCEVSuite) Test_evLoadControlLimitDataUpdate() {
 
 	s.sut.evLoadControlLimitDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemOSCEVSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.evEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		model.UseCaseNameTypeOptimizationOfSelfConsumptionDuringEVCharging,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.evEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cem/oscev/testhelper_test.go
+++ b/usecases/cem/oscev/testhelper_test.go
@@ -129,13 +129,6 @@ func setupDevices(
 				model.FunctionTypeLoadControlLimitListData,
 			},
 		},
-		{model.FeatureTypeTypeElectricalConnection,
-			model.RoleTypeServer,
-			[]model.FunctionType{
-				model.FunctionTypeElectricalConnectionParameterDescriptionListData,
-				model.FunctionTypeElectricalConnectionPermittedValueSetListData,
-			},
-		},
 		{model.FeatureTypeTypeDeviceDiagnosis,
 			model.RoleTypeClient,
 			[]model.FunctionType{},

--- a/usecases/cem/vabd/events.go
+++ b/usecases/cem/vabd/events.go
@@ -2,7 +2,6 @@ package vabd
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	"github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/ship-go/logging"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -17,13 +16,12 @@ func (e *VABD) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.inverterConnected(payload.Entity)
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
 
-	if payload.EventType != spineapi.EventTypeDataChange ||
-		payload.ChangeType != spineapi.ElementChangeUpdate {
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/cem/vabd/events_test.go
+++ b/usecases/cem/vabd/events_test.go
@@ -27,6 +27,14 @@ func (s *CemVABDSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.MeasurementDescriptionListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.DeviceConfigurationKeyValueDescriptionListDataType{})
@@ -113,4 +121,37 @@ func (s *CemVABDSuite) Test_inverterMeasurementDataUpdate() {
 
 	s.sut.inverterMeasurementDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemVABDSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.batteryEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeBatterySystem,
+		model.UseCaseNameTypeVisualizationOfAggregatedBatteryData,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.batteryEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
+}
+
+func (s *CemVABDSuite) Test_inverterConnected() {
+	s.sut.inverterConnected(s.batteryEntity)
 }

--- a/usecases/cem/vabd/usecase.go
+++ b/usecases/cem/vabd/usecase.go
@@ -78,6 +78,10 @@ func NewVABD(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventC
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.inverterConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cem/vapd/events.go
+++ b/usecases/cem/vapd/events.go
@@ -2,7 +2,6 @@ package vapd
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	"github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/ship-go/logging"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -17,13 +16,12 @@ func (e *VAPD) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.inverterConnected(payload.Entity)
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
 
-	if payload.EventType != spineapi.EventTypeDataChange ||
-		payload.ChangeType != spineapi.ElementChangeUpdate {
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/cem/vapd/events_test.go
+++ b/usecases/cem/vapd/events_test.go
@@ -27,6 +27,14 @@ func (s *CemVAPDSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.DeviceConfigurationKeyValueDescriptionListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.DeviceConfigurationKeyValueDescriptionListDataType{})
@@ -145,4 +153,37 @@ func (s *CemVAPDSuite) Test_inverterMeasurementDataUpdate() {
 
 	s.sut.inverterMeasurementDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CemVAPDSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.pvEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypePVSystem,
+		model.UseCaseNameTypeVisualizationOfAggregatedPhotovoltaicData,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.pvEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
+}
+
+func (s *CemVAPDSuite) Test_inverterConnected() {
+	s.sut.inverterConnected(s.pvEntity)
 }

--- a/usecases/cem/vapd/usecase.go
+++ b/usecases/cem/vapd/usecase.go
@@ -69,6 +69,10 @@ func NewVAPD(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventC
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.inverterConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/cs/lpc/events.go
+++ b/usecases/cs/lpc/events.go
@@ -12,23 +12,18 @@ import (
 
 // handle SPINE events
 func (e *LPC) HandleEvent(payload spineapi.EventPayload) {
-	if internal.IsDeviceConnected(payload) {
-		e.deviceConnected(payload)
-		return
-	}
-
 	if !e.IsCompatibleEntityType(payload.Entity) {
 		return
 	}
 
-	// did we receive a binding to the loadControl server and the
-	// heartbeatWorkaround is required?
+	// subscribe to heartbeat when a remote entity binds to our loadControl server
 	if payload.EventType == spineapi.EventTypeBindingChange &&
 		payload.ChangeType == spineapi.ElementChangeAdd &&
 		payload.LocalFeature != nil &&
 		payload.LocalFeature.Type() == model.FeatureTypeTypeLoadControl &&
-		payload.LocalFeature.Role() == model.RoleTypeServer {
-		e.subscribeHeartbeatWorkaround(payload)
+		payload.LocalFeature.Role() == model.RoleTypeServer &&
+		e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
+		e.subscribeHeartbeat(payload.Entity)
 		return
 	}
 
@@ -41,6 +36,10 @@ func (e *LPC) HandleEvent(payload spineapi.EventPayload) {
 		payload.ChangeType != spineapi.ElementChangeUpdate ||
 		payload.CmdClassifier == nil ||
 		*payload.CmdClassifier != model.CmdClassifierTypeWrite {
+		return
+	}
+
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 
@@ -66,77 +65,18 @@ func (e *LPC) HandleEvent(payload spineapi.EventPayload) {
 	}
 }
 
-// a remote device was connected and we know its entities
-func (e *LPC) deviceConnected(payload spineapi.EventPayload) {
-	if payload.Device == nil {
-		return
-	}
-
-	// check if there is a DeviceDiagnosis server on one or more entities
-	remoteDevice := payload.Device
-
-	var deviceDiagEntities []spineapi.EntityRemoteInterface
-
-	entities := remoteDevice.Entities()
-	for _, entity := range entities {
-		if !e.IsCompatibleEntityType(entity) {
-			continue
-		}
-
-		deviceDiagF := entity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
-		if deviceDiagF == nil {
-			continue
-		}
-
-		deviceDiagEntities = append(deviceDiagEntities, entity)
-	}
-
-	logging.Log().Debug("cs-lpc:", len(deviceDiagEntities), "DeviceDiagnosis Server found")
-
-	// the remote device does not have a DeviceDiagnosis Server, which it should
-	if len(deviceDiagEntities) == 0 {
-		return
-	}
-
-	// we only found one matching entity, as it should be, subscribe
-	if len(deviceDiagEntities) == 1 {
-		if localDeviceDiag, err := client.NewDeviceDiagnosis(e.LocalEntity, deviceDiagEntities[0]); err == nil {
-			e.heartbeatDiag = localDeviceDiag
-			if !localDeviceDiag.HasSubscription() {
-				if _, err := localDeviceDiag.Subscribe(); err != nil {
-					logging.Log().Debug(err)
-				}
-			}
-
-			if _, err := localDeviceDiag.RequestHeartbeat(); err != nil {
+// subscribe to the DeviceDiagnosis of the entity that created a binding
+func (e *LPC) subscribeHeartbeat(entity spineapi.EntityRemoteInterface) {
+	if localDeviceDiag, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
+		e.heartbeatDiag = localDeviceDiag
+		if !localDeviceDiag.HasSubscription() {
+			if _, err := localDeviceDiag.Subscribe(); err != nil {
 				logging.Log().Debug(err)
 			}
 		}
 
-		return
-	}
-
-	// we found more than one matching entity, this is not good
-	// according to KEO the subscription should be done on the entity that requests a binding to
-	// the local loadControlLimit server feature
-	e.heartbeatKeoWorkaround = true
-}
-
-// subscribe to the DeviceDiagnosis Server of the entity that created a binding
-func (e *LPC) subscribeHeartbeatWorkaround(payload spineapi.EventPayload) {
-	// is the workaround is needed?
-	if e.heartbeatKeoWorkaround {
-		if localDeviceDiag, err := client.NewDeviceDiagnosis(e.LocalEntity, payload.Entity); err == nil {
-			e.heartbeatDiag = localDeviceDiag
-			if !localDeviceDiag.HasSubscription() {
-				if _, err := localDeviceDiag.Subscribe(); err != nil {
-					logging.Log().Debug(err)
-				}
-			}
-
-			if _, err := localDeviceDiag.RequestHeartbeat(); err != nil {
-				logging.Log().Debug(err)
-			}
+		if _, err := localDeviceDiag.RequestHeartbeat(); err != nil {
+			logging.Log().Debug(err)
 		}
 	}
 }

--- a/usecases/cs/lpc/events_test.go
+++ b/usecases/cs/lpc/events_test.go
@@ -1,10 +1,7 @@
 package lpc
 
 import (
-	"fmt"
-
 	spineapi "github.com/enbility/spine-go/api"
-	"github.com/enbility/spine-go/mocks"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +29,16 @@ func (s *CsLPCSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeRemove
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.CmdClassifier = util.Ptr(model.CmdClassifierTypeWrite)
+	payload.Data = &model.LoadControlLimitListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
+	payload.Data = nil
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.CmdClassifier = util.Ptr(model.CmdClassifierTypeWrite)
@@ -71,153 +78,9 @@ func (s *CsLPCSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *CsLPCSuite) Test_deviceConnected() {
-	payload := spineapi.EventPayload{
-		Entity: s.mockRemoteEntity,
-	}
-
-	s.sut.deviceConnected(payload)
-
-	// no entities
-	mockRemoteDevice := mocks.NewDeviceRemoteInterface(s.T())
-	mockRemoteDevice.EXPECT().Entities().Return(nil)
-	payload.Device = mockRemoteDevice
-	s.sut.deviceConnected(payload)
-
-	// one entity with one DeviceDiagnosis server
-	payload.Device = s.remoteDevice
-	s.sut.deviceConnected(payload)
-
-	s.sut.subscribeHeartbeatWorkaround(payload)
-}
-
-func (s *CsLPCSuite) Test_multipleDeviceDiagServer() {
-	// multiple entities each with DeviceDiagnosis server
-
-	payload := spineapi.EventPayload{
-		Device: s.remoteDevice,
-		Entity: s.mockRemoteEntity,
-	}
-
-	remoteDeviceName := "remote"
-
-	var remoteFeatures = []struct {
-		featureType   model.FeatureTypeType
-		role          model.RoleType
-		supportedFcts []model.FunctionType
-	}{
-		{model.FeatureTypeTypeLoadControl,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-		{model.FeatureTypeTypeDeviceConfiguration,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-		{model.FeatureTypeTypeDeviceDiagnosis,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-		{model.FeatureTypeTypeDeviceDiagnosis,
-			model.RoleTypeServer,
-			[]model.FunctionType{
-				model.FunctionTypeDeviceDiagnosisHeartbeatData,
-			},
-		},
-		{model.FeatureTypeTypeElectricalConnection,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-	}
-	var featureInformations []model.NodeManagementDetailedDiscoveryFeatureInformationType
-	// 4 entities
-	for i := 1; i < 5; i++ {
-		for index, feature := range remoteFeatures {
-			supportedFcts := []model.FunctionPropertyType{}
-			for _, fct := range feature.supportedFcts {
-				supportedFct := model.FunctionPropertyType{
-					Function: util.Ptr(fct),
-					PossibleOperations: &model.PossibleOperationsType{
-						Read: &model.PossibleOperationsReadType{},
-					},
-				}
-				supportedFcts = append(supportedFcts, supportedFct)
-			}
-
-			featureInformation := model.NodeManagementDetailedDiscoveryFeatureInformationType{
-				Description: &model.NetworkManagementFeatureDescriptionDataType{
-					FeatureAddress: &model.FeatureAddressType{
-						Device:  util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity:  []model.AddressEntityType{model.AddressEntityType(i)},
-						Feature: util.Ptr(model.AddressFeatureType(index)),
-					},
-					FeatureType:       util.Ptr(feature.featureType),
-					Role:              util.Ptr(feature.role),
-					SupportedFunction: supportedFcts,
-				},
-			}
-			featureInformations = append(featureInformations, featureInformation)
-		}
-	}
-
-	detailedData := &model.NodeManagementDetailedDiscoveryDataType{
-		DeviceInformation: &model.NodeManagementDetailedDiscoveryDeviceInformationType{
-			Description: &model.NetworkManagementDeviceDescriptionDataType{
-				DeviceAddress: &model.DeviceAddressType{
-					Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-				},
-			},
-		},
-		EntityInformation: []model.NodeManagementDetailedDiscoveryEntityInformationType{
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{1},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{2},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{3},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{4},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-		},
-		FeatureInformation: featureInformations,
-	}
-
-	_, err := s.remoteDevice.AddEntityAndFeatures(true, detailedData, nil)
-	if err != nil {
-		fmt.Println(err)
-	}
-	s.remoteDevice.UpdateDevice(detailedData.DeviceInformation.Description)
-
-	s.sut.deviceConnected(payload)
-
-	s.sut.subscribeHeartbeatWorkaround(payload)
+func (s *CsLPCSuite) Test_subscribeHeartbeat() {
+	// test heartbeat subscription with a compatible entity
+	s.sut.subscribeHeartbeat(s.monitoredEntity)
 }
 
 func (s *CsLPCSuite) Test_loadControlLimitDataUpdate() {
@@ -336,4 +199,33 @@ func (s *CsLPCSuite) Test_configurationDataUpdate() {
 	s.eventCalled = false
 	s.sut.configurationDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CsLPCSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEnergyGuard,
+		model.UseCaseNameTypeLimitationOfPowerConsumption,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.monitoredEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cs/lpc/usecase.go
+++ b/usecases/cs/lpc/usecase.go
@@ -23,8 +23,6 @@ type LPC struct {
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
 	heartbeatDiag *features.DeviceDiagnosis
-
-	heartbeatKeoWorkaround bool // required because KEO Stack uses multiple identical entities for the same functionality, and it is not clear which to use
 }
 
 var _ ucapi.CsLPCInterface = (*LPC)(nil)

--- a/usecases/cs/lpp/events.go
+++ b/usecases/cs/lpp/events.go
@@ -12,23 +12,18 @@ import (
 
 // handle SPINE events
 func (e *LPP) HandleEvent(payload spineapi.EventPayload) {
-	if internal.IsDeviceConnected(payload) {
-		e.deviceConnected(payload)
-		return
-	}
-
 	if !e.IsCompatibleEntityType(payload.Entity) {
 		return
 	}
 
-	// did we receive a binding to the loadControl server and the
-	// heartbeatWorkaround is required?
+	// subscribe to heartbeat when a remote entity binds to our loadControl server
 	if payload.EventType == spineapi.EventTypeBindingChange &&
 		payload.ChangeType == spineapi.ElementChangeAdd &&
 		payload.LocalFeature != nil &&
 		payload.LocalFeature.Type() == model.FeatureTypeTypeLoadControl &&
-		payload.LocalFeature.Role() == model.RoleTypeServer {
-		e.subscribeHeartbeatWorkaround(payload)
+		payload.LocalFeature.Role() == model.RoleTypeServer &&
+		e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
+		e.subscribeHeartbeat(payload.Entity)
 		return
 	}
 
@@ -41,6 +36,10 @@ func (e *LPP) HandleEvent(payload spineapi.EventPayload) {
 		payload.ChangeType != spineapi.ElementChangeUpdate ||
 		payload.CmdClassifier == nil ||
 		*payload.CmdClassifier != model.CmdClassifierTypeWrite {
+		return
+	}
+
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 
@@ -66,77 +65,18 @@ func (e *LPP) HandleEvent(payload spineapi.EventPayload) {
 	}
 }
 
-// a remote device was connected and we know its entities
-func (e *LPP) deviceConnected(payload spineapi.EventPayload) {
-	if payload.Device == nil {
-		return
-	}
-
-	// check if there is a DeviceDiagnosis server on one or more entities
-	remoteDevice := payload.Device
-
-	var deviceDiagEntities []spineapi.EntityRemoteInterface
-
-	entities := remoteDevice.Entities()
-	for _, entity := range entities {
-		if !e.IsCompatibleEntityType(entity) {
-			continue
-		}
-
-		deviceDiagF := entity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
-		if deviceDiagF == nil {
-			continue
-		}
-
-		deviceDiagEntities = append(deviceDiagEntities, entity)
-	}
-
-	logging.Log().Debug("cs-lpp:", len(deviceDiagEntities), "DeviceDiagnosis Server found")
-
-	// the remote device does not have a DeviceDiagnosis Server, which it should
-	if len(deviceDiagEntities) == 0 {
-		return
-	}
-
-	// we only found one matching entity, as it should be, subscribe
-	if len(deviceDiagEntities) == 1 {
-		if localDeviceDiag, err := client.NewDeviceDiagnosis(e.LocalEntity, deviceDiagEntities[0]); err == nil {
-			e.heartbeatDiag = localDeviceDiag
-			if !localDeviceDiag.HasSubscription() {
-				if _, err := localDeviceDiag.Subscribe(); err != nil {
-					logging.Log().Debug(err)
-				}
-			}
-
-			if _, err := localDeviceDiag.RequestHeartbeat(); err != nil {
+// subscribe to the DeviceDiagnosis of the entity that created a binding
+func (e *LPP) subscribeHeartbeat(entity spineapi.EntityRemoteInterface) {
+	if localDeviceDiag, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
+		e.heartbeatDiag = localDeviceDiag
+		if !localDeviceDiag.HasSubscription() {
+			if _, err := localDeviceDiag.Subscribe(); err != nil {
 				logging.Log().Debug(err)
 			}
 		}
 
-		return
-	}
-
-	// we found more than one matching entity, this is not good
-	// according to KEO the subscription should be done on the entity that requests a binding to
-	// the local loadControlLimit server feature
-	e.heartbeatKeoWorkaround = true
-}
-
-// subscribe to the DeviceDiagnosis Server of the entity that created a binding
-func (e *LPP) subscribeHeartbeatWorkaround(payload spineapi.EventPayload) {
-	// is the workaround is needed?
-	if e.heartbeatKeoWorkaround {
-		if localDeviceDiag, err := client.NewDeviceDiagnosis(e.LocalEntity, payload.Entity); err == nil {
-			e.heartbeatDiag = localDeviceDiag
-			if !localDeviceDiag.HasSubscription() {
-				if _, err := localDeviceDiag.Subscribe(); err != nil {
-					logging.Log().Debug(err)
-				}
-			}
-
-			if _, err := localDeviceDiag.RequestHeartbeat(); err != nil {
-				logging.Log().Debug(err)
-			}
+		if _, err := localDeviceDiag.RequestHeartbeat(); err != nil {
+			logging.Log().Debug(err)
 		}
 	}
 }

--- a/usecases/cs/lpp/events_test.go
+++ b/usecases/cs/lpp/events_test.go
@@ -1,10 +1,7 @@
 package lpp
 
 import (
-	"fmt"
-
 	spineapi "github.com/enbility/spine-go/api"
-	"github.com/enbility/spine-go/mocks"
 	"github.com/enbility/spine-go/model"
 	"github.com/enbility/spine-go/util"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +29,16 @@ func (s *CsLPPSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeRemove
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.CmdClassifier = util.Ptr(model.CmdClassifierTypeWrite)
+	payload.Data = &model.LoadControlLimitListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
+	payload.Data = nil
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.CmdClassifier = util.Ptr(model.CmdClassifierTypeWrite)
@@ -71,153 +78,9 @@ func (s *CsLPPSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
-func (s *CsLPPSuite) Test_deviceConnected() {
-	payload := spineapi.EventPayload{
-		Entity: s.mockRemoteEntity,
-	}
-
-	s.sut.deviceConnected(payload)
-
-	// no entities
-	mockRemoteDevice := mocks.NewDeviceRemoteInterface(s.T())
-	mockRemoteDevice.EXPECT().Entities().Return(nil)
-	payload.Device = mockRemoteDevice
-	s.sut.deviceConnected(payload)
-
-	// one entity with one DeviceDiagnosis server
-	payload.Device = s.remoteDevice
-	s.sut.deviceConnected(payload)
-
-	s.sut.subscribeHeartbeatWorkaround(payload)
-}
-
-func (s *CsLPPSuite) Test_multipleDeviceDiagServer() {
-	// multiple entities each with DeviceDiagnosis server
-
-	payload := spineapi.EventPayload{
-		Device: s.remoteDevice,
-		Entity: s.mockRemoteEntity,
-	}
-
-	remoteDeviceName := "remote"
-
-	var remoteFeatures = []struct {
-		featureType   model.FeatureTypeType
-		role          model.RoleType
-		supportedFcts []model.FunctionType
-	}{
-		{model.FeatureTypeTypeLoadControl,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-		{model.FeatureTypeTypeDeviceConfiguration,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-		{model.FeatureTypeTypeDeviceDiagnosis,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-		{model.FeatureTypeTypeDeviceDiagnosis,
-			model.RoleTypeServer,
-			[]model.FunctionType{
-				model.FunctionTypeDeviceDiagnosisHeartbeatData,
-			},
-		},
-		{model.FeatureTypeTypeElectricalConnection,
-			model.RoleTypeClient,
-			[]model.FunctionType{},
-		},
-	}
-	var featureInformations []model.NodeManagementDetailedDiscoveryFeatureInformationType
-	// 4 entities
-	for i := 1; i < 5; i++ {
-		for index, feature := range remoteFeatures {
-			supportedFcts := []model.FunctionPropertyType{}
-			for _, fct := range feature.supportedFcts {
-				supportedFct := model.FunctionPropertyType{
-					Function: util.Ptr(fct),
-					PossibleOperations: &model.PossibleOperationsType{
-						Read: &model.PossibleOperationsReadType{},
-					},
-				}
-				supportedFcts = append(supportedFcts, supportedFct)
-			}
-
-			featureInformation := model.NodeManagementDetailedDiscoveryFeatureInformationType{
-				Description: &model.NetworkManagementFeatureDescriptionDataType{
-					FeatureAddress: &model.FeatureAddressType{
-						Device:  util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity:  []model.AddressEntityType{model.AddressEntityType(i)},
-						Feature: util.Ptr(model.AddressFeatureType(index)),
-					},
-					FeatureType:       util.Ptr(feature.featureType),
-					Role:              util.Ptr(feature.role),
-					SupportedFunction: supportedFcts,
-				},
-			}
-			featureInformations = append(featureInformations, featureInformation)
-		}
-	}
-
-	detailedData := &model.NodeManagementDetailedDiscoveryDataType{
-		DeviceInformation: &model.NodeManagementDetailedDiscoveryDeviceInformationType{
-			Description: &model.NetworkManagementDeviceDescriptionDataType{
-				DeviceAddress: &model.DeviceAddressType{
-					Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-				},
-			},
-		},
-		EntityInformation: []model.NodeManagementDetailedDiscoveryEntityInformationType{
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{1},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{2},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{3},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-			{
-				Description: &model.NetworkManagementEntityDescriptionDataType{
-					EntityAddress: &model.EntityAddressType{
-						Device: util.Ptr(model.AddressDeviceType(remoteDeviceName)),
-						Entity: []model.AddressEntityType{4},
-					},
-					EntityType: util.Ptr(model.EntityTypeTypeCEM),
-				},
-			},
-		},
-		FeatureInformation: featureInformations,
-	}
-
-	_, err := s.remoteDevice.AddEntityAndFeatures(true, detailedData, nil)
-	if err != nil {
-		fmt.Println(err)
-	}
-	s.remoteDevice.UpdateDevice(detailedData.DeviceInformation.Description)
-
-	s.sut.deviceConnected(payload)
-
-	s.sut.subscribeHeartbeatWorkaround(payload)
+func (s *CsLPPSuite) Test_subscribeHeartbeat() {
+	// test heartbeat subscription with a compatible entity
+	s.sut.subscribeHeartbeat(s.monitoredEntity)
 }
 
 func (s *CsLPPSuite) Test_loadControlLimitDataUpdate() {
@@ -336,4 +199,33 @@ func (s *CsLPPSuite) Test_configurationDataUpdate() {
 	s.eventCalled = false
 	s.sut.configurationDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *CsLPPSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEnergyGuard,
+		model.UseCaseNameTypeLimitationOfPowerProduction,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.monitoredEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
 }

--- a/usecases/cs/lpp/usecase.go
+++ b/usecases/cs/lpp/usecase.go
@@ -23,8 +23,6 @@ type LPP struct {
 	pendingLimits map[model.MsgCounterType]*spineapi.Message
 
 	heartbeatDiag *features.DeviceDiagnosis
-
-	heartbeatKeoWorkaround bool // required because KEO Stack uses multiple identical entities for the same functionality, and it is not clear which to use
 }
 
 var _ ucapi.CsLPPInterface = (*LPP)(nil)

--- a/usecases/eg/lpc/events.go
+++ b/usecases/eg/lpc/events.go
@@ -14,10 +14,6 @@ func (e *LPC) HandleEvent(payload spineapi.EventPayload) {
 	if !e.IsCompatibleEntityType(payload.Entity) {
 		return
 	}
-	if internal.IsEntityAdded(payload) {
-		e.connected(payload.Entity)
-		return
-	}
 
 	if internal.IsHeartbeat(payload) && e.EventCB != nil {
 		e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateHeartbeat)
@@ -26,6 +22,10 @@ func (e *LPC) HandleEvent(payload spineapi.EventPayload) {
 
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
+		return
+	}
+
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/eg/lpc/events_test.go
+++ b/usecases/eg/lpc/events_test.go
@@ -27,6 +27,14 @@ func (s *EgLPCSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.LoadControlLimitListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.LoadControlLimitDescriptionListDataType{})
@@ -191,4 +199,37 @@ func (s *EgLPCSuite) Test_configurationDataUpdate() {
 
 	s.sut.configurationDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *EgLPCSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeControllableSystem,
+		model.UseCaseNameTypeLimitationOfPowerConsumption,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.monitoredEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
+}
+
+func (s *EgLPCSuite) Test_connected() {
+	s.sut.connected(s.monitoredEntity)
 }

--- a/usecases/eg/lpc/usecase.go
+++ b/usecases/eg/lpc/usecase.go
@@ -72,6 +72,10 @@ func NewLPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.connected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/eg/lpp/events.go
+++ b/usecases/eg/lpp/events.go
@@ -15,11 +15,6 @@ func (e *LPP) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.connected(payload.Entity)
-		return
-	}
-
 	if internal.IsHeartbeat(payload) && e.EventCB != nil {
 		e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateHeartbeat)
 		return
@@ -27,6 +22,10 @@ func (e *LPP) HandleEvent(payload spineapi.EventPayload) {
 
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
+		return
+	}
+
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/eg/lpp/events_test.go
+++ b/usecases/eg/lpp/events_test.go
@@ -27,6 +27,14 @@ func (s *EgLPPSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.LoadControlLimitListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.LoadControlLimitDescriptionListDataType{})
@@ -191,4 +199,37 @@ func (s *EgLPPSuite) Test_configurationDataUpdate() {
 
 	s.sut.configurationDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *EgLPPSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeControllableSystem,
+		model.UseCaseNameTypeLimitationOfPowerProduction,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.monitoredEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
+}
+
+func (s *EgLPPSuite) Test_connected() {
+	s.sut.connected(s.monitoredEntity)
 }

--- a/usecases/eg/lpp/usecase.go
+++ b/usecases/eg/lpp/usecase.go
@@ -69,6 +69,10 @@ func NewLPP(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.connected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/ma/mgcp/events.go
+++ b/usecases/ma/mgcp/events.go
@@ -2,7 +2,6 @@ package mgcp
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	internal "github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/ship-go/logging"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -17,13 +16,12 @@ func (e *MGCP) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.gridConnected(payload.Entity)
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
 
-	if payload.EventType != spineapi.EventTypeDataChange ||
-		payload.ChangeType != spineapi.ElementChangeUpdate {
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/ma/mgcp/events_test.go
+++ b/usecases/ma/mgcp/events_test.go
@@ -27,6 +27,14 @@ func (s *GcpMGCPSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.DeviceConfigurationKeyValueDescriptionListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.DeviceConfigurationKeyValueDescriptionListDataType{})
@@ -171,4 +179,37 @@ func (s *GcpMGCPSuite) Test_gridMeasurementDataUpdate() {
 
 	s.sut.gridMeasurementDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *GcpMGCPSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.smgwEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeGridConnectionPoint,
+		model.UseCaseNameTypeMonitoringOfGridConnectionPoint,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4, 5, 6, 7})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.smgwEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
+}
+
+func (s *GcpMGCPSuite) Test_gridConnected() {
+	s.sut.gridConnected(s.smgwEntity)
 }

--- a/usecases/ma/mgcp/usecase.go
+++ b/usecases/ma/mgcp/usecase.go
@@ -99,6 +99,10 @@ func NewMGCP(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventC
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.gridConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/ma/mpc/events.go
+++ b/usecases/ma/mpc/events.go
@@ -2,7 +2,6 @@ package mpc
 
 import (
 	"github.com/enbility/eebus-go/features/client"
-	internal "github.com/enbility/eebus-go/usecases/internal"
 	"github.com/enbility/ship-go/logging"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -17,13 +16,12 @@ func (e *MPC) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
-	if internal.IsEntityAdded(payload) {
-		e.deviceConnected(payload.Entity)
+	if payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
 
-	if payload.EventType != spineapi.EventTypeDataChange ||
-		payload.ChangeType != spineapi.ElementChangeUpdate {
+	if !e.IsScenarioAvailableAtEntity(payload.Entity, 1) {
 		return
 	}
 

--- a/usecases/ma/mpc/events_test.go
+++ b/usecases/ma/mpc/events_test.go
@@ -27,6 +27,14 @@ func (s *MaMPCSuite) Test_Events() {
 	payload.ChangeType = spineapi.ElementChangeAdd
 	s.sut.HandleEvent(payload)
 
+	// test scenario gate rejects data changes without scenarios
+	payload.EventType = spineapi.EventTypeDataChange
+	payload.ChangeType = spineapi.ElementChangeUpdate
+	payload.Data = &model.MeasurementDescriptionListDataType{}
+	s.sut.HandleEvent(payload)
+
+	s.setUpUseCaseScenarios()
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Data = util.Ptr(model.MeasurementDescriptionListDataType{})
@@ -131,4 +139,37 @@ func (s *MaMPCSuite) Test_deviceMeasurementDataUpdate() {
 
 	s.sut.deviceMeasurementDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *MaMPCSuite) setUpUseCaseScenarios() {
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeMonitoredUnit,
+		model.UseCaseNameTypeMonitoringOfPowerConsumption,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3, 4, 5})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.monitoredEntity,
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.sut.UseCaseBase.HandleEvent(payload)
+}
+
+func (s *MaMPCSuite) Test_deviceConnected() {
+	s.sut.deviceConnected(s.monitoredEntity)
 }

--- a/usecases/ma/mpc/usecase.go
+++ b/usecases/ma/mpc/usecase.go
@@ -91,6 +91,10 @@ func NewMPC(localEntity spineapi.EntityLocalInterface, eventCB api.EntityEventCa
 		UseCaseBase: usecase,
 	}
 
+	uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		uc.deviceConnected(entity)
+	}
+
 	_ = spine.Events.Subscribe(uc)
 
 	return uc

--- a/usecases/usecase/events.go
+++ b/usecases/usecase/events.go
@@ -47,6 +47,9 @@ func (u *UseCaseBase) useCaseDataUpdate(
 ) {
 	remoteDevice := payload.Device
 
+	// track which entities get updated so we can clear stale scenarios afterwards
+	updatedEntities := map[spineapi.EntityRemoteInterface]bool{}
+
 	// go over the use cases and check which entity of the remote device supports the usecase
 	ucs := remoteDevice.UseCases()
 	for _, uc := range ucs {
@@ -126,8 +129,13 @@ func (u *UseCaseBase) useCaseDataUpdate(
 					supportedScenarios = append(supportedScenarios, scenario.Scenario)
 				}
 
+				updatedEntities[entity] = true
 				u.updateRemoteEntityScenarios(entity, supportedScenarios)
 			}
 		}
 	}
+
+	// clear scenarios for entities of this device that were not updated,
+	// e.g. because the use case was removed or set unavailable
+	u.clearStaleEntityScenarios(remoteDevice, updatedEntities)
 }

--- a/usecases/usecase/events_test.go
+++ b/usecases/usecase/events_test.go
@@ -149,6 +149,211 @@ func (s *UseCaseSuite) Test_useCaseDataUpdate() {
 	assert.False(s.T(), result)
 }
 
+func (s *UseCaseSuite) Test_OnScenariosChanged() {
+	// Track callback invocations
+	var callbackEntity spineapi.EntityRemoteInterface
+	var callbackScenarios []uint
+	callbackCount := 0
+
+	s.uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		callbackEntity = entity
+		callbackScenarios = scenarios
+		callbackCount++
+	}
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.remoteDevice.Entities()[0],
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+
+	// Set up use case data with valid scenarios
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		useCaseName,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	s.uc.useCaseDataUpdate(payload)
+
+	// Callback should have been called with non-empty scenarios
+	assert.Equal(s.T(), 1, callbackCount)
+	assert.NotNil(s.T(), callbackEntity)
+	assert.NotEmpty(s.T(), callbackScenarios)
+
+	// Update with same scenarios should not trigger callback again
+	s.uc.useCaseDataUpdate(payload)
+	assert.Equal(s.T(), 1, callbackCount)
+
+	// Update with different scenarios should trigger callback
+	data = &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		useCaseName,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	s.uc.useCaseDataUpdate(payload)
+	assert.Equal(s.T(), 2, callbackCount)
+}
+
+func (s *UseCaseSuite) Test_OnScenariosChanged_EmptyScenarios() {
+	callbackCount := 0
+	s.uc.OnScenariosChanged = func(entity spineapi.EntityRemoteInterface, scenarios []uint) {
+		callbackCount++
+	}
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.remoteDevice.Entities()[0],
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+
+	// Set up use case data with wrong actor type (results in empty scenarios)
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeHeatPump, // wrong actor type
+		useCaseName,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	s.uc.useCaseDataUpdate(payload)
+
+	// Callback should NOT have been called because no scenarios matched
+	assert.Equal(s.T(), 0, callbackCount)
+}
+
+func (s *UseCaseSuite) Test_useCaseDataUpdate_UseCaseRemoved() {
+	// First, set up valid scenarios
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		useCaseName,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.remoteDevice.Entities()[0],
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.uc.useCaseDataUpdate(payload)
+
+	// Scenarios should be available
+	assert.True(s.T(), s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1))
+
+	// Now replace with a completely different use case
+	data = &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		model.UseCaseNameTypeCoordinatedEVCharging, // different use case
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	s.uc.useCaseDataUpdate(payload)
+
+	// Scenarios should now be cleared
+	assert.False(s.T(), s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1))
+	assert.False(s.T(), s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 2))
+}
+
+func (s *UseCaseSuite) Test_useCaseDataUpdate_UseCaseUnavailable() {
+	// First, set up valid scenarios
+	address := &model.FeatureAddressType{
+		Device:  s.monitoredEntity.Device().Address(),
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(0)),
+	}
+	nodeFeature := s.remoteDevice.FeatureByAddress(address)
+
+	data := &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		useCaseName,
+		"1.0.0",
+		"release",
+		true,
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	payload := spineapi.EventPayload{
+		Device:     s.remoteDevice,
+		Entity:     s.remoteDevice.Entities()[0],
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.NodeManagementUseCaseDataType{},
+	}
+	s.uc.useCaseDataUpdate(payload)
+
+	assert.True(s.T(), s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1))
+
+	// Now set the use case as unavailable
+	data = &model.NodeManagementUseCaseDataType{}
+	data.AddUseCaseSupport(
+		model.FeatureAddressType{},
+		model.UseCaseActorTypeEV,
+		useCaseName,
+		"1.0.0",
+		"release",
+		false, // unavailable
+		[]model.UseCaseScenarioSupportType{1, 2, 3})
+	_, _ = nodeFeature.UpdateData(true, model.FunctionTypeNodeManagementUseCaseData, data, nil, nil)
+
+	s.uc.useCaseDataUpdate(payload)
+
+	// Scenarios should be cleared
+	assert.False(s.T(), s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1))
+}
+
 func (s *UseCaseSuite) Test_useCaseDataUpdate_PMCP() {
 	payload := spineapi.EventPayload{
 		Device:     s.remoteDevice,

--- a/usecases/usecase/usecase.go
+++ b/usecases/usecase/usecase.go
@@ -23,6 +23,10 @@ type UseCaseBase struct {
 	EventCB            api.EntityEventCallback
 	useCaseUpdateEvent api.EventType
 
+	// Called when an entity's available scenarios change.
+	// Runs within the same goroutine as useCaseDataUpdate.
+	OnScenariosChanged func(entity spineapi.EntityRemoteInterface, scenarios []uint)
+
 	availableEntityScenarios []api.RemoteEntityScenarios // map of scenarios and their availability for each compatible remote entity
 
 	validActorTypes  []model.UseCaseActorType // valid remote actor types for this use case
@@ -214,8 +218,30 @@ func (u *UseCaseBase) updateRemoteEntityScenarios(
 		updateEvent = true
 	}
 
-	if updateEvent && u.EventCB != nil {
-		u.EventCB(entity.Device().Ski(), entity.Device(), entity, u.useCaseUpdateEvent)
+	if updateEvent {
+		if u.OnScenariosChanged != nil && len(scenarioValues) > 0 {
+			u.OnScenariosChanged(entity, scenarioValues)
+		}
+		if u.EventCB != nil {
+			u.EventCB(entity.Device().Ski(), entity.Device(), entity, u.useCaseUpdateEvent)
+		}
+	}
+}
+
+// clear scenarios for entities of a device that were not updated during useCaseDataUpdate
+func (u *UseCaseBase) clearStaleEntityScenarios(
+	device spineapi.DeviceRemoteInterface,
+	updatedEntities map[spineapi.EntityRemoteInterface]bool,
+) {
+	indices := u.entityScenarioIndicesOfDevice(device)
+	for _, idx := range indices {
+		u.mux.Lock()
+		entity := u.availableEntityScenarios[idx].Entity
+		u.mux.Unlock()
+
+		if !updatedEntities[entity] {
+			u.updateRemoteEntityScenarios(entity, nil)
+		}
 	}
 }
 


### PR DESCRIPTION
Move subscribe/bind/read from entity-added events to an OnScenariosChanged callback that fires once NodeManagementUseCaseData confirms the remote entity actually supports the use case. This prevents cross-triggering between devices running the same use case (e.g. two eg/lpc instances).

All HandleEvent data handlers are now gated by IsScenarioAvailableAtEntity so data is only processed for verified use cases. Stale scenarios are cleared when a use case is removed or set unavailable.

CS use cases (cs/lpc, cs/lpp) retain binding-driven heartbeat subscription, gated with a scenario check.

Fixes #190 and #198