### PR TITLE
Fix validActorTypes for GCP MGCP use case.

### DIFF
--- a/usecases/gcp/mgcp/usecase.go
+++ b/usecases/gcp/mgcp/usecase.go
@@ -63,7 +63,7 @@ func NewMGCP(
 		return nil, errors.New("monitorEnergyConfig must be set")
 	}
 
-	validActorTypes := []model.UseCaseActorType{model.UseCaseActorTypeGridConnectionPoint}
+	validActorTypes := []model.UseCaseActorType{model.UseCaseActorTypeMonitoringAppliance}
 	useCaseScenarios := make([]api.UseCaseScenario, 0)
 
 	if monitorFeedInLimitationConfig != nil {


### PR DESCRIPTION
validActorTypes contains the valid remote actors, not which actors are valid locally.