### PR TITLE
feat: handle EV heartbeats in OPEV/OSCEV Energy Guard (#237)

### DIFF
--- a/usecases/cem/opev/events.go
+++ b/usecases/cem/opev/events.go
@@ -22,6 +22,11 @@ func (e *OPEV) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 
+	if internal.IsHeartbeat(payload) && e.EventCB != nil {
+		e.EventCB(payload.Ski, payload.Device, payload.Entity, DataUpdateHeartbeat)
+		return
+	}
+
 	if payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
@@ -69,6 +74,19 @@ func (e *OPEV) evConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get constraints
 		if _, err := evLoadControl.RequestLimitConstraints(nil, nil); err != nil {
+			logging.Log().Debug(err)
+		}
+	}
+
+	// subscribe to the EV's heartbeats, so a missing EV can be detected
+	if evDeviceDiagnosis, err := client.NewDeviceDiagnosis(e.LocalEntity, entity); err == nil {
+		if !evDeviceDiagnosis.HasSubscription() {
+			if _, err := evDeviceDiagnosis.Subscribe(); err != nil {
+				logging.Log().Debug(err)
+			}
+		}
+
+		if _, err := evDeviceDiagnosis.RequestHeartbeat(); err != nil {
 			logging.Log().Debug(err)
 		}
 	}

--- a/usecases/cem/opev/events_test.go
+++ b/usecases/cem/opev/events_test.go
@@ -42,6 +42,21 @@ func (s *CemOPEVSuite) Test_Events() {
 	s.sut.HandleEvent(payload)
 }
 
+func (s *CemOPEVSuite) Test_Heartbeat() {
+	payload := spineapi.EventPayload{
+		Ski:           remoteSki,
+		Device:        s.remoteDevice,
+		Entity:        s.evEntity,
+		EventType:     spineapi.EventTypeDataChange,
+		ChangeType:    spineapi.ElementChangeUpdate,
+		Function:      model.FunctionTypeDeviceDiagnosisHeartbeatData,
+		CmdClassifier: util.Ptr(model.CmdClassifierTypeNotify),
+		Data:          util.Ptr(model.DeviceDiagnosisHeartbeatDataType{}),
+	}
+	s.sut.HandleEvent(payload)
+	assert.True(s.T(), s.eventCalled)
+}
+
 func (s *CemOPEVSuite) Test_Failures() {
 	s.sut.evConnected(s.mockRemoteEntity)
 

--- a/usecases/cem/opev/types.go
+++ b/usecases/cem/opev/types.go
@@ -17,4 +17,9 @@ const (
 	//
 	// Use `LoadControlLimits` to get the current data
 	DataUpdateLimit api.EventType = "cem-opev-DataUpdateLimit"
+
+	// EV sent a heartbeat via its DeviceDiagnosis server
+	//
+	// This can be used to detect a missing EV, e.g. to enter a failsafe state
+	DataUpdateHeartbeat api.EventType = "cem-opev-DataUpdateHeartbeat"
 )

--- a/usecases/cem/opev/usecase.go
+++ b/usecases/cem/opev/usecase.go
@@ -74,6 +74,7 @@ func (e *OPEV) AddFeatures() {
 	var clientFeatures = []model.FeatureTypeType{
 		model.FeatureTypeTypeLoadControl,
 		model.FeatureTypeTypeElectricalConnection,
+		model.FeatureTypeTypeDeviceDiagnosis,
 	}
 	for _, feature := range clientFeatures {
 		_ = e.LocalEntity.GetOrAddFeature(feature, model.RoleTypeClient)


### PR DESCRIPTION
Fixes #237

## Problem

The Energy Guard (CEM) side of OPEV/OSCEV registers the `DeviceDiagnosis`
heartbeat server read-only but never subscribes to the remote EV's heartbeat,
so it has no way to detect a missing EV via `notify`. This is exactly the
pre-#120 state that `eg/lpc` and `eg/lpp` were in, and issue #237 asks for the
same treatment.

## Change

On EV connect, `opev.evConnected` now:

- adds `DeviceDiagnosis` as a client feature,
- creates a `DeviceDiagnosis` client, subscribes, and requests the heartbeat,

mirroring `eg/lpc`/`eg/lpp`. Incoming heartbeat notifies are surfaced as a new
`DataUpdateHeartbeat` event (mirroring `cs/lpc`), so the application can react
to a missing EV, e.g. to enter a failsafe state per the OPEV spec (§3.4.2.3,
Figure 14).

`OSCEV` is covered by the same change: it is only usable together with `OPEV`
and, by its own design (`oscev/events.go`: *"OPEV is required to be used, we
don't handle the same events in here"*), defers subscriptions and shared events
to `OPEV`. Both use cases share the same local entity, so no separate handling
is needed.

## On the "never sends a notify" symptom

While investigating I verified that the CEM's own heartbeat **sending** already
works: the spine `HeartbeatManager` auto-starts as soon as the read-only
heartbeat function is registered (`FeatureLocal.AddFunctionType` →
`HeartbeatManager.SetLocalFeature` → `StartHeartbeat`), and notifies any peer
that has subscribed to the CEM's `DeviceDiagnosis` server. Confirmed at runtime:
after `AddFeatures()`, `LocalEntity.HeartbeatManager().IsHeartbeatRunning()` is
`true`. A peer only receives those notifies if it subscribes — which the CEM
cannot force. So this PR focuses on the actionable gap vs. lpc/lpp: the receive
side.

## Tests

`go test ./usecases/cem/...` passes. Added `Test_Heartbeat` in
`usecases/cem/opev/events_test.go`, mirroring the test #120 added for the EG
LPC/LPP pair.
