### PR TITLE
Add msgCounter to function signature of result callbacks

### DIFF
--- a/examples/ced/main.go
+++ b/examples/ced/main.go
@@ -162,7 +162,7 @@ func (h *controlbox) sendLimit(entity spineapi.EntityRemoteInterface) {
 			Value:    7000,
 		}
 
-		resultCB := func(msg model.ResultDataType) {
+		resultCB := func(msg model.ResultDataType, msgCounter model.MsgCounterType) {
 			if *msg.ErrorNumber == model.ErrorNumberTypeNoError {
 				fmt.Println("Limit accepted.")
 			} else {

--- a/examples/controlbox/main.go
+++ b/examples/controlbox/main.go
@@ -156,7 +156,7 @@ func (h *controlbox) sendConsumptionLimit(entity spineapi.EntityRemoteInterface)
 			Value:    100,
 		}
 
-		resultCB := func(msg model.ResultDataType) {
+		resultCB := func(msg model.ResultDataType, msgCounter model.MsgCounterType) {
 			if *msg.ErrorNumber == model.ErrorNumberTypeNoError {
 				fmt.Println("Consumption limit accepted.")
 			} else {
@@ -205,7 +205,7 @@ func (h *controlbox) sendProductionLimit(entity spineapi.EntityRemoteInterface) 
 			Value:    100,
 		}
 
-		resultCB := func(msg model.ResultDataType) {
+		resultCB := func(msg model.ResultDataType, msgCounter model.MsgCounterType) {
 			if *msg.ErrorNumber == model.ErrorNumberTypeNoError {
 				fmt.Println("Production limit accepted.")
 			} else {

--- a/usecases/api/cem_opev.go
+++ b/usecases/api/cem_opev.go
@@ -55,7 +55,7 @@ type CemOPEVInterface interface {
 	WriteLoadControlLimits(
 		entity spineapi.EntityRemoteInterface,
 		limits []LoadLimitsPhase,
-		resultCB func(result model.ResultDataType),
+		resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 	) (*model.MsgCounterType, error)
 
 	// Scenario 2

--- a/usecases/api/cem_oscev.go
+++ b/usecases/api/cem_oscev.go
@@ -48,7 +48,7 @@ type CemOSCEVInterface interface {
 	WriteLoadControlLimits(
 		entity spineapi.EntityRemoteInterface,
 		limits []LoadLimitsPhase,
-		resultCB func(result model.ResultDataType),
+		resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 	) (*model.MsgCounterType, error)
 
 	// Scenario 2

--- a/usecases/api/eg_lpc.go
+++ b/usecases/api/eg_lpc.go
@@ -37,7 +37,7 @@ type EgLPCInterface interface {
 	WriteConsumptionLimit(
 		entity spineapi.EntityRemoteInterface,
 		limit LoadLimit,
-		resultCB func(result model.ResultDataType),
+		resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 	) (*model.MsgCounterType, error)
 
 	// Scenario 2

--- a/usecases/api/eg_lpp.go
+++ b/usecases/api/eg_lpp.go
@@ -37,7 +37,7 @@ type EgLPPInterface interface {
 	WriteProductionLimit(
 		entity spineapi.EntityRemoteInterface,
 		limit LoadLimit,
-		resultCB func(result model.ResultDataType),
+		resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 	) (*model.MsgCounterType, error)
 
 	// Scenario 2

--- a/usecases/cem/opev/public.go
+++ b/usecases/cem/opev/public.go
@@ -113,7 +113,7 @@ func (e *OPEV) LoadControlLimits(entity spineapi.EntityRemoteInterface) (
 func (e *OPEV) WriteLoadControlLimits(
 	entity spineapi.EntityRemoteInterface,
 	limits []ucapi.LoadLimitsPhase,
-	resultCB func(result model.ResultDataType),
+	resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 ) (*model.MsgCounterType, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity

--- a/usecases/cem/oscev/public.go
+++ b/usecases/cem/oscev/public.go
@@ -102,7 +102,7 @@ func (e *OSCEV) LoadControlLimits(entity spineapi.EntityRemoteInterface) (
 func (e *OSCEV) WriteLoadControlLimits(
 	entity spineapi.EntityRemoteInterface,
 	limits []ucapi.LoadLimitsPhase,
-	resultCB func(result model.ResultDataType),
+	resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 ) (*model.MsgCounterType, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity

--- a/usecases/eg/lpc/public.go
+++ b/usecases/eg/lpc/public.go
@@ -83,7 +83,7 @@ func (e *LPC) ConsumptionLimit(entity spineapi.EntityRemoteInterface) (
 func (e *LPC) WriteConsumptionLimit(
 	entity spineapi.EntityRemoteInterface,
 	limit ucapi.LoadLimit,
-	resultCB func(result model.ResultDataType),
+	resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 ) (*model.MsgCounterType, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity

--- a/usecases/eg/lpc/public_test.go
+++ b/usecases/eg/lpc/public_test.go
@@ -124,7 +124,7 @@ func (s *EgLPCSuite) Test_WriteLoadControlLimit() {
 	assert.Nil(s.T(), err)
 
 	limit.Duration = time.Duration(time.Hour * 2)
-	_, err = s.sut.WriteConsumptionLimit(s.monitoredEntity, limit, func(result model.ResultDataType) {})
+	_, err = s.sut.WriteConsumptionLimit(s.monitoredEntity, limit, func(result model.ResultDataType, msgCounter model.MsgCounterType) {})
 	assert.Nil(s.T(), err)
 }
 

--- a/usecases/eg/lpp/public.go
+++ b/usecases/eg/lpp/public.go
@@ -83,7 +83,7 @@ func (e *LPP) ProductionLimit(entity spineapi.EntityRemoteInterface) (
 func (e *LPP) WriteProductionLimit(
 	entity spineapi.EntityRemoteInterface,
 	limit ucapi.LoadLimit,
-	resultCB func(result model.ResultDataType),
+	resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 ) (*model.MsgCounterType, error) {
 	if !e.IsCompatibleEntityType(entity) {
 		return nil, api.ErrNoCompatibleEntity

--- a/usecases/eg/lpp/public_test.go
+++ b/usecases/eg/lpp/public_test.go
@@ -118,7 +118,7 @@ func (s *EgLPPSuite) Test_WriteLoadControlLimit() {
 	assert.Nil(s.T(), err)
 
 	limit.Duration = time.Duration(time.Hour * 2)
-	_, err = s.sut.WriteProductionLimit(s.monitoredEntity, limit, func(result model.ResultDataType) {})
+	_, err = s.sut.WriteProductionLimit(s.monitoredEntity, limit, func(result model.ResultDataType, msgCounter model.MsgCounterType) {})
 	assert.Nil(s.T(), err)
 }
 

--- a/usecases/internal/loadcontrol.go
+++ b/usecases/internal/loadcontrol.go
@@ -127,7 +127,7 @@ func WriteLoadControlLimit(
 	remoteEntity spineapi.EntityRemoteInterface,
 	filter model.LoadControlLimitDescriptionDataType,
 	limit ucapi.LoadLimit,
-	resultCB func(result model.ResultDataType),
+	resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 ) (*model.MsgCounterType, error) {
 	loadControl, err := client.NewLoadControl(localEntity, remoteEntity)
 	if err != nil {
@@ -181,7 +181,7 @@ func WriteLoadControlLimit(
 		cb := func(msg spineapi.ResponseMessage) {
 			response, ok := msg.Data.(*model.ResultDataType)
 			if ok {
-				resultCB(*response)
+				resultCB(*response, *msgCounter)
 			}
 		}
 		if errCB := loadControl.AddResponseCallback(*msgCounter, cb); errCB != nil {
@@ -224,7 +224,7 @@ func WriteLoadControlPhaseLimits(
 	remoteEntity spineapi.EntityRemoteInterface,
 	filter model.LoadControlLimitDescriptionDataType,
 	limits []ucapi.LoadLimitsPhase,
-	resultCB func(result model.ResultDataType),
+	resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType),
 ) (*model.MsgCounterType, error) {
 	loadControl, err := client.NewLoadControl(localEntity, remoteEntity)
 	electricalConnection, err2 := client.NewElectricalConnection(localEntity, remoteEntity)
@@ -293,7 +293,7 @@ func WriteLoadControlPhaseLimits(
 		cb := func(msg spineapi.ResponseMessage) {
 			response, ok := msg.Data.(*model.ResultDataType)
 			if ok {
-				resultCB(*response)
+				resultCB(*response, *msgCounter)
 			}
 		}
 

--- a/usecases/internal/loadcontrol_test.go
+++ b/usecases/internal/loadcontrol_test.go
@@ -846,10 +846,12 @@ func (s *InternalSuite) Test_WriteLoadControlLimit() {
 
 	s.mux.Lock()
 	cbInvoked := false
+	cbMsgCounter := model.MsgCounterType(1_000_000)
 	s.mux.Unlock()
 	cb := func(result model.ResultDataType, msgCounter model.MsgCounterType) {
 		s.mux.Lock()
 		cbInvoked = true
+		cbMsgCounter = msgCounter
 		s.mux.Unlock()
 	}
 	msgCounter, err = WriteLoadControlLimit(s.localEntity, s.monitoredEntity, filter, loadLimit, cb)
@@ -876,6 +878,7 @@ func (s *InternalSuite) Test_WriteLoadControlLimit() {
 	time.Sleep(time.Millisecond * 200)
 	s.mux.Lock()
 	assert.True(s.T(), cbInvoked)
+	assert.Equal(s.T(), *msgCounter, cbMsgCounter)
 	s.mux.Unlock()
 
 	loadLimit = ucapi.LoadLimit{
@@ -1125,10 +1128,12 @@ func (s *InternalSuite) Test_WriteLoadControlLimits() {
 
 				s.mux.Lock()
 				cbInvoked := false
+				cbMsgCounter := model.MsgCounterType(1_000_000)
 				s.mux.Unlock()
 				cb := func(result model.ResultDataType, msgCounter model.MsgCounterType) {
 					s.mux.Lock()
 					cbInvoked = true
+					cbMsgCounter = msgCounter
 					s.mux.Unlock()
 				}
 				msgCounter, err = WriteLoadControlPhaseLimits(s.localEntity, s.monitoredEntity, filter, phaseLimitValues, cb)
@@ -1159,6 +1164,7 @@ func (s *InternalSuite) Test_WriteLoadControlLimits() {
 				time.Sleep(time.Millisecond * 200)
 				s.mux.Lock()
 				assert.True(s.T(), cbInvoked)
+				assert.Equal(s.T(), *msgCounter, cbMsgCounter)
 				s.mux.Unlock()
 			}
 		})

--- a/usecases/internal/loadcontrol_test.go
+++ b/usecases/internal/loadcontrol_test.go
@@ -847,7 +847,7 @@ func (s *InternalSuite) Test_WriteLoadControlLimit() {
 	s.mux.Lock()
 	cbInvoked := false
 	s.mux.Unlock()
-	cb := func(result model.ResultDataType) {
+	cb := func(result model.ResultDataType, msgCounter model.MsgCounterType) {
 		s.mux.Lock()
 		cbInvoked = true
 		s.mux.Unlock()
@@ -1126,7 +1126,7 @@ func (s *InternalSuite) Test_WriteLoadControlLimits() {
 				s.mux.Lock()
 				cbInvoked := false
 				s.mux.Unlock()
-				cb := func(result model.ResultDataType) {
+				cb := func(result model.ResultDataType, msgCounter model.MsgCounterType) {
 					s.mux.Lock()
 					cbInvoked = true
 					s.mux.Unlock()

--- a/usecases/mocks/CemOPEVInterface.go
+++ b/usecases/mocks/CemOPEVInterface.go
@@ -643,7 +643,7 @@ func (_c *CemOPEVInterface_UpdateUseCaseAvailability_Call) RunAndReturn(run func
 }
 
 // WriteLoadControlLimits provides a mock function for the type CemOPEVInterface
-func (_mock *CemOPEVInterface) WriteLoadControlLimits(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error) {
+func (_mock *CemOPEVInterface) WriteLoadControlLimits(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
 	ret := _mock.Called(entity, limits, resultCB)
 
 	if len(ret) == 0 {
@@ -652,17 +652,17 @@ func (_mock *CemOPEVInterface) WriteLoadControlLimits(entity api.EntityRemoteInt
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType)) (*model.MsgCounterType, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)); ok {
 		return returnFunc(entity, limits, resultCB)
 	}
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType)) *model.MsgCounterType); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType, msgCounter model.MsgCounterType)) *model.MsgCounterType); ok {
 		r0 = returnFunc(entity, limits, resultCB)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType)) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType, msgCounter model.MsgCounterType)) error); ok {
 		r1 = returnFunc(entity, limits, resultCB)
 	} else {
 		r1 = ret.Error(1)
@@ -678,12 +678,12 @@ type CemOPEVInterface_WriteLoadControlLimits_Call struct {
 // WriteLoadControlLimits is a helper method to define mock.On call
 //   - entity api.EntityRemoteInterface
 //   - limits []api0.LoadLimitsPhase
-//   - resultCB func(result model.ResultDataType)
+//   - resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)
 func (_e *CemOPEVInterface_Expecter) WriteLoadControlLimits(entity interface{}, limits interface{}, resultCB interface{}) *CemOPEVInterface_WriteLoadControlLimits_Call {
 	return &CemOPEVInterface_WriteLoadControlLimits_Call{Call: _e.mock.On("WriteLoadControlLimits", entity, limits, resultCB)}
 }
 
-func (_c *CemOPEVInterface_WriteLoadControlLimits_Call) Run(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType))) *CemOPEVInterface_WriteLoadControlLimits_Call {
+func (_c *CemOPEVInterface_WriteLoadControlLimits_Call) Run(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType))) *CemOPEVInterface_WriteLoadControlLimits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 api.EntityRemoteInterface
 		if args[0] != nil {
@@ -693,9 +693,9 @@ func (_c *CemOPEVInterface_WriteLoadControlLimits_Call) Run(run func(entity api.
 		if args[1] != nil {
 			arg1 = args[1].([]api0.LoadLimitsPhase)
 		}
-		var arg2 func(result model.ResultDataType)
+		var arg2 func(result model.ResultDataType, msgCounter model.MsgCounterType)
 		if args[2] != nil {
-			arg2 = args[2].(func(result model.ResultDataType))
+			arg2 = args[2].(func(result model.ResultDataType, msgCounter model.MsgCounterType))
 		}
 		run(
 			arg0,
@@ -711,7 +711,7 @@ func (_c *CemOPEVInterface_WriteLoadControlLimits_Call) Return(msgCounterType *m
 	return _c
 }
 
-func (_c *CemOPEVInterface_WriteLoadControlLimits_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error)) *CemOPEVInterface_WriteLoadControlLimits_Call {
+func (_c *CemOPEVInterface_WriteLoadControlLimits_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)) *CemOPEVInterface_WriteLoadControlLimits_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/mocks/CemOSCEVInterface.go
+++ b/usecases/mocks/CemOSCEVInterface.go
@@ -643,7 +643,7 @@ func (_c *CemOSCEVInterface_UpdateUseCaseAvailability_Call) RunAndReturn(run fun
 }
 
 // WriteLoadControlLimits provides a mock function for the type CemOSCEVInterface
-func (_mock *CemOSCEVInterface) WriteLoadControlLimits(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error) {
+func (_mock *CemOSCEVInterface) WriteLoadControlLimits(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
 	ret := _mock.Called(entity, limits, resultCB)
 
 	if len(ret) == 0 {
@@ -652,17 +652,17 @@ func (_mock *CemOSCEVInterface) WriteLoadControlLimits(entity api.EntityRemoteIn
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType)) (*model.MsgCounterType, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)); ok {
 		return returnFunc(entity, limits, resultCB)
 	}
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType)) *model.MsgCounterType); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType, msgCounter model.MsgCounterType)) *model.MsgCounterType); ok {
 		r0 = returnFunc(entity, limits, resultCB)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType)) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, []api0.LoadLimitsPhase, func(result model.ResultDataType, msgCounter model.MsgCounterType)) error); ok {
 		r1 = returnFunc(entity, limits, resultCB)
 	} else {
 		r1 = ret.Error(1)
@@ -678,12 +678,12 @@ type CemOSCEVInterface_WriteLoadControlLimits_Call struct {
 // WriteLoadControlLimits is a helper method to define mock.On call
 //   - entity api.EntityRemoteInterface
 //   - limits []api0.LoadLimitsPhase
-//   - resultCB func(result model.ResultDataType)
+//   - resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)
 func (_e *CemOSCEVInterface_Expecter) WriteLoadControlLimits(entity interface{}, limits interface{}, resultCB interface{}) *CemOSCEVInterface_WriteLoadControlLimits_Call {
 	return &CemOSCEVInterface_WriteLoadControlLimits_Call{Call: _e.mock.On("WriteLoadControlLimits", entity, limits, resultCB)}
 }
 
-func (_c *CemOSCEVInterface_WriteLoadControlLimits_Call) Run(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType))) *CemOSCEVInterface_WriteLoadControlLimits_Call {
+func (_c *CemOSCEVInterface_WriteLoadControlLimits_Call) Run(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType))) *CemOSCEVInterface_WriteLoadControlLimits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 api.EntityRemoteInterface
 		if args[0] != nil {
@@ -693,9 +693,9 @@ func (_c *CemOSCEVInterface_WriteLoadControlLimits_Call) Run(run func(entity api
 		if args[1] != nil {
 			arg1 = args[1].([]api0.LoadLimitsPhase)
 		}
-		var arg2 func(result model.ResultDataType)
+		var arg2 func(result model.ResultDataType, msgCounter model.MsgCounterType)
 		if args[2] != nil {
-			arg2 = args[2].(func(result model.ResultDataType))
+			arg2 = args[2].(func(result model.ResultDataType, msgCounter model.MsgCounterType))
 		}
 		run(
 			arg0,
@@ -711,7 +711,7 @@ func (_c *CemOSCEVInterface_WriteLoadControlLimits_Call) Return(msgCounterType *
 	return _c
 }
 
-func (_c *CemOSCEVInterface_WriteLoadControlLimits_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error)) *CemOSCEVInterface_WriteLoadControlLimits_Call {
+func (_c *CemOSCEVInterface_WriteLoadControlLimits_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limits []api0.LoadLimitsPhase, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)) *CemOSCEVInterface_WriteLoadControlLimits_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/mocks/EgLPCInterface.go
+++ b/usecases/mocks/EgLPCInterface.go
@@ -745,7 +745,7 @@ func (_c *EgLPCInterface_UpdateUseCaseAvailability_Call) RunAndReturn(run func(a
 }
 
 // WriteConsumptionLimit provides a mock function for the type EgLPCInterface
-func (_mock *EgLPCInterface) WriteConsumptionLimit(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error) {
+func (_mock *EgLPCInterface) WriteConsumptionLimit(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
 	ret := _mock.Called(entity, limit, resultCB)
 
 	if len(ret) == 0 {
@@ -754,17 +754,17 @@ func (_mock *EgLPCInterface) WriteConsumptionLimit(entity api.EntityRemoteInterf
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType)) (*model.MsgCounterType, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)); ok {
 		return returnFunc(entity, limit, resultCB)
 	}
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType)) *model.MsgCounterType); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType, msgCounter model.MsgCounterType)) *model.MsgCounterType); ok {
 		r0 = returnFunc(entity, limit, resultCB)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType)) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType, msgCounter model.MsgCounterType)) error); ok {
 		r1 = returnFunc(entity, limit, resultCB)
 	} else {
 		r1 = ret.Error(1)
@@ -780,12 +780,12 @@ type EgLPCInterface_WriteConsumptionLimit_Call struct {
 // WriteConsumptionLimit is a helper method to define mock.On call
 //   - entity api.EntityRemoteInterface
 //   - limit api0.LoadLimit
-//   - resultCB func(result model.ResultDataType)
+//   - resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)
 func (_e *EgLPCInterface_Expecter) WriteConsumptionLimit(entity interface{}, limit interface{}, resultCB interface{}) *EgLPCInterface_WriteConsumptionLimit_Call {
 	return &EgLPCInterface_WriteConsumptionLimit_Call{Call: _e.mock.On("WriteConsumptionLimit", entity, limit, resultCB)}
 }
 
-func (_c *EgLPCInterface_WriteConsumptionLimit_Call) Run(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType))) *EgLPCInterface_WriteConsumptionLimit_Call {
+func (_c *EgLPCInterface_WriteConsumptionLimit_Call) Run(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType))) *EgLPCInterface_WriteConsumptionLimit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 api.EntityRemoteInterface
 		if args[0] != nil {
@@ -795,9 +795,9 @@ func (_c *EgLPCInterface_WriteConsumptionLimit_Call) Run(run func(entity api.Ent
 		if args[1] != nil {
 			arg1 = args[1].(api0.LoadLimit)
 		}
-		var arg2 func(result model.ResultDataType)
+		var arg2 func(result model.ResultDataType, msgCounter model.MsgCounterType)
 		if args[2] != nil {
-			arg2 = args[2].(func(result model.ResultDataType))
+			arg2 = args[2].(func(result model.ResultDataType, msgCounter model.MsgCounterType))
 		}
 		run(
 			arg0,
@@ -813,7 +813,7 @@ func (_c *EgLPCInterface_WriteConsumptionLimit_Call) Return(msgCounterType *mode
 	return _c
 }
 
-func (_c *EgLPCInterface_WriteConsumptionLimit_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error)) *EgLPCInterface_WriteConsumptionLimit_Call {
+func (_c *EgLPCInterface_WriteConsumptionLimit_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)) *EgLPCInterface_WriteConsumptionLimit_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/mocks/EgLPPInterface.go
+++ b/usecases/mocks/EgLPPInterface.go
@@ -881,7 +881,7 @@ func (_c *EgLPPInterface_WriteFailsafeProductionActivePowerLimit_Call) RunAndRet
 }
 
 // WriteProductionLimit provides a mock function for the type EgLPPInterface
-func (_mock *EgLPPInterface) WriteProductionLimit(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error) {
+func (_mock *EgLPPInterface) WriteProductionLimit(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
 	ret := _mock.Called(entity, limit, resultCB)
 
 	if len(ret) == 0 {
@@ -890,17 +890,17 @@ func (_mock *EgLPPInterface) WriteProductionLimit(entity api.EntityRemoteInterfa
 
 	var r0 *model.MsgCounterType
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType)) (*model.MsgCounterType, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)); ok {
 		return returnFunc(entity, limit, resultCB)
 	}
-	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType)) *model.MsgCounterType); ok {
+	if returnFunc, ok := ret.Get(0).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType, msgCounter model.MsgCounterType)) *model.MsgCounterType); ok {
 		r0 = returnFunc(entity, limit, resultCB)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.MsgCounterType)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType)) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(api.EntityRemoteInterface, api0.LoadLimit, func(result model.ResultDataType, msgCounter model.MsgCounterType)) error); ok {
 		r1 = returnFunc(entity, limit, resultCB)
 	} else {
 		r1 = ret.Error(1)
@@ -916,12 +916,12 @@ type EgLPPInterface_WriteProductionLimit_Call struct {
 // WriteProductionLimit is a helper method to define mock.On call
 //   - entity api.EntityRemoteInterface
 //   - limit api0.LoadLimit
-//   - resultCB func(result model.ResultDataType)
+//   - resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)
 func (_e *EgLPPInterface_Expecter) WriteProductionLimit(entity interface{}, limit interface{}, resultCB interface{}) *EgLPPInterface_WriteProductionLimit_Call {
 	return &EgLPPInterface_WriteProductionLimit_Call{Call: _e.mock.On("WriteProductionLimit", entity, limit, resultCB)}
 }
 
-func (_c *EgLPPInterface_WriteProductionLimit_Call) Run(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType))) *EgLPPInterface_WriteProductionLimit_Call {
+func (_c *EgLPPInterface_WriteProductionLimit_Call) Run(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType))) *EgLPPInterface_WriteProductionLimit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 api.EntityRemoteInterface
 		if args[0] != nil {
@@ -931,9 +931,9 @@ func (_c *EgLPPInterface_WriteProductionLimit_Call) Run(run func(entity api.Enti
 		if args[1] != nil {
 			arg1 = args[1].(api0.LoadLimit)
 		}
-		var arg2 func(result model.ResultDataType)
+		var arg2 func(result model.ResultDataType, msgCounter model.MsgCounterType)
 		if args[2] != nil {
-			arg2 = args[2].(func(result model.ResultDataType))
+			arg2 = args[2].(func(result model.ResultDataType, msgCounter model.MsgCounterType))
 		}
 		run(
 			arg0,
@@ -949,7 +949,7 @@ func (_c *EgLPPInterface_WriteProductionLimit_Call) Return(msgCounterType *model
 	return _c
 }
 
-func (_c *EgLPPInterface_WriteProductionLimit_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType)) (*model.MsgCounterType, error)) *EgLPPInterface_WriteProductionLimit_Call {
+func (_c *EgLPPInterface_WriteProductionLimit_Call) RunAndReturn(run func(entity api.EntityRemoteInterface, limit api0.LoadLimit, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error)) *EgLPPInterface_WriteProductionLimit_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This simplifies usage of the result callback as you can use the msgCounter in the callback to determine which message the response correlates to and don't need to provide that information out-of-band.