### PR TITLE
Fix wrong parameter description selection in LoadControlLimits

### DIFF
--- a/usecases/internal/loadcontrol.go
+++ b/usecases/internal/loadcontrol.go
@@ -50,25 +50,39 @@ func LoadControlLimits(
 		filter := model.ElectricalConnectionParameterDescriptionDataType{
 			AcMeasuredPhases: &phaseName,
 		}
-		elParamDesc, err := evElectricalConnection.GetParameterDescriptionsForFilter(filter)
-		if err != nil || len(elParamDesc) == 0 || elParamDesc[0].MeasurementId == nil {
+		elParamDescs, err := evElectricalConnection.GetParameterDescriptionsForFilter(filter)
+		if err != nil || len(elParamDescs) == 0 {
 			// there is no data for this phase, the phase may not exist
 			// so do not add id to the result
 			continue
 		}
 
+		// A phase may have several parameter descriptions (e.g. current, voltage, power).
+		// Pick the one whose MeasurementId is referenced by one of the limit descriptions —
+		// blindly using elParamDescs[0] would resolve the limit against the wrong measurement
+		// type when a conformant remote lists them in an unexpected order.
+		var paramDesc *model.ElectricalConnectionParameterDescriptionDataType
 		var limitDesc *model.LoadControlLimitDescriptionDataType
-		for _, desc := range limitDescriptions {
-			if desc.MeasurementId != nil &&
-				elParamDesc[0].MeasurementId != nil &&
-				*desc.MeasurementId == *elParamDesc[0].MeasurementId {
+		for _, pd := range elParamDescs {
+			if pd.MeasurementId == nil {
+				continue
+			}
+			for _, desc := range limitDescriptions {
+				if desc.MeasurementId == nil || *desc.MeasurementId != *pd.MeasurementId {
+					continue
+				}
+				safePD := pd
 				safeDesc := desc
+				paramDesc = &safePD
 				limitDesc = &safeDesc
+				break
+			}
+			if limitDesc != nil {
 				break
 			}
 		}
 
-		if limitDesc == nil || limitDesc.LimitId == nil {
+		if paramDesc == nil || limitDesc == nil || limitDesc.LimitId == nil {
 			return
 		}
 
@@ -81,7 +95,7 @@ func LoadControlLimits(
 		if limitIdData.Value == nil || (limitIdData.IsLimitActive != nil && !*limitIdData.IsLimitActive) {
 			// report maximum possible if no limit is available or the limit is not active
 			filter := model.ElectricalConnectionPermittedValueSetDataType{
-				ParameterId: elParamDesc[0].ParameterId,
+				ParameterId: paramDesc.ParameterId,
 			}
 			_, dataMax, _, err := evElectricalConnection.GetPermittedValueDataForFilter(filter)
 			if err != nil {
@@ -244,23 +258,37 @@ func WriteLoadControlPhaseLimits(
 		filter2 := model.ElectricalConnectionParameterDescriptionDataType{
 			AcMeasuredPhases: util.Ptr(phaseLimit.Phase),
 		}
-		elParamDesc, err := electricalConnection.GetParameterDescriptionsForFilter(filter2)
-		if err != nil || len(elParamDesc) == 0 || elParamDesc[0].MeasurementId == nil {
+		elParamDescs, err := electricalConnection.GetParameterDescriptionsForFilter(filter2)
+		if err != nil || len(elParamDescs) == 0 {
 			continue
 		}
 
+		// A phase may have several parameter descriptions (e.g. current, voltage, power).
+		// Pick the one whose MeasurementId is referenced by one of the limit descriptions —
+		// blindly using elParamDescs[0] would resolve the limit against the wrong measurement
+		// type when a conformant remote lists them in an unexpected order.
+		var paramDesc *model.ElectricalConnectionParameterDescriptionDataType
 		var limitDesc *model.LoadControlLimitDescriptionDataType
-		for _, desc := range limitDescriptions {
-			if desc.MeasurementId != nil &&
-				elParamDesc[0].MeasurementId != nil &&
-				*desc.MeasurementId == *elParamDesc[0].MeasurementId {
+		for _, pd := range elParamDescs {
+			if pd.MeasurementId == nil {
+				continue
+			}
+			for _, desc := range limitDescriptions {
+				if desc.MeasurementId == nil || *desc.MeasurementId != *pd.MeasurementId {
+					continue
+				}
+				safePD := pd
 				safeDesc := desc
+				paramDesc = &safePD
 				limitDesc = &safeDesc
+				break
+			}
+			if limitDesc != nil {
 				break
 			}
 		}
 
-		if limitDesc == nil || limitDesc.LimitId == nil {
+		if paramDesc == nil || paramDesc.ParameterId == nil || limitDesc == nil || limitDesc.LimitId == nil {
 			continue
 		}
 
@@ -277,7 +305,7 @@ func WriteLoadControlPhaseLimits(
 
 		// electricalPermittedValueSet contains the allowed min, max and the default values per phase
 		limit := electricalConnection.AdjustValueToBeWithinPermittedValuesForParameterId(
-			phaseLimit.Value, *elParamDesc[0].ParameterId)
+			phaseLimit.Value, *paramDesc.ParameterId)
 
 		newLimit := model.LoadControlLimitDataType{
 			LimitId:       limitDesc.LimitId,

--- a/usecases/internal/loadcontrol_test.go
+++ b/usecases/internal/loadcontrol_test.go
@@ -1164,3 +1164,165 @@ func (s *InternalSuite) Test_WriteLoadControlLimits() {
 		})
 	}
 }
+
+// Regression for https://github.com/enbility/eebus-go/issues/217 — a remote may
+// expose more than one ElectricalConnectionParameterDescription per phase (e.g.
+// voltage and current). The resolver must pick the description whose
+// MeasurementId is referenced by a LoadControlLimitDescription rather than
+// blindly using the first entry.
+func (s *InternalSuite) Test_LoadControl_MultipleParameterDescriptionsPerPhase() {
+	filter := model.LoadControlLimitDescriptionDataType{
+		LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+		LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+		ScopeType:     util.Ptr(model.ScopeTypeTypeSelfConsumption),
+	}
+
+	// Limit descriptions reference only current measurements (ids 0/1/2).
+	descData := &model.LoadControlLimitDescriptionListDataType{
+		LoadControlLimitDescriptionData: []model.LoadControlLimitDescriptionDataType{
+			{
+				LimitId:       util.Ptr(model.LoadControlLimitIdType(0)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+				MeasurementId: util.Ptr(model.MeasurementIdType(0)),
+				LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				ScopeType:     util.Ptr(model.ScopeTypeTypeSelfConsumption),
+			},
+			{
+				LimitId:       util.Ptr(model.LoadControlLimitIdType(1)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+				MeasurementId: util.Ptr(model.MeasurementIdType(1)),
+				LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				ScopeType:     util.Ptr(model.ScopeTypeTypeSelfConsumption),
+			},
+			{
+				LimitId:       util.Ptr(model.LoadControlLimitIdType(2)),
+				LimitCategory: util.Ptr(model.LoadControlCategoryTypeObligation),
+				MeasurementId: util.Ptr(model.MeasurementIdType(2)),
+				LimitType:     util.Ptr(model.LoadControlLimitTypeTypeMaxValueLimit),
+				ScopeType:     util.Ptr(model.ScopeTypeTypeSelfConsumption),
+			},
+		},
+	}
+	rLcFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeLoadControl, model.RoleTypeServer)
+	_, fErr := rLcFeature.UpdateData(true, model.FunctionTypeLoadControlLimitDescriptionListData, descData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	// For each phase, a non-matching parameter description (voltage, ids 10/11/12)
+	// is listed BEFORE the current description (ids 0/1/2). With the legacy
+	// behavior, elParamDescs[0] is voltage and resolution fails.
+	paramData := &model.ElectricalConnectionParameterDescriptionListDataType{
+		ElectricalConnectionParameterDescriptionData: []model.ElectricalConnectionParameterDescriptionDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(10)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(10)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(0)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(0)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeA),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(11)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(11)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(1)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(1)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeB),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(12)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(12)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeC),
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(2)),
+				MeasurementId:          util.Ptr(model.MeasurementIdType(2)),
+				AcMeasuredPhases:       util.Ptr(model.ElectricalConnectionPhaseNameTypeC),
+			},
+		},
+	}
+	rElFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+	_, fErr = rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionParameterDescriptionListData, paramData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	limitData := &model.LoadControlLimitListDataType{
+		LoadControlLimitData: []model.LoadControlLimitDataType{
+			{
+				LimitId:           util.Ptr(model.LoadControlLimitIdType(0)),
+				IsLimitChangeable: util.Ptr(true),
+				IsLimitActive:     util.Ptr(true),
+				Value:             model.NewScaledNumberType(11),
+			},
+			{
+				LimitId:           util.Ptr(model.LoadControlLimitIdType(1)),
+				IsLimitChangeable: util.Ptr(true),
+				IsLimitActive:     util.Ptr(true),
+				Value:             model.NewScaledNumberType(12),
+			},
+			{
+				LimitId:           util.Ptr(model.LoadControlLimitIdType(2)),
+				IsLimitChangeable: util.Ptr(true),
+				IsLimitActive:     util.Ptr(true),
+				Value:             model.NewScaledNumberType(13),
+			},
+		},
+	}
+	_, fErr = rLcFeature.UpdateData(true, model.FunctionTypeLoadControlLimitListData, limitData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	permData := &model.ElectricalConnectionPermittedValueSetListDataType{
+		ElectricalConnectionPermittedValueSetData: []model.ElectricalConnectionPermittedValueSetDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(0)),
+				PermittedValueSet: []model.ScaledNumberSetType{
+					{Range: []model.ScaledNumberRangeType{{Min: model.NewScaledNumberType(6), Max: model.NewScaledNumberType(16)}}},
+				},
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(1)),
+				PermittedValueSet: []model.ScaledNumberSetType{
+					{Range: []model.ScaledNumberRangeType{{Min: model.NewScaledNumberType(6), Max: model.NewScaledNumberType(16)}}},
+				},
+			},
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(2)),
+				PermittedValueSet: []model.ScaledNumberSetType{
+					{Range: []model.ScaledNumberRangeType{{Min: model.NewScaledNumberType(6), Max: model.NewScaledNumberType(16)}}},
+				},
+			},
+		},
+	}
+	_, fErr = rElFeature.UpdateData(true, model.FunctionTypeElectricalConnectionPermittedValueSetListData, permData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	// Read path: the resolver must walk past voltage descriptions and return
+	// the current limit value for each phase.
+	data, err := LoadControlLimits(s.localEntity, s.monitoredEntity, filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 3, len(data))
+	assert.Equal(s.T(), 11.0, data[0].Value)
+	assert.Equal(s.T(), 12.0, data[1].Value)
+	assert.Equal(s.T(), 13.0, data[2].Value)
+
+	// Write path: must resolve to the current LimitId for each phase.
+	writeLimits := []ucapi.LoadLimitsPhase{
+		{Phase: model.ElectricalConnectionPhaseNameTypeA, IsActive: true, Value: 10},
+		{Phase: model.ElectricalConnectionPhaseNameTypeB, IsActive: true, Value: 10},
+		{Phase: model.ElectricalConnectionPhaseNameTypeC, IsActive: true, Value: 10},
+	}
+	msgCounter, err := WriteLoadControlPhaseLimits(s.localEntity, s.monitoredEntity, filter, writeLimits, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), msgCounter)
+}


### PR DESCRIPTION
Fixes #217.

Asked Claude for a fix since [evcc-io/evcc](https://github.com/evcc-io/evcc) uses both opev and oscev. Fix is LGTM.

## Problem

`LoadControlLimits` and `WriteLoadControlPhaseLimits` in `usecases/internal/loadcontrol.go` looked up `ElectricalConnectionParameterDescription` entries filtered only by `AcMeasuredPhases` and then blindly used `elParamDesc[0]`. If a remote device exposes more than one description per phase (e.g. current and voltage), the wrong entry could be picked and the limit would be resolved against an unrelated `MeasurementId` / `ParameterId`. Additionally, `*elParamDesc[0].ParameterId` was dereferenced without a nil guard on the write side, which could panic against a conformant remote that omits the optional `ParameterId`.

Not observed on Elli, Porsche MCC, or SMA HEM 2.0 (they only expose current descriptions), but a conformant device is allowed to expose more — and the bug surfaces whenever a non-current description is listed first.

## Fix

Walk all parameter descriptions for the phase and pick the one whose `MeasurementId` is referenced by one of the limit descriptions, then use that description's `ParameterId` for the permitted-value lookup / adjustment. Adds the missing `ParameterId` nil guard on the write path.

The four public entry points are all thin wrappers over the two internal helpers and inherit the fix:

- `opev.OPEV.LoadControlLimits` / `opev.OPEV.WriteLoadControlLimits`
- `oscev.OSCEV.LoadControlLimits` / `oscev.OSCEV.WriteLoadControlLimits`

