### PR TITLE
Add Hvac and Setpoint client features

### DIFF
--- a/features/client/hvac.go
+++ b/features/client/hvac.go
@@ -74,6 +74,40 @@ func (h *Hvac) RequestHvacSystemFunctionSetpointRelations(
 	return h.requestData(model.FunctionTypeHvacSystemFunctionSetPointRelationListData, selector, elements)
 }
 
+// request FunctionTypeHvacOverrunDescriptionListData from a remote device
+func (h *Hvac) RequestHvacOverrunDescriptions(
+	selector *model.HvacOverrunDescriptionListDataSelectorsType,
+	elements *model.HvacOverrunDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return h.requestData(model.FunctionTypeHvacOverrunDescriptionListData, selector, elements)
+}
+
+// request FunctionTypeHvacOverrunListData from a remote device
+func (h *Hvac) RequestHvacOverruns(
+	selector *model.HvacOverrunListDataSelectorsType,
+	elements *model.HvacOverrunDataElementsType,
+) (*model.MsgCounterType, error) {
+	return h.requestData(model.FunctionTypeHvacOverrunListData, selector, elements)
+}
+
+// write the given HVAC overrun data to the remote device,
+// e.g. to start or stop an overrun
+func (h *Hvac) WriteHvacOverrunListData(
+	data []model.HvacOverrunDataType,
+) (*model.MsgCounterType, error) {
+	if len(data) == 0 {
+		return nil, api.ErrMissingData
+	}
+
+	cmd := model.CmdType{
+		HvacOverrunListData: &model.HvacOverrunListDataType{
+			HvacOverrunData: data,
+		},
+	}
+
+	return h.remoteDevice.Sender().Write(h.featureLocal.Address(), h.featureRemote.Address(), cmd)
+}
+
 // write the given HVAC system function data to the remote device,
 // e.g. to change the current operation mode of a system function
 func (h *Hvac) WriteHvacSystemFunctionListData(

--- a/features/client/hvac.go
+++ b/features/client/hvac.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"github.com/enbility/eebus-go/api"
+	"github.com/enbility/eebus-go/features/internal"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+type Hvac struct {
+	*Feature
+
+	*internal.HvacCommon
+}
+
+// Get a new HVAC features helper
+//
+// - The feature on the local entity has to be of role client
+// - The feature on the remote entity has to be of role server
+func NewHvac(
+	localEntity spineapi.EntityLocalInterface,
+	remoteEntity spineapi.EntityRemoteInterface,
+) (*Hvac, error) {
+	feature, err := NewFeature(model.FeatureTypeTypeHvac, localEntity, remoteEntity)
+	if err != nil {
+		return nil, err
+	}
+
+	hvac := &Hvac{
+		Feature:    feature,
+		HvacCommon: internal.NewRemoteHvac(feature.featureRemote),
+	}
+
+	return hvac, nil
+}
+
+// request FunctionTypeHvacSystemFunctionDescriptionListData from a remote device
+func (h *Hvac) RequestHvacSystemFunctionDescriptions(
+	selector *model.HvacSystemFunctionDescriptionListDataSelectorsType,
+	elements *model.HvacSystemFunctionDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return h.requestData(model.FunctionTypeHvacSystemFunctionDescriptionListData, selector, elements)
+}
+
+// request FunctionTypeHvacSystemFunctionListData from a remote device
+func (h *Hvac) RequestHvacSystemFunctions(
+	selector *model.HvacSystemFunctionListDataSelectorsType,
+	elements *model.HvacSystemFunctionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return h.requestData(model.FunctionTypeHvacSystemFunctionListData, selector, elements)
+}
+
+// request FunctionTypeHvacOperationModeDescriptionListData from a remote device
+func (h *Hvac) RequestHvacOperationModeDescriptions(
+	selector *model.HvacOperationModeDescriptionListDataSelectorsType,
+	elements *model.HvacOperationModeDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return h.requestData(model.FunctionTypeHvacOperationModeDescriptionListData, selector, elements)
+}
+
+// request FunctionTypeHvacSystemFunctionOperationModeRelationListData from a remote device
+func (h *Hvac) RequestHvacSystemFunctionOperationModeRelations(
+	selector *model.HvacSystemFunctionOperationModeRelationListDataSelectorsType,
+	elements *model.HvacSystemFunctionOperationModeRelationDataElementsType,
+) (*model.MsgCounterType, error) {
+	return h.requestData(model.FunctionTypeHvacSystemFunctionOperationModeRelationListData, selector, elements)
+}
+
+// request FunctionTypeHvacSystemFunctionSetPointRelationListData from a remote device
+func (h *Hvac) RequestHvacSystemFunctionSetpointRelations(
+	selector *model.HvacSystemFunctionSetpointRelationListDataSelectorsType,
+	elements *model.HvacSystemFunctionSetpointRelationDataElementsType,
+) (*model.MsgCounterType, error) {
+	return h.requestData(model.FunctionTypeHvacSystemFunctionSetPointRelationListData, selector, elements)
+}
+
+// write the given HVAC system function data to the remote device,
+// e.g. to change the current operation mode of a system function
+func (h *Hvac) WriteHvacSystemFunctionListData(
+	data []model.HvacSystemFunctionDataType,
+) (*model.MsgCounterType, error) {
+	if len(data) == 0 {
+		return nil, api.ErrMissingData
+	}
+
+	cmd := model.CmdType{
+		HvacSystemFunctionListData: &model.HvacSystemFunctionListDataType{
+			HvacSystemFunctionData: data,
+		},
+	}
+
+	return h.remoteDevice.Sender().Write(h.featureLocal.Address(), h.featureRemote.Address(), cmd)
+}

--- a/features/client/hvac.go
+++ b/features/client/hvac.go
@@ -5,6 +5,7 @@ import (
 	"github.com/enbility/eebus-go/features/internal"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
 )
 
 type Hvac struct {
@@ -105,10 +106,28 @@ func (h *Hvac) WriteHvacOverrunListData(
 		return nil, api.ErrNotSupported
 	}
 
+	// use a partial write when the server supports it, otherwise merge the
+	// modified entries into the cached list and write the complete list, so
+	// unrelated overruns are not dropped by a full replacement
+	filters := []model.FilterType{*model.NewFilterTypePartial()}
+	if !operation.WritePartial() {
+		filters = nil
+		updateData := &model.HvacOverrunListDataType{
+			HvacOverrunData: data,
+		}
+		if mergedData, err := h.featureRemote.UpdateData(false, model.FunctionTypeHvacOverrunListData, updateData, nil, nil); err == nil {
+			data = mergedData.([]model.HvacOverrunDataType)
+		}
+	}
+
 	cmd := model.CmdType{
 		HvacOverrunListData: &model.HvacOverrunListDataType{
 			HvacOverrunData: data,
 		},
+	}
+	if filters != nil {
+		cmd.Filter = filters
+		cmd.Function = util.Ptr(model.FunctionTypeHvacOverrunListData)
 	}
 
 	return h.remoteDevice.Sender().Write(h.featureLocal.Address(), h.featureRemote.Address(), cmd)
@@ -129,10 +148,28 @@ func (h *Hvac) WriteHvacSystemFunctionListData(
 		return nil, api.ErrNotSupported
 	}
 
+	// use a partial write when the server supports it, otherwise merge the
+	// modified entries into the cached list and write the complete list, so
+	// unrelated system functions are not dropped by a full replacement
+	filters := []model.FilterType{*model.NewFilterTypePartial()}
+	if !operation.WritePartial() {
+		filters = nil
+		updateData := &model.HvacSystemFunctionListDataType{
+			HvacSystemFunctionData: data,
+		}
+		if mergedData, err := h.featureRemote.UpdateData(false, model.FunctionTypeHvacSystemFunctionListData, updateData, nil, nil); err == nil {
+			data = mergedData.([]model.HvacSystemFunctionDataType)
+		}
+	}
+
 	cmd := model.CmdType{
 		HvacSystemFunctionListData: &model.HvacSystemFunctionListDataType{
 			HvacSystemFunctionData: data,
 		},
+	}
+	if filters != nil {
+		cmd.Filter = filters
+		cmd.Function = util.Ptr(model.FunctionTypeHvacSystemFunctionListData)
 	}
 
 	return h.remoteDevice.Sender().Write(h.featureLocal.Address(), h.featureRemote.Address(), cmd)

--- a/features/client/hvac.go
+++ b/features/client/hvac.go
@@ -99,6 +99,12 @@ func (h *Hvac) WriteHvacOverrunListData(
 		return nil, api.ErrMissingData
 	}
 
+	// the remote server has to advertise the write operation for this function
+	operation := h.featureRemote.Operations()[model.FunctionTypeHvacOverrunListData]
+	if operation == nil || !operation.Write() {
+		return nil, api.ErrNotSupported
+	}
+
 	cmd := model.CmdType{
 		HvacOverrunListData: &model.HvacOverrunListDataType{
 			HvacOverrunData: data,
@@ -115,6 +121,12 @@ func (h *Hvac) WriteHvacSystemFunctionListData(
 ) (*model.MsgCounterType, error) {
 	if len(data) == 0 {
 		return nil, api.ErrMissingData
+	}
+
+	// the remote server has to advertise the write operation for this function
+	operation := h.featureRemote.Operations()[model.FunctionTypeHvacSystemFunctionListData]
+	if operation == nil || !operation.Write() {
+		return nil, api.ErrNotSupported
 	}
 
 	cmd := model.CmdType{

--- a/features/client/hvac_test.go
+++ b/features/client/hvac_test.go
@@ -44,6 +44,8 @@ func (s *HvacSuite) BeforeTest(suiteName, testName string) {
 					model.FunctionTypeHvacOperationModeDescriptionListData,
 					model.FunctionTypeHvacSystemFunctionOperationModeRelationListData,
 					model.FunctionTypeHvacSystemFunctionSetPointRelationListData,
+					model.FunctionTypeHvacOverrunDescriptionListData,
+					model.FunctionTypeHvacOverrunListData,
 				},
 			},
 		},
@@ -106,6 +108,34 @@ func (s *HvacSuite) Test_WriteHvacSystemFunctionListData() {
 		},
 	}
 	counter, err = s.hvac.WriteHvacSystemFunctionListData(data)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_RequestHvacOverrunDescriptions() {
+	counter, err := s.hvac.RequestHvacOverrunDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_RequestHvacOverruns() {
+	counter, err := s.hvac.RequestHvacOverruns(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_WriteHvacOverrunListData() {
+	counter, err := s.hvac.WriteHvacOverrunListData(nil)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), counter)
+
+	data := []model.HvacOverrunDataType{
+		{
+			OverrunId:     util.Ptr(model.HvacOverrunIdType(1)),
+			OverrunStatus: util.Ptr(model.HvacOverrunStatusTypeActive),
+		},
+	}
+	counter, err = s.hvac.WriteHvacOverrunListData(data)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }

--- a/features/client/hvac_test.go
+++ b/features/client/hvac_test.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"testing"
+
+	shipapi "github.com/enbility/ship-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestHvacSuite(t *testing.T) {
+	suite.Run(t, new(HvacSuite))
+}
+
+type HvacSuite struct {
+	suite.Suite
+
+	localEntity  spineapi.EntityLocalInterface
+	remoteEntity spineapi.EntityRemoteInterface
+
+	hvac        *Hvac
+	sentMessage []byte
+}
+
+var _ shipapi.ShipConnectionDataWriterInterface = (*HvacSuite)(nil)
+
+func (s *HvacSuite) WriteShipMessageWithPayload(message []byte) {
+	s.sentMessage = message
+}
+
+func (s *HvacSuite) BeforeTest(suiteName, testName string) {
+	s.localEntity, s.remoteEntity = setupFeatures(
+		s.T(),
+		s,
+		[]featureFunctions{
+			{
+				featureType: model.FeatureTypeTypeHvac,
+				functions: []model.FunctionType{
+					model.FunctionTypeHvacSystemFunctionDescriptionListData,
+					model.FunctionTypeHvacSystemFunctionListData,
+					model.FunctionTypeHvacOperationModeDescriptionListData,
+					model.FunctionTypeHvacSystemFunctionOperationModeRelationListData,
+					model.FunctionTypeHvacSystemFunctionSetPointRelationListData,
+				},
+			},
+		},
+	)
+
+	var err error
+	s.hvac, err = NewHvac(s.localEntity, nil)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), s.hvac)
+
+	s.hvac, err = NewHvac(s.localEntity, s.remoteEntity)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), s.hvac)
+}
+
+func (s *HvacSuite) Test_RequestHvacSystemFunctionDescriptions() {
+	counter, err := s.hvac.RequestHvacSystemFunctionDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_RequestHvacSystemFunctions() {
+	counter, err := s.hvac.RequestHvacSystemFunctions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_RequestHvacOperationModeDescriptions() {
+	counter, err := s.hvac.RequestHvacOperationModeDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_RequestHvacSystemFunctionOperationModeRelations() {
+	counter, err := s.hvac.RequestHvacSystemFunctionOperationModeRelations(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_RequestHvacSystemFunctionSetpointRelations() {
+	counter, err := s.hvac.RequestHvacSystemFunctionSetpointRelations(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *HvacSuite) Test_WriteHvacSystemFunctionListData() {
+	counter, err := s.hvac.WriteHvacSystemFunctionListData(nil)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), counter)
+
+	data := []model.HvacSystemFunctionDataType{}
+	counter, err = s.hvac.WriteHvacSystemFunctionListData(data)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), counter)
+
+	data = []model.HvacSystemFunctionDataType{
+		{
+			SystemFunctionId:       util.Ptr(model.HvacSystemFunctionIdType(1)),
+			CurrentOperationModeId: util.Ptr(model.HvacOperationModeIdType(2)),
+		},
+	}
+	counter, err = s.hvac.WriteHvacSystemFunctionListData(data)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}

--- a/features/client/hvac_test.go
+++ b/features/client/hvac_test.go
@@ -139,3 +139,32 @@ func (s *HvacSuite) Test_WriteHvacOverrunListData() {
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 }
+
+func (s *HvacSuite) Test_WriteHvacSystemFunctionListData_Partial() {
+	localEntity, remoteEntity := setupFeatures(
+		s.T(),
+		s,
+		[]featureFunctions{
+			{
+				featureType: model.FeatureTypeTypeHvac,
+				functions: []model.FunctionType{
+					model.FunctionTypeHvacSystemFunctionListData,
+				},
+				partial: true,
+			},
+		},
+	)
+
+	hvac, err := NewHvac(localEntity, remoteEntity)
+	assert.Nil(s.T(), err)
+
+	data := []model.HvacSystemFunctionDataType{
+		{
+			SystemFunctionId:       util.Ptr(model.HvacSystemFunctionIdType(1)),
+			CurrentOperationModeId: util.Ptr(model.HvacOperationModeIdType(2)),
+		},
+	}
+	counter, err := hvac.WriteHvacSystemFunctionListData(data)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}

--- a/features/client/setpoint.go
+++ b/features/client/setpoint.go
@@ -67,6 +67,12 @@ func (s *Setpoint) WriteSetpointListData(
 		return nil, api.ErrMissingData
 	}
 
+	// the remote server has to advertise the write operation for this function
+	operation := s.featureRemote.Operations()[model.FunctionTypeSetpointListData]
+	if operation == nil || !operation.Write() {
+		return nil, api.ErrNotSupported
+	}
+
 	cmd := model.CmdType{
 		SetpointListData: &model.SetpointListDataType{
 			SetpointData: data,

--- a/features/client/setpoint.go
+++ b/features/client/setpoint.go
@@ -5,6 +5,7 @@ import (
 	"github.com/enbility/eebus-go/features/internal"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
 )
 
 type Setpoint struct {
@@ -73,10 +74,28 @@ func (s *Setpoint) WriteSetpointListData(
 		return nil, api.ErrNotSupported
 	}
 
+	// use a partial write when the server supports it, otherwise merge the
+	// modified entries into the cached list and write the complete list, so
+	// unrelated setpoints are not dropped by a full replacement
+	filters := []model.FilterType{*model.NewFilterTypePartial()}
+	if !operation.WritePartial() {
+		filters = nil
+		updateData := &model.SetpointListDataType{
+			SetpointData: data,
+		}
+		if mergedData, err := s.featureRemote.UpdateData(false, model.FunctionTypeSetpointListData, updateData, nil, nil); err == nil {
+			data = mergedData.([]model.SetpointDataType)
+		}
+	}
+
 	cmd := model.CmdType{
 		SetpointListData: &model.SetpointListDataType{
 			SetpointData: data,
 		},
+	}
+	if filters != nil {
+		cmd.Filter = filters
+		cmd.Function = util.Ptr(model.FunctionTypeSetpointListData)
 	}
 
 	return s.remoteDevice.Sender().Write(s.featureLocal.Address(), s.featureRemote.Address(), cmd)

--- a/features/client/setpoint.go
+++ b/features/client/setpoint.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"github.com/enbility/eebus-go/api"
+	"github.com/enbility/eebus-go/features/internal"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+type Setpoint struct {
+	*Feature
+
+	*internal.SetpointCommon
+}
+
+// Get a new Setpoint features helper
+//
+// - The feature on the local entity has to be of role client
+// - The feature on the remote entity has to be of role server
+func NewSetpoint(
+	localEntity spineapi.EntityLocalInterface,
+	remoteEntity spineapi.EntityRemoteInterface,
+) (*Setpoint, error) {
+	feature, err := NewFeature(model.FeatureTypeTypeSetpoint, localEntity, remoteEntity)
+	if err != nil {
+		return nil, err
+	}
+
+	sp := &Setpoint{
+		Feature:        feature,
+		SetpointCommon: internal.NewRemoteSetpoint(feature.featureRemote),
+	}
+
+	return sp, nil
+}
+
+// request FunctionTypeSetpointDescriptionListData from a remote device
+func (s *Setpoint) RequestSetpointDescriptions(
+	selector *model.SetpointDescriptionListDataSelectorsType,
+	elements *model.SetpointDescriptionDataElementsType,
+) (*model.MsgCounterType, error) {
+	return s.requestData(model.FunctionTypeSetpointDescriptionListData, selector, elements)
+}
+
+// request FunctionTypeSetpointConstraintsListData from a remote device
+func (s *Setpoint) RequestSetpointConstraints(
+	selector *model.SetpointConstraintsListDataSelectorsType,
+	elements *model.SetpointConstraintsDataElementsType,
+) (*model.MsgCounterType, error) {
+	return s.requestData(model.FunctionTypeSetpointConstraintsListData, selector, elements)
+}
+
+// request FunctionTypeSetpointListData from a remote device
+func (s *Setpoint) RequestSetpoints(
+	selector *model.SetpointListDataSelectorsType,
+	elements *model.SetpointDataElementsType,
+) (*model.MsgCounterType, error) {
+	return s.requestData(model.FunctionTypeSetpointListData, selector, elements)
+}
+
+// write the given setpoint data to the remote device,
+// returns the message counter of the sent message
+func (s *Setpoint) WriteSetpointListData(
+	data []model.SetpointDataType,
+) (*model.MsgCounterType, error) {
+	if len(data) == 0 {
+		return nil, api.ErrMissingData
+	}
+
+	cmd := model.CmdType{
+		SetpointListData: &model.SetpointListDataType{
+			SetpointData: data,
+		},
+	}
+
+	return s.remoteDevice.Sender().Write(s.featureLocal.Address(), s.featureRemote.Address(), cmd)
+}

--- a/features/client/setpoint_test.go
+++ b/features/client/setpoint_test.go
@@ -1,0 +1,97 @@
+package client
+
+import (
+	"testing"
+
+	shipapi "github.com/enbility/ship-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestSetpointSuite(t *testing.T) {
+	suite.Run(t, new(SetpointSuite))
+}
+
+type SetpointSuite struct {
+	suite.Suite
+
+	localEntity  spineapi.EntityLocalInterface
+	remoteEntity spineapi.EntityRemoteInterface
+
+	setpoint    *Setpoint
+	sentMessage []byte
+}
+
+var _ shipapi.ShipConnectionDataWriterInterface = (*SetpointSuite)(nil)
+
+func (s *SetpointSuite) WriteShipMessageWithPayload(message []byte) {
+	s.sentMessage = message
+}
+
+func (s *SetpointSuite) BeforeTest(suiteName, testName string) {
+	s.localEntity, s.remoteEntity = setupFeatures(
+		s.T(),
+		s,
+		[]featureFunctions{
+			{
+				featureType: model.FeatureTypeTypeSetpoint,
+				functions: []model.FunctionType{
+					model.FunctionTypeSetpointDescriptionListData,
+					model.FunctionTypeSetpointConstraintsListData,
+					model.FunctionTypeSetpointListData,
+				},
+			},
+		},
+	)
+
+	var err error
+	s.setpoint, err = NewSetpoint(s.localEntity, nil)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), s.setpoint)
+
+	s.setpoint, err = NewSetpoint(s.localEntity, s.remoteEntity)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), s.setpoint)
+}
+
+func (s *SetpointSuite) Test_RequestSetpointDescriptions() {
+	counter, err := s.setpoint.RequestSetpointDescriptions(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *SetpointSuite) Test_RequestSetpointConstraints() {
+	counter, err := s.setpoint.RequestSetpointConstraints(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *SetpointSuite) Test_RequestSetpoints() {
+	counter, err := s.setpoint.RequestSetpoints(nil, nil)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}
+
+func (s *SetpointSuite) Test_WriteSetpointListData() {
+	counter, err := s.setpoint.WriteSetpointListData(nil)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), counter)
+
+	data := []model.SetpointDataType{}
+	counter, err = s.setpoint.WriteSetpointListData(data)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), counter)
+
+	data = []model.SetpointDataType{
+		{
+			SetpointId: util.Ptr(model.SetpointIdType(1)),
+			Value:      model.NewScaledNumberType(21),
+		},
+	}
+	counter, err = s.setpoint.WriteSetpointListData(data)
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), counter)
+}

--- a/features/internal/hvac.go
+++ b/features/internal/hvac.go
@@ -1,0 +1,174 @@
+package internal
+
+import (
+	"github.com/enbility/eebus-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+)
+
+type HvacCommon struct {
+	featureLocal  spineapi.FeatureLocalInterface
+	featureRemote spineapi.FeatureRemoteInterface
+}
+
+// NewLocalHvac creates a new HvacCommon helper for local entities
+func NewLocalHvac(featureLocal spineapi.FeatureLocalInterface) *HvacCommon {
+	return &HvacCommon{
+		featureLocal: featureLocal,
+	}
+}
+
+// NewRemoteHvac creates a new HvacCommon helper for remote entities
+func NewRemoteHvac(featureRemote spineapi.FeatureRemoteInterface) *HvacCommon {
+	return &HvacCommon{
+		featureRemote: featureRemote,
+	}
+}
+
+// GetHvacSystemFunctionDescriptionsForFilter returns the system function descriptions for a given filter
+func (h *HvacCommon) GetHvacSystemFunctionDescriptionsForFilter(
+	filter model.HvacSystemFunctionDescriptionDataType,
+) ([]model.HvacSystemFunctionDescriptionDataType, error) {
+	function := model.FunctionTypeHvacSystemFunctionDescriptionListData
+
+	data, err := featureDataCopyOfType[model.HvacSystemFunctionDescriptionListDataType](h.featureLocal, h.featureRemote, function)
+	if err != nil || data == nil || data.HvacSystemFunctionDescriptionData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.HvacSystemFunctionDescriptionDataType](data.HvacSystemFunctionDescriptionData, filter)
+
+	return result, nil
+}
+
+// GetHvacSystemFunctionDescriptionForId returns the system function description for a given system function ID
+func (h *HvacCommon) GetHvacSystemFunctionDescriptionForId(
+	id model.HvacSystemFunctionIdType,
+) (*model.HvacSystemFunctionDescriptionDataType, error) {
+	filter := model.HvacSystemFunctionDescriptionDataType{
+		SystemFunctionId: &id,
+	}
+
+	result, err := h.GetHvacSystemFunctionDescriptionsForFilter(filter)
+	if err != nil || len(result) == 0 {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	return util.Ptr(result[0]), nil
+}
+
+// GetHvacSystemFunctionsForFilter returns the system function data for a given filter
+func (h *HvacCommon) GetHvacSystemFunctionsForFilter(
+	filter model.HvacSystemFunctionDataType,
+) ([]model.HvacSystemFunctionDataType, error) {
+	function := model.FunctionTypeHvacSystemFunctionListData
+
+	data, err := featureDataCopyOfType[model.HvacSystemFunctionListDataType](h.featureLocal, h.featureRemote, function)
+	if err != nil || data == nil || data.HvacSystemFunctionData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.HvacSystemFunctionDataType](data.HvacSystemFunctionData, filter)
+
+	return result, nil
+}
+
+// GetHvacSystemFunctionForId returns the system function data for a given system function ID
+func (h *HvacCommon) GetHvacSystemFunctionForId(
+	id model.HvacSystemFunctionIdType,
+) (*model.HvacSystemFunctionDataType, error) {
+	filter := model.HvacSystemFunctionDataType{
+		SystemFunctionId: &id,
+	}
+
+	result, err := h.GetHvacSystemFunctionsForFilter(filter)
+	if err != nil || len(result) == 0 {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	return util.Ptr(result[0]), nil
+}
+
+// GetHvacOperationModeDescriptionsForFilter returns the operation mode descriptions for a given filter
+func (h *HvacCommon) GetHvacOperationModeDescriptionsForFilter(
+	filter model.HvacOperationModeDescriptionDataType,
+) ([]model.HvacOperationModeDescriptionDataType, error) {
+	function := model.FunctionTypeHvacOperationModeDescriptionListData
+
+	data, err := featureDataCopyOfType[model.HvacOperationModeDescriptionListDataType](h.featureLocal, h.featureRemote, function)
+	if err != nil || data == nil || data.HvacOperationModeDescriptionData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.HvacOperationModeDescriptionDataType](data.HvacOperationModeDescriptionData, filter)
+
+	return result, nil
+}
+
+// GetHvacOperationModeDescriptionForId returns the operation mode description for a given operation mode ID
+func (h *HvacCommon) GetHvacOperationModeDescriptionForId(
+	id model.HvacOperationModeIdType,
+) (*model.HvacOperationModeDescriptionDataType, error) {
+	filter := model.HvacOperationModeDescriptionDataType{
+		OperationModeId: &id,
+	}
+
+	result, err := h.GetHvacOperationModeDescriptionsForFilter(filter)
+	if err != nil || len(result) == 0 {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	return util.Ptr(result[0]), nil
+}
+
+// GetHvacSystemFunctionOperationModeRelationsForFilter returns the system function
+// operation mode relations for a given filter
+func (h *HvacCommon) GetHvacSystemFunctionOperationModeRelationsForFilter(
+	filter model.HvacSystemFunctionOperationModeRelationDataType,
+) ([]model.HvacSystemFunctionOperationModeRelationDataType, error) {
+	function := model.FunctionTypeHvacSystemFunctionOperationModeRelationListData
+
+	data, err := featureDataCopyOfType[model.HvacSystemFunctionOperationModeRelationListDataType](h.featureLocal, h.featureRemote, function)
+	if err != nil || data == nil || data.HvacSystemFunctionOperationModeRelationData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.HvacSystemFunctionOperationModeRelationDataType](data.HvacSystemFunctionOperationModeRelationData, filter)
+
+	return result, nil
+}
+
+// GetHvacSystemFunctionSetpointRelationsForFilter returns the system function
+// setpoint relations for a given filter
+func (h *HvacCommon) GetHvacSystemFunctionSetpointRelationsForFilter(
+	filter model.HvacSystemFunctionSetpointRelationDataType,
+) ([]model.HvacSystemFunctionSetpointRelationDataType, error) {
+	function := model.FunctionTypeHvacSystemFunctionSetPointRelationListData
+
+	data, err := featureDataCopyOfType[model.HvacSystemFunctionSetpointRelationListDataType](h.featureLocal, h.featureRemote, function)
+	if err != nil || data == nil || data.HvacSystemFunctionSetpointRelationData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.HvacSystemFunctionSetpointRelationDataType](data.HvacSystemFunctionSetpointRelationData, filter)
+
+	return result, nil
+}
+
+// CheckEventPayloadDataForFilter checks if the given event payload data contains
+// system function data matching the given filter
+func (h *HvacCommon) CheckEventPayloadDataForFilter(payloadData any, filter model.HvacSystemFunctionDataType) bool {
+	if payloadData == nil {
+		return false
+	}
+
+	data, ok := payloadData.(*model.HvacSystemFunctionListDataType)
+	if !ok || data.HvacSystemFunctionData == nil {
+		return false
+	}
+
+	result := searchFilterInList[model.HvacSystemFunctionDataType](data.HvacSystemFunctionData, filter)
+
+	return len(result) > 0
+}

--- a/features/internal/hvac.go
+++ b/features/internal/hvac.go
@@ -156,6 +156,54 @@ func (h *HvacCommon) GetHvacSystemFunctionSetpointRelationsForFilter(
 	return result, nil
 }
 
+// GetHvacOverrunDescriptionsForFilter returns the overrun descriptions for a given filter
+func (h *HvacCommon) GetHvacOverrunDescriptionsForFilter(
+	filter model.HvacOverrunDescriptionDataType,
+) ([]model.HvacOverrunDescriptionDataType, error) {
+	function := model.FunctionTypeHvacOverrunDescriptionListData
+
+	data, err := featureDataCopyOfType[model.HvacOverrunDescriptionListDataType](h.featureLocal, h.featureRemote, function)
+	if err != nil || data == nil || data.HvacOverrunDescriptionData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.HvacOverrunDescriptionDataType](data.HvacOverrunDescriptionData, filter)
+
+	return result, nil
+}
+
+// GetHvacOverrunDataForFilter returns the overrun data for a given filter
+func (h *HvacCommon) GetHvacOverrunDataForFilter(
+	filter model.HvacOverrunDataType,
+) ([]model.HvacOverrunDataType, error) {
+	function := model.FunctionTypeHvacOverrunListData
+
+	data, err := featureDataCopyOfType[model.HvacOverrunListDataType](h.featureLocal, h.featureRemote, function)
+	if err != nil || data == nil || data.HvacOverrunData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.HvacOverrunDataType](data.HvacOverrunData, filter)
+
+	return result, nil
+}
+
+// GetHvacOverrunForId returns the overrun data for a given overrun ID
+func (h *HvacCommon) GetHvacOverrunForId(
+	id model.HvacOverrunIdType,
+) (*model.HvacOverrunDataType, error) {
+	filter := model.HvacOverrunDataType{
+		OverrunId: &id,
+	}
+
+	result, err := h.GetHvacOverrunDataForFilter(filter)
+	if err != nil || len(result) == 0 {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	return util.Ptr(result[0]), nil
+}
+
 // CheckEventPayloadDataForFilter checks if the given event payload data contains
 // system function data matching the given filter
 func (h *HvacCommon) CheckEventPayloadDataForFilter(payloadData any, filter model.HvacSystemFunctionDataType) bool {

--- a/features/internal/hvac_test.go
+++ b/features/internal/hvac_test.go
@@ -1,0 +1,336 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/enbility/eebus-go/features/internal"
+	shipmocks "github.com/enbility/ship-go/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestHvacSuite(t *testing.T) {
+	suite.Run(t, new(HvacSuite))
+}
+
+type HvacSuite struct {
+	suite.Suite
+
+	localEntity  spineapi.EntityLocalInterface
+	remoteEntity spineapi.EntityRemoteInterface
+
+	localFeature  spineapi.FeatureLocalInterface
+	remoteFeature spineapi.FeatureRemoteInterface
+
+	localSut,
+	remoteSut *internal.HvacCommon
+}
+
+func (s *HvacSuite) BeforeTest(suiteName, testName string) {
+	mockWriter := shipmocks.NewShipConnectionDataWriterInterface(s.T())
+	mockWriter.EXPECT().WriteShipMessageWithPayload(mock.Anything).Return().Maybe()
+
+	s.localEntity, s.remoteEntity = setupFeatures(
+		s.T(),
+		mockWriter,
+		[]featureFunctions{
+			{
+				featureType: model.FeatureTypeTypeHvac,
+				functions: []model.FunctionType{
+					model.FunctionTypeHvacSystemFunctionDescriptionListData,
+					model.FunctionTypeHvacSystemFunctionListData,
+					model.FunctionTypeHvacOperationModeDescriptionListData,
+					model.FunctionTypeHvacSystemFunctionOperationModeRelationListData,
+					model.FunctionTypeHvacSystemFunctionSetPointRelationListData,
+				},
+			},
+		},
+	)
+
+	s.localFeature = s.localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeHvac, model.RoleTypeServer)
+	assert.NotNil(s.T(), s.localFeature)
+	s.localSut = internal.NewLocalHvac(s.localFeature)
+	assert.NotNil(s.T(), s.localSut)
+
+	s.remoteFeature = s.remoteEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeHvac, model.RoleTypeServer)
+	assert.NotNil(s.T(), s.remoteFeature)
+	s.remoteSut = internal.NewRemoteHvac(s.remoteFeature)
+	assert.NotNil(s.T(), s.remoteSut)
+}
+
+func (s *HvacSuite) Test_GetHvacSystemFunctionDescriptions() {
+	filter := model.HvacSystemFunctionDescriptionDataType{}
+	data, err := s.localSut.GetHvacSystemFunctionDescriptionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetHvacSystemFunctionDescriptionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	desc, err := s.localSut.GetHvacSystemFunctionDescriptionForId(model.HvacSystemFunctionIdType(1))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), desc)
+
+	s.addDescriptions()
+
+	data, err = s.localSut.GetHvacSystemFunctionDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+	data, err = s.remoteSut.GetHvacSystemFunctionDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+
+	filter.SystemFunctionType = util.Ptr(model.HvacSystemFunctionTypeTypeHeating)
+	data, err = s.localSut.GetHvacSystemFunctionDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+
+	desc, err = s.localSut.GetHvacSystemFunctionDescriptionForId(model.HvacSystemFunctionIdType(1))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), desc)
+	desc, err = s.remoteSut.GetHvacSystemFunctionDescriptionForId(model.HvacSystemFunctionIdType(10))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), desc)
+}
+
+func (s *HvacSuite) Test_GetHvacSystemFunctions() {
+	filter := model.HvacSystemFunctionDataType{}
+	data, err := s.localSut.GetHvacSystemFunctionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetHvacSystemFunctionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	function, err := s.localSut.GetHvacSystemFunctionForId(model.HvacSystemFunctionIdType(1))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), function)
+
+	s.addData()
+
+	data, err = s.localSut.GetHvacSystemFunctionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+	data, err = s.remoteSut.GetHvacSystemFunctionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+
+	function, err = s.localSut.GetHvacSystemFunctionForId(model.HvacSystemFunctionIdType(1))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), function)
+	assert.Equal(s.T(), model.HvacOperationModeIdType(2), *function.CurrentOperationModeId)
+
+	function, err = s.remoteSut.GetHvacSystemFunctionForId(model.HvacSystemFunctionIdType(10))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), function)
+}
+
+func (s *HvacSuite) Test_GetHvacOperationModeDescriptions() {
+	filter := model.HvacOperationModeDescriptionDataType{}
+	data, err := s.localSut.GetHvacOperationModeDescriptionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetHvacOperationModeDescriptionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	desc, err := s.localSut.GetHvacOperationModeDescriptionForId(model.HvacOperationModeIdType(1))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), desc)
+
+	s.addOperationModeDescriptions()
+
+	data, err = s.localSut.GetHvacOperationModeDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+	data, err = s.remoteSut.GetHvacOperationModeDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+
+	filter.OperationModeType = util.Ptr(model.HvacOperationModeTypeTypeAuto)
+	data, err = s.localSut.GetHvacOperationModeDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+
+	desc, err = s.localSut.GetHvacOperationModeDescriptionForId(model.HvacOperationModeIdType(1))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), desc)
+	desc, err = s.remoteSut.GetHvacOperationModeDescriptionForId(model.HvacOperationModeIdType(10))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), desc)
+}
+
+func (s *HvacSuite) Test_GetHvacSystemFunctionOperationModeRelations() {
+	filter := model.HvacSystemFunctionOperationModeRelationDataType{}
+	data, err := s.localSut.GetHvacSystemFunctionOperationModeRelationsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetHvacSystemFunctionOperationModeRelationsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	s.addOperationModeRelations()
+
+	data, err = s.localSut.GetHvacSystemFunctionOperationModeRelationsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+	data, err = s.remoteSut.GetHvacSystemFunctionOperationModeRelationsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+
+	filter.SystemFunctionId = util.Ptr(model.HvacSystemFunctionIdType(1))
+	data, err = s.localSut.GetHvacSystemFunctionOperationModeRelationsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+}
+
+func (s *HvacSuite) Test_GetHvacSystemFunctionSetpointRelations() {
+	filter := model.HvacSystemFunctionSetpointRelationDataType{}
+	data, err := s.localSut.GetHvacSystemFunctionSetpointRelationsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetHvacSystemFunctionSetpointRelationsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	s.addSetpointRelations()
+
+	data, err = s.localSut.GetHvacSystemFunctionSetpointRelationsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+	data, err = s.remoteSut.GetHvacSystemFunctionSetpointRelationsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+
+	filter.OperationModeId = util.Ptr(model.HvacOperationModeIdType(1))
+	data, err = s.localSut.GetHvacSystemFunctionSetpointRelationsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+}
+
+func (s *HvacSuite) Test_CheckEventPayloadDataForFilter() {
+	filter := model.HvacSystemFunctionDataType{
+		SystemFunctionId: util.Ptr(model.HvacSystemFunctionIdType(1)),
+	}
+
+	exists := s.localSut.CheckEventPayloadDataForFilter(nil, filter)
+	assert.False(s.T(), exists)
+	exists = s.remoteSut.CheckEventPayloadDataForFilter(nil, filter)
+	assert.False(s.T(), exists)
+
+	temp := true
+	exists = s.localSut.CheckEventPayloadDataForFilter(temp, filter)
+	assert.False(s.T(), exists)
+
+	data := &model.HvacSystemFunctionListDataType{}
+	exists = s.localSut.CheckEventPayloadDataForFilter(data, filter)
+	assert.False(s.T(), exists)
+
+	data = &model.HvacSystemFunctionListDataType{
+		HvacSystemFunctionData: []model.HvacSystemFunctionDataType{
+			{
+				SystemFunctionId:       util.Ptr(model.HvacSystemFunctionIdType(1)),
+				CurrentOperationModeId: util.Ptr(model.HvacOperationModeIdType(2)),
+			},
+		},
+	}
+	exists = s.localSut.CheckEventPayloadDataForFilter(data, filter)
+	assert.True(s.T(), exists)
+
+	filter.SystemFunctionId = util.Ptr(model.HvacSystemFunctionIdType(10))
+	exists = s.localSut.CheckEventPayloadDataForFilter(data, filter)
+	assert.False(s.T(), exists)
+}
+
+// helpers
+
+func (s *HvacSuite) addDescriptions() {
+	fData := &model.HvacSystemFunctionDescriptionListDataType{
+		HvacSystemFunctionDescriptionData: []model.HvacSystemFunctionDescriptionDataType{
+			{
+				SystemFunctionId:   util.Ptr(model.HvacSystemFunctionIdType(1)),
+				SystemFunctionType: util.Ptr(model.HvacSystemFunctionTypeTypeHeating),
+			},
+			{
+				SystemFunctionId:   util.Ptr(model.HvacSystemFunctionIdType(2)),
+				SystemFunctionType: util.Ptr(model.HvacSystemFunctionTypeTypeDhw),
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeHvacSystemFunctionDescriptionListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeHvacSystemFunctionDescriptionListData, fData, nil, nil)
+}
+
+func (s *HvacSuite) addData() {
+	fData := &model.HvacSystemFunctionListDataType{
+		HvacSystemFunctionData: []model.HvacSystemFunctionDataType{
+			{
+				SystemFunctionId:            util.Ptr(model.HvacSystemFunctionIdType(1)),
+				CurrentOperationModeId:      util.Ptr(model.HvacOperationModeIdType(2)),
+				IsOperationModeIdChangeable: util.Ptr(true),
+				CurrentSetpointId:           util.Ptr(model.SetpointIdType(1)),
+				IsSetpointIdChangeable:      util.Ptr(true),
+				IsOverrunActive:             util.Ptr(false),
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeHvacSystemFunctionListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeHvacSystemFunctionListData, fData, nil, nil)
+}
+
+func (s *HvacSuite) addOperationModeDescriptions() {
+	fData := &model.HvacOperationModeDescriptionListDataType{
+		HvacOperationModeDescriptionData: []model.HvacOperationModeDescriptionDataType{
+			{
+				OperationModeId:   util.Ptr(model.HvacOperationModeIdType(1)),
+				OperationModeType: util.Ptr(model.HvacOperationModeTypeTypeAuto),
+			},
+			{
+				OperationModeId:   util.Ptr(model.HvacOperationModeIdType(2)),
+				OperationModeType: util.Ptr(model.HvacOperationModeTypeTypeOff),
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeHvacOperationModeDescriptionListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeHvacOperationModeDescriptionListData, fData, nil, nil)
+}
+
+func (s *HvacSuite) addOperationModeRelations() {
+	fData := &model.HvacSystemFunctionOperationModeRelationListDataType{
+		HvacSystemFunctionOperationModeRelationData: []model.HvacSystemFunctionOperationModeRelationDataType{
+			{
+				SystemFunctionId: util.Ptr(model.HvacSystemFunctionIdType(1)),
+				OperationModeId:  []model.HvacOperationModeIdType{1},
+			},
+			{
+				SystemFunctionId: util.Ptr(model.HvacSystemFunctionIdType(2)),
+				OperationModeId:  []model.HvacOperationModeIdType{2},
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeHvacSystemFunctionOperationModeRelationListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeHvacSystemFunctionOperationModeRelationListData, fData, nil, nil)
+}
+
+func (s *HvacSuite) addSetpointRelations() {
+	fData := &model.HvacSystemFunctionSetpointRelationListDataType{
+		HvacSystemFunctionSetpointRelationData: []model.HvacSystemFunctionSetpointRelationDataType{
+			{
+				SystemFunctionId: util.Ptr(model.HvacSystemFunctionIdType(1)),
+				OperationModeId:  util.Ptr(model.HvacOperationModeIdType(1)),
+				SetpointId:       []model.SetpointIdType{1},
+			},
+			{
+				SystemFunctionId: util.Ptr(model.HvacSystemFunctionIdType(1)),
+				OperationModeId:  util.Ptr(model.HvacOperationModeIdType(2)),
+				SetpointId:       []model.SetpointIdType{2},
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeHvacSystemFunctionSetPointRelationListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeHvacSystemFunctionSetPointRelationListData, fData, nil, nil)
+}

--- a/features/internal/hvac_test.go
+++ b/features/internal/hvac_test.go
@@ -46,6 +46,8 @@ func (s *HvacSuite) BeforeTest(suiteName, testName string) {
 					model.FunctionTypeHvacOperationModeDescriptionListData,
 					model.FunctionTypeHvacSystemFunctionOperationModeRelationListData,
 					model.FunctionTypeHvacSystemFunctionSetPointRelationListData,
+					model.FunctionTypeHvacOverrunDescriptionListData,
+					model.FunctionTypeHvacOverrunListData,
 				},
 			},
 		},
@@ -246,7 +248,74 @@ func (s *HvacSuite) Test_CheckEventPayloadDataForFilter() {
 	assert.False(s.T(), exists)
 }
 
+func (s *HvacSuite) Test_GetHvacOverruns() {
+	descFilter := model.HvacOverrunDescriptionDataType{}
+	descriptions, err := s.localSut.GetHvacOverrunDescriptionsForFilter(descFilter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), descriptions)
+	descriptions, err = s.remoteSut.GetHvacOverrunDescriptionsForFilter(descFilter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), descriptions)
+
+	filter := model.HvacOverrunDataType{}
+	data, err := s.localSut.GetHvacOverrunDataForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	overrun, err := s.localSut.GetHvacOverrunForId(model.HvacOverrunIdType(1))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), overrun)
+
+	s.addOverrunData()
+
+	descFilter.OverrunType = util.Ptr(model.HvacOverrunTypeTypeOneTimeDhw)
+	descriptions, err = s.localSut.GetHvacOverrunDescriptionsForFilter(descFilter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(descriptions))
+	descriptions, err = s.remoteSut.GetHvacOverrunDescriptionsForFilter(descFilter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(descriptions))
+
+	data, err = s.localSut.GetHvacOverrunDataForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+
+	overrun, err = s.localSut.GetHvacOverrunForId(model.HvacOverrunIdType(1))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), overrun)
+	assert.Equal(s.T(), model.HvacOverrunStatusTypeInactive, *overrun.OverrunStatus)
+
+	overrun, err = s.remoteSut.GetHvacOverrunForId(model.HvacOverrunIdType(10))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), overrun)
+}
+
 // helpers
+
+func (s *HvacSuite) addOverrunData() {
+	descData := &model.HvacOverrunDescriptionListDataType{
+		HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{
+			{
+				OverrunId:                util.Ptr(model.HvacOverrunIdType(1)),
+				OverrunType:              util.Ptr(model.HvacOverrunTypeTypeOneTimeDhw),
+				AffectedSystemFunctionId: []model.HvacSystemFunctionIdType{1},
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeHvacOverrunDescriptionListData, descData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeHvacOverrunDescriptionListData, descData, nil, nil)
+
+	fData := &model.HvacOverrunListDataType{
+		HvacOverrunData: []model.HvacOverrunDataType{
+			{
+				OverrunId:     util.Ptr(model.HvacOverrunIdType(1)),
+				OverrunStatus: util.Ptr(model.HvacOverrunStatusTypeInactive),
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeHvacOverrunListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeHvacOverrunListData, fData, nil, nil)
+}
 
 func (s *HvacSuite) addDescriptions() {
 	fData := &model.HvacSystemFunctionDescriptionListDataType{

--- a/features/internal/setpoint.go
+++ b/features/internal/setpoint.go
@@ -1,0 +1,140 @@
+package internal
+
+import (
+	"github.com/enbility/eebus-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+)
+
+type SetpointCommon struct {
+	featureLocal  spineapi.FeatureLocalInterface
+	featureRemote spineapi.FeatureRemoteInterface
+}
+
+// NewLocalSetpoint creates a new SetpointCommon helper for local entities
+func NewLocalSetpoint(featureLocal spineapi.FeatureLocalInterface) *SetpointCommon {
+	return &SetpointCommon{
+		featureLocal: featureLocal,
+	}
+}
+
+// NewRemoteSetpoint creates a new SetpointCommon helper for remote entities
+func NewRemoteSetpoint(featureRemote spineapi.FeatureRemoteInterface) *SetpointCommon {
+	return &SetpointCommon{
+		featureRemote: featureRemote,
+	}
+}
+
+// GetSetpointDescriptionsForFilter returns the setpoint descriptions for a given filter
+func (s *SetpointCommon) GetSetpointDescriptionsForFilter(
+	filter model.SetpointDescriptionDataType,
+) ([]model.SetpointDescriptionDataType, error) {
+	function := model.FunctionTypeSetpointDescriptionListData
+
+	data, err := featureDataCopyOfType[model.SetpointDescriptionListDataType](s.featureLocal, s.featureRemote, function)
+	if err != nil || data == nil || data.SetpointDescriptionData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.SetpointDescriptionDataType](data.SetpointDescriptionData, filter)
+
+	return result, nil
+}
+
+// GetSetpointDescriptionForId returns the setpoint description for a given setpoint ID
+func (s *SetpointCommon) GetSetpointDescriptionForId(
+	id model.SetpointIdType,
+) (*model.SetpointDescriptionDataType, error) {
+	filter := model.SetpointDescriptionDataType{
+		SetpointId: &id,
+	}
+
+	result, err := s.GetSetpointDescriptionsForFilter(filter)
+	if err != nil || len(result) == 0 {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	return util.Ptr(result[0]), nil
+}
+
+// GetSetpointDataForFilter returns the setpoint data for a given filter
+func (s *SetpointCommon) GetSetpointDataForFilter(
+	filter model.SetpointDataType,
+) ([]model.SetpointDataType, error) {
+	function := model.FunctionTypeSetpointListData
+
+	data, err := featureDataCopyOfType[model.SetpointListDataType](s.featureLocal, s.featureRemote, function)
+	if err != nil || data == nil || data.SetpointData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.SetpointDataType](data.SetpointData, filter)
+
+	return result, nil
+}
+
+// GetSetpointForId returns the setpoint data for a given setpoint ID
+func (s *SetpointCommon) GetSetpointForId(
+	id model.SetpointIdType,
+) (*model.SetpointDataType, error) {
+	filter := model.SetpointDataType{
+		SetpointId: &id,
+	}
+
+	result, err := s.GetSetpointDataForFilter(filter)
+	if err != nil || len(result) == 0 {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	return util.Ptr(result[0]), nil
+}
+
+// GetSetpointConstraintsForFilter returns the setpoint constraints for a given filter
+func (s *SetpointCommon) GetSetpointConstraintsForFilter(
+	filter model.SetpointConstraintsDataType,
+) ([]model.SetpointConstraintsDataType, error) {
+	function := model.FunctionTypeSetpointConstraintsListData
+
+	data, err := featureDataCopyOfType[model.SetpointConstraintsListDataType](s.featureLocal, s.featureRemote, function)
+	if err != nil || data == nil || data.SetpointConstraintsData == nil {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	result := searchFilterInList[model.SetpointConstraintsDataType](data.SetpointConstraintsData, filter)
+
+	return result, nil
+}
+
+// GetSetpointConstraintsForId returns the setpoint constraints for a given setpoint ID
+func (s *SetpointCommon) GetSetpointConstraintsForId(
+	id model.SetpointIdType,
+) (*model.SetpointConstraintsDataType, error) {
+	filter := model.SetpointConstraintsDataType{
+		SetpointId: &id,
+	}
+
+	result, err := s.GetSetpointConstraintsForFilter(filter)
+	if err != nil || len(result) == 0 {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	return util.Ptr(result[0]), nil
+}
+
+// CheckEventPayloadDataForFilter checks if the given event payload data contains
+// setpoint data for the given setpoint ID
+func (s *SetpointCommon) CheckEventPayloadDataForFilter(payloadData any, filter model.SetpointDataType) bool {
+	if payloadData == nil {
+		return false
+	}
+
+	data, ok := payloadData.(*model.SetpointListDataType)
+	if !ok || data.SetpointData == nil {
+		return false
+	}
+
+	result := searchFilterInList[model.SetpointDataType](data.SetpointData, filter)
+
+	return len(result) > 0
+}

--- a/features/internal/setpoint_test.go
+++ b/features/internal/setpoint_test.go
@@ -1,0 +1,252 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/enbility/eebus-go/features/internal"
+	shipmocks "github.com/enbility/ship-go/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestSetpointSuite(t *testing.T) {
+	suite.Run(t, new(SetpointSuite))
+}
+
+type SetpointSuite struct {
+	suite.Suite
+
+	localEntity  spineapi.EntityLocalInterface
+	remoteEntity spineapi.EntityRemoteInterface
+
+	localFeature  spineapi.FeatureLocalInterface
+	remoteFeature spineapi.FeatureRemoteInterface
+
+	localSut,
+	remoteSut *internal.SetpointCommon
+}
+
+func (s *SetpointSuite) BeforeTest(suiteName, testName string) {
+	mockWriter := shipmocks.NewShipConnectionDataWriterInterface(s.T())
+	mockWriter.EXPECT().WriteShipMessageWithPayload(mock.Anything).Return().Maybe()
+
+	s.localEntity, s.remoteEntity = setupFeatures(
+		s.T(),
+		mockWriter,
+		[]featureFunctions{
+			{
+				featureType: model.FeatureTypeTypeSetpoint,
+				functions: []model.FunctionType{
+					model.FunctionTypeSetpointDescriptionListData,
+					model.FunctionTypeSetpointConstraintsListData,
+					model.FunctionTypeSetpointListData,
+				},
+			},
+		},
+	)
+
+	s.localFeature = s.localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeSetpoint, model.RoleTypeServer)
+	assert.NotNil(s.T(), s.localFeature)
+	s.localSut = internal.NewLocalSetpoint(s.localFeature)
+	assert.NotNil(s.T(), s.localSut)
+
+	s.remoteFeature = s.remoteEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeSetpoint, model.RoleTypeServer)
+	assert.NotNil(s.T(), s.remoteFeature)
+	s.remoteSut = internal.NewRemoteSetpoint(s.remoteFeature)
+	assert.NotNil(s.T(), s.remoteSut)
+}
+
+func (s *SetpointSuite) Test_GetSetpointDescriptions() {
+	filter := model.SetpointDescriptionDataType{}
+	data, err := s.localSut.GetSetpointDescriptionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetSetpointDescriptionsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	desc, err := s.localSut.GetSetpointDescriptionForId(model.SetpointIdType(0))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), desc)
+
+	s.addDescriptions()
+
+	data, err = s.localSut.GetSetpointDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+	data, err = s.remoteSut.GetSetpointDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+
+	filter.ScopeType = util.Ptr(model.ScopeTypeTypeDhwTemperature)
+	data, err = s.localSut.GetSetpointDescriptionsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+
+	desc, err = s.localSut.GetSetpointDescriptionForId(model.SetpointIdType(0))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), desc)
+	desc, err = s.remoteSut.GetSetpointDescriptionForId(model.SetpointIdType(10))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), desc)
+}
+
+func (s *SetpointSuite) Test_GetSetpointData() {
+	filter := model.SetpointDataType{}
+	data, err := s.localSut.GetSetpointDataForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetSetpointDataForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	sp, err := s.localSut.GetSetpointForId(model.SetpointIdType(0))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), sp)
+
+	s.addData()
+
+	data, err = s.localSut.GetSetpointDataForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+	data, err = s.remoteSut.GetSetpointDataForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 2, len(data))
+
+	sp, err = s.localSut.GetSetpointForId(model.SetpointIdType(0))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), sp)
+	assert.Equal(s.T(), 21.0, sp.Value.GetValue())
+
+	sp, err = s.remoteSut.GetSetpointForId(model.SetpointIdType(10))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), sp)
+}
+
+func (s *SetpointSuite) Test_GetSetpointConstraints() {
+	filter := model.SetpointConstraintsDataType{}
+	data, err := s.localSut.GetSetpointConstraintsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+	data, err = s.remoteSut.GetSetpointConstraintsForFilter(filter)
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), data)
+
+	constraints, err := s.localSut.GetSetpointConstraintsForId(model.SetpointIdType(0))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), constraints)
+
+	s.addConstraints()
+
+	data, err = s.localSut.GetSetpointConstraintsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+	data, err = s.remoteSut.GetSetpointConstraintsForFilter(filter)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 1, len(data))
+
+	constraints, err = s.localSut.GetSetpointConstraintsForId(model.SetpointIdType(0))
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), constraints)
+	assert.Equal(s.T(), 16.0, constraints.SetpointRangeMin.GetValue())
+	assert.Equal(s.T(), 25.0, constraints.SetpointRangeMax.GetValue())
+
+	constraints, err = s.remoteSut.GetSetpointConstraintsForId(model.SetpointIdType(10))
+	assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), constraints)
+}
+
+func (s *SetpointSuite) Test_CheckEventPayloadDataForFilter() {
+	filter := model.SetpointDataType{
+		SetpointId: util.Ptr(model.SetpointIdType(0)),
+	}
+
+	exists := s.localSut.CheckEventPayloadDataForFilter(nil, filter)
+	assert.False(s.T(), exists)
+	exists = s.remoteSut.CheckEventPayloadDataForFilter(nil, filter)
+	assert.False(s.T(), exists)
+
+	temp := true
+	exists = s.localSut.CheckEventPayloadDataForFilter(temp, filter)
+	assert.False(s.T(), exists)
+
+	data := &model.SetpointListDataType{}
+	exists = s.localSut.CheckEventPayloadDataForFilter(data, filter)
+	assert.False(s.T(), exists)
+
+	data = &model.SetpointListDataType{
+		SetpointData: []model.SetpointDataType{
+			{
+				SetpointId: util.Ptr(model.SetpointIdType(0)),
+				Value:      model.NewScaledNumberType(21),
+			},
+		},
+	}
+	exists = s.localSut.CheckEventPayloadDataForFilter(data, filter)
+	assert.True(s.T(), exists)
+
+	filter.SetpointId = util.Ptr(model.SetpointIdType(10))
+	exists = s.localSut.CheckEventPayloadDataForFilter(data, filter)
+	assert.False(s.T(), exists)
+}
+
+// helpers
+
+func (s *SetpointSuite) addDescriptions() {
+	fData := &model.SetpointDescriptionListDataType{
+		SetpointDescriptionData: []model.SetpointDescriptionDataType{
+			{
+				SetpointId:   util.Ptr(model.SetpointIdType(0)),
+				SetpointType: util.Ptr(model.SetpointTypeTypeValueAbsolute),
+				ScopeType:    util.Ptr(model.ScopeTypeTypeDhwTemperature),
+				Unit:         util.Ptr(model.UnitOfMeasurementTypedegC),
+			},
+			{
+				SetpointId:   util.Ptr(model.SetpointIdType(1)),
+				SetpointType: util.Ptr(model.SetpointTypeTypeValueAbsolute),
+				ScopeType:    util.Ptr(model.ScopeTypeTypeRoomAirTemperature),
+				Unit:         util.Ptr(model.UnitOfMeasurementTypedegC),
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeSetpointDescriptionListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeSetpointDescriptionListData, fData, nil, nil)
+}
+
+func (s *SetpointSuite) addData() {
+	fData := &model.SetpointListDataType{
+		SetpointData: []model.SetpointDataType{
+			{
+				SetpointId:           util.Ptr(model.SetpointIdType(0)),
+				Value:                model.NewScaledNumberType(21),
+				IsSetpointChangeable: util.Ptr(true),
+			},
+			{
+				SetpointId:       util.Ptr(model.SetpointIdType(1)),
+				Value:            model.NewScaledNumberType(45),
+				IsSetpointActive: util.Ptr(true),
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeSetpointListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeSetpointListData, fData, nil, nil)
+}
+
+func (s *SetpointSuite) addConstraints() {
+	fData := &model.SetpointConstraintsListDataType{
+		SetpointConstraintsData: []model.SetpointConstraintsDataType{
+			{
+				SetpointId:       util.Ptr(model.SetpointIdType(0)),
+				SetpointRangeMin: model.NewScaledNumberType(16),
+				SetpointRangeMax: model.NewScaledNumberType(25),
+				SetpointStepSize: model.NewScaledNumberType(0.5),
+			},
+		},
+	}
+	_ = s.localFeature.UpdateData(model.FunctionTypeSetpointConstraintsListData, fData, nil, nil)
+	_, _ = s.remoteFeature.UpdateData(true, model.FunctionTypeSetpointConstraintsListData, fData, nil, nil)
+}

--- a/usecases/api/types.go
+++ b/usecases/api/types.go
@@ -194,3 +194,49 @@ type PendingDeviceConfiguration struct {
 	Value             *model.DeviceConfigurationKeyValueValueType          `json:"value,omitempty"`
 	IsValueChangeable *bool                                                `json:"isValueChangeable,omitempty"`
 }
+
+// operation mode of an HVAC system function
+type HvacOperationModeType string
+
+const (
+	HvacOperationModeTypeAuto HvacOperationModeType = "auto"
+	HvacOperationModeTypeOn   HvacOperationModeType = "on"
+	HvacOperationModeTypeOff  HvacOperationModeType = "off"
+	HvacOperationModeTypeEco  HvacOperationModeType = "eco"
+)
+
+// HVAC temperature setpoint, e.g. for a room or domestic hot water
+type Setpoint struct {
+	// the setpoint identifier
+	Id uint
+
+	// the setpoint temperature value
+	Value float64
+
+	// the minimum allowed temperature value
+	MinValue float64
+
+	// the maximum allowed temperature value
+	MaxValue float64
+
+	// whether the setpoint is currently active
+	IsActive bool
+
+	// whether the setpoint may be changed by a client
+	IsChangeable bool
+}
+
+// constraints for an HVAC temperature setpoint
+type SetpointConstraints struct {
+	// the setpoint identifier
+	Id uint
+
+	// the minimum allowed temperature value
+	MinValue float64
+
+	// the maximum allowed temperature value
+	MaxValue float64
+
+	// the step size for temperature value changes
+	StepSize float64
+}


### PR DESCRIPTION
Adds `features/client` and `features/internal` helpers for the SPINE `HVAC` and `Setpoint` features, including tests.

This is groundwork for the remaining HVAC use cases (system function monitoring/configuration and temperature configuration), which will be submitted as separate PRs per use case, stacked on this one:

- Hvac: read system function descriptions/data, operation mode descriptions, operation mode and setpoint relations; write `hvacSystemFunctionListData`
- Setpoint: read setpoint descriptions/data/constraints; write `setpointListData`

🤖 Generated with [Claude Code](https://claude.com/claude-code)