### PR TITLE
EG LPC: subscribe and read electrical connection characteristics

### DIFF
--- a/usecases/eg/lpc/events.go
+++ b/usecases/eg/lpc/events.go
@@ -41,6 +41,9 @@ func (e *LPC) HandleEvent(payload spineapi.EventPayload) {
 
 	case *model.DeviceConfigurationKeyValueListDataType:
 		e.configurationDataUpdate(payload)
+
+	case *model.ElectricalConnectionCharacteristicListDataType:
+		e.electricalConnectionCharacteristicDataUpdate(payload)
 	}
 }
 
@@ -91,6 +94,19 @@ func (e *LPC) connected(entity spineapi.EntityRemoteInterface) {
 		}
 	}
 
+	if electricalConnection, err := client.NewElectricalConnection(e.LocalEntity, entity); err == nil {
+		if !electricalConnection.HasSubscription() {
+			if _, err := electricalConnection.Subscribe(); err != nil {
+				logging.Log().Debug(err)
+			}
+		}
+
+		// get the current characteristics, e.g. the nominal max consumption
+		if _, err := electricalConnection.RequestCharacteristics(nil, nil); err != nil {
+			logging.Log().Debug(err)
+		}
+	}
+
 	if deviceDiagnosis, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
 		if !deviceDiagnosis.HasSubscription() {
 			if _, err := deviceDiagnosis.Subscribe(); err != nil {
@@ -136,6 +152,14 @@ func (e *LPC) loadControlLimitDataUpdate(payload spineapi.EventPayload) {
 		if lc.CheckEventPayloadDataForFilter(payload.Data, filter) && e.EventCB != nil {
 			e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateLimit)
 		}
+	}
+}
+
+// the electrical connection characteristic data was updated
+func (e *LPC) electricalConnectionCharacteristicDataUpdate(payload spineapi.EventPayload) {
+	// only inform about an update if the nominal max consumption is available
+	if _, err := e.ConsumptionNominalMax(payload.Entity); err == nil && e.EventCB != nil {
+		e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateConsumptionNominalMax)
 	}
 }
 

--- a/usecases/eg/lpc/events_test.go
+++ b/usecases/eg/lpc/events_test.go
@@ -41,6 +41,9 @@ func (s *EgLPCSuite) Test_Events() {
 	payload.Data = util.Ptr(model.DeviceConfigurationKeyValueListDataType{})
 	s.sut.HandleEvent(payload)
 
+	payload.Data = util.Ptr(model.ElectricalConnectionCharacteristicListDataType{})
+	s.sut.HandleEvent(payload)
+
 	payload.EventType = spineapi.EventTypeDataChange
 	payload.ChangeType = spineapi.ElementChangeUpdate
 	payload.Function = model.FunctionTypeDeviceDiagnosisHeartbeatData
@@ -190,5 +193,34 @@ func (s *EgLPCSuite) Test_configurationDataUpdate() {
 	payload.Data = data
 
 	s.sut.configurationDataUpdate(payload)
+	assert.True(s.T(), s.eventCalled)
+}
+
+func (s *EgLPCSuite) Test_electricalConnectionCharacteristicDataUpdate() {
+	payload := spineapi.EventPayload{
+		Ski:    remoteSki,
+		Device: s.remoteDevice,
+		Entity: s.monitoredEntity,
+	}
+	s.sut.electricalConnectionCharacteristicDataUpdate(payload)
+	assert.False(s.T(), s.eventCalled)
+
+	charData := &model.ElectricalConnectionCharacteristicListDataType{
+		ElectricalConnectionCharacteristicData: []model.ElectricalConnectionCharacteristicDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(0)),
+				CharacteristicId:       util.Ptr(model.ElectricalConnectionCharacteristicIdType(0)),
+				CharacteristicContext:  util.Ptr(model.ElectricalConnectionCharacteristicContextTypeEntity),
+				CharacteristicType:     util.Ptr(model.ElectricalConnectionCharacteristicTypeTypePowerConsumptionNominalMax),
+				Value:                  model.NewScaledNumberType(8000),
+			},
+		},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeServer)
+	_, fErr := rFeature.UpdateData(true, model.FunctionTypeElectricalConnectionCharacteristicListData, charData, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	s.sut.electricalConnectionCharacteristicDataUpdate(payload)
 	assert.True(s.T(), s.eventCalled)
 }

--- a/usecases/eg/lpc/types.go
+++ b/usecases/eg/lpc/types.go
@@ -36,4 +36,12 @@ const (
 	//
 	// Use Case LPC, Scenario 3
 	DataUpdateHeartbeat api.EventType = "eg-lpc-DataUpdateHeartbeat"
+
+	// Nominal maximum active (real) power the Controllable System is able to
+	// consume data updated
+	//
+	// Use `ConsumptionNominalMax` to get the current data
+	//
+	// Use Case LPC, Scenario 4
+	DataUpdateConsumptionNominalMax api.EventType = "eg-lpc-DataUpdateConsumptionNominalMax"
 )


### PR DESCRIPTION
## Problem

The EG LPC use case has a `ConsumptionNominalMax` getter, but `connected()` only set up subscriptions/reads for LoadControl, DeviceConfiguration and DeviceDiagnosis — never for ElectricalConnection. As a result the value is only ever populated by an unsolicited partial notify from the controllable system, so:

- a value `Set` before a subscriber exists is never delivered (#225), and
- there is no subscription/notification for changes (#173).

The getter therefore returns `ErrDataNotAvailable` until the CS happens to re-send the characteristic to an already-connected subscriber.

## Fix

- On connect, subscribe to the remote ElectricalConnection feature and read its characteristics, so the current nominal max is fetched immediately.
- Dispatch `ElectricalConnectionCharacteristicListData` updates and emit a new `DataUpdateConsumptionNominalMax` event when the nominal max becomes available.

Mirrors the existing DeviceConfiguration handling. Test added covering both the dispatch case and the handler.

Fixes #225, #173
