### PR TITLE
Revert LPP Failsafe values back to positive values in the examples

### DIFF
--- a/examples/hems/main.go
+++ b/examples/hems/main.go
@@ -129,13 +129,13 @@ func (h *hems) run() {
 	// NOTE: Per the LPP spec, APPL (Active Power Limit) values for production
 	// must be <= 0. The eebus-go stack does not transform positive values to
 	// negative values, so the caller must provide the correct sign.
-	_ = h.uccslpp.SetProductionNominalMax(-10000)
+	_ = h.uccslpp.SetProductionNominalMax(10000)
 	_ = h.uccslpp.SetProductionLimit(ucapi.LoadLimit{
 		Value:        -10000,
 		IsChangeable: true,
 		IsActive:     false,
 	})
-	_ = h.uccslpp.SetFailsafeProductionActivePowerLimit(-4200, true)
+	_ = h.uccslpp.SetFailsafeProductionActivePowerLimit(4200, true)
 	_ = h.uccslpp.SetFailsafeDurationMinimum(2*time.Hour, true)
 
 	if len(remoteSki) == 0 {

--- a/usecases/api/eg_lpp.go
+++ b/usecases/api/eg_lpp.go
@@ -49,7 +49,7 @@ type EgLPPInterface interface {
 	//   - entity: the entity of the e.g. EVSE
 	//
 	// return values:
-	//   - negative values or 0 are used for production
+	//   - positive values are used for production
 	FailsafeProductionActivePowerLimit(entity spineapi.EntityRemoteInterface) (float64, error)
 
 	// send new Failsafe Production Active Power Limit


### PR DESCRIPTION
Per the spec, the values are always >= 0 because their name already indicates the production direction Only the APPL value itself (the LoadLimit.Value in SetProductionLimit and WriteProductionLimit) remains <= 0 (-10000 in HEMS, -100 in controlbox), since that's the SignDependentAbsValueLimit where sign matters.