### PR TITLE
Add missing nil/length guards before pointer dereferences

### DIFF
--- a/usecases/cem/cevc/public_scen3.go
+++ b/usecases/cem/cevc/public_scen3.go
@@ -66,6 +66,9 @@ func (e *CEVC) WriteIncentiveTableDescriptions(entity spineapi.EntityRemoteInter
 		logging.Log().Error(err)
 		return err
 	}
+	if len(descriptions) == 0 {
+		return api.ErrDataNotAvailable
+	}
 
 	// default tariff
 	//

--- a/usecases/cem/evcem/public.go
+++ b/usecases/cem/evcem/public.go
@@ -128,6 +128,7 @@ func (e *EVCEM) PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64,
 			}
 			elParam, err := evElectricalConnection.GetParameterDescriptionsForFilter(filter)
 			if err != nil || len(elParam) == 0 ||
+				elParam[0].AcMeasuredPhases == nil ||
 				*elParam[0].AcMeasuredPhases != phase {
 				continue
 			}

--- a/usecases/eg/lpc/public.go
+++ b/usecases/eg/lpc/public.go
@@ -51,7 +51,7 @@ func (e *LPC) ConsumptionLimit(entity spineapi.EntityRemoteInterface) (
 		ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 	}
 	limitDescriptions, err := loadControl.GetLimitDescriptionsForFilter(filter)
-	if err != nil || len(limitDescriptions) != 1 {
+	if err != nil || len(limitDescriptions) != 1 || limitDescriptions[0].LimitId == nil {
 		return
 	}
 

--- a/usecases/eg/lpp/public.go
+++ b/usecases/eg/lpp/public.go
@@ -51,7 +51,7 @@ func (e *LPP) ProductionLimit(entity spineapi.EntityRemoteInterface) (
 		ScopeType:      util.Ptr(model.ScopeTypeTypeActivePowerLimit),
 	}
 	limitDescriptions, err := loadControl.GetLimitDescriptionsForFilter(filter)
-	if err != nil || len(limitDescriptions) != 1 {
+	if err != nil || len(limitDescriptions) != 1 || limitDescriptions[0].LimitId == nil {
 		return
 	}
 


### PR DESCRIPTION
Follow-up to #218.

While fixing #217, I audited the codebase for the same class of bug — a slice element subfield dereferenced without a nil guard, or `[0]` indexing without a `len > 0` check. EEBus model fields are almost all `*T` and optional per spec, so a conformant remote that omits one of them would panic the client.

## Findings

| File | Site | Pattern |
| --- | --- | --- |
| `usecases/cem/evcem/public.go` | `PowerPerPhase` | `*elParam[0].AcMeasuredPhases` dereferenced; only `len(elParam) == 0` was guarded. `AcMeasuredPhases` is optional. |
| `usecases/cem/cevc/public_scen3.go` | `WriteIncentiveTableDescriptions` | `descriptions[0].TariffDescription` accessed after only an error check; no `len(descriptions) > 0` guard. |
| `usecases/eg/lpc/public.go` | `ConsumptionLimit` | `*limitDescriptions[0].LimitId` dereferenced; `len(limitDescriptions) != 1` was guarded but `LimitId == nil` was not. |
| `usecases/eg/lpp/public.go` | `ProductionLimit` | Same pattern as `lpc/public.go`. |

Each site adds the missing guard and bails out early (`continue` / early return / `api.ErrDataNotAvailable`).

## Test

No fixture changes — these are defensive guards against malformed remote data and the existing per-usecase test suites continue to pass:

```
go test ./usecases/cem/evcem/... ./usecases/cem/cevc/... ./usecases/eg/lpc/... ./usecases/eg/lpp/...
ok  github.com/enbility/eebus-go/usecases/cem/evcem
ok  github.com/enbility/eebus-go/usecases/cem/cevc
ok  github.com/enbility/eebus-go/usecases/eg/lpc
ok  github.com/enbility/eebus-go/usecases/eg/lpp
```

Building and vetting the full module is clean.