### PR TITLE
Fixed examples for LPP in HEMS and Controlbox

### DIFF
--- a/examples/controlbox/main.go
+++ b/examples/controlbox/main.go
@@ -199,10 +199,13 @@ func (h *controlbox) sendProductionLimit(entity spineapi.EntityRemoteInterface) 
 
 	fmt.Println("Sending a production limit in 5s...")
 	time.AfterFunc(time.Second*5, func() {
+		// NOTE: Per the LPP spec, APPL (Active Power Limit) values for production
+		// must be <= 0. The eebus-go stack does not transform positive values to
+		// negative values, so the caller must provide the correct sign.
 		limit := ucapi.LoadLimit{
 			Duration: time.Hour*1 + time.Minute*2 + time.Second*3,
 			IsActive: true,
-			Value:    100,
+			Value:    -100,
 		}
 
 		resultCB := func(msg model.ResultDataType) {

--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -126,13 +126,16 @@ func (h *hems) run() {
 	_ = h.uccslpc.SetFailsafeConsumptionActivePowerLimit(4200, true)
 	_ = h.uccslpc.SetFailsafeDurationMinimum(2*time.Hour, true)
 
-	_ = h.uccslpp.SetProductionNominalMax(10000)
+	// NOTE: Per the LPP spec, APPL (Active Power Limit) values for production
+	// must be <= 0. The eebus-go stack does not transform positive values to
+	// negative values, so the caller must provide the correct sign.
+	_ = h.uccslpp.SetProductionNominalMax(-10000)
 	_ = h.uccslpp.SetProductionLimit(ucapi.LoadLimit{
-		Value:        10000,
+		Value:        -10000,
 		IsChangeable: true,
 		IsActive:     false,
 	})
-	_ = h.uccslpp.SetFailsafeProductionActivePowerLimit(4200, true)
+	_ = h.uccslpp.SetFailsafeProductionActivePowerLimit(-4200, true)
 	_ = h.uccslpp.SetFailsafeDurationMinimum(2*time.Hour, true)
 
 	if len(remoteSki) == 0 {

--- a/usecases/api/eg_lpc.go
+++ b/usecases/api/eg_lpc.go
@@ -65,8 +65,6 @@ type EgLPCInterface interface {
 	// parameters:
 	//   - entity: the entity of the e.g. EVSE
 	//
-	// return values:
-	//   - negative values are used for production
 	FailsafeDurationMinimum(entity spineapi.EntityRemoteInterface) (time.Duration, error)
 
 	// send new Failsafe Duration Minimum

--- a/usecases/api/eg_lpp.go
+++ b/usecases/api/eg_lpp.go
@@ -49,7 +49,7 @@ type EgLPPInterface interface {
 	//   - entity: the entity of the e.g. EVSE
 	//
 	// return values:
-	//   - positive values are used for production
+	//   - negative values or 0 are used for production
 	FailsafeProductionActivePowerLimit(entity spineapi.EntityRemoteInterface) (float64, error)
 
 	// send new Failsafe Production Active Power Limit
@@ -65,8 +65,6 @@ type EgLPPInterface interface {
 	// parameters:
 	//   - entity: the entity of the e.g. EVSE
 	//
-	// return values:
-	//   - negative values are used for production
 	FailsafeDurationMinimum(entity spineapi.EntityRemoteInterface) (time.Duration, error)
 
 	// send new Failsafe Duration Minimum


### PR DESCRIPTION
LPP use case shall use negative numbers to show that the stack does not transform positive numbers to negative numbers.