### PR TITLE
feat(features/client): gate writes on remote Write() support

### DIFF
--- a/features/client/deviceconfiguration.go
+++ b/features/client/deviceconfiguration.go
@@ -61,9 +61,14 @@ func (d *DeviceConfiguration) WriteKeyValues(data []model.DeviceConfigurationKey
 
 	filters := []model.FilterType{*model.NewFilterTypePartial()}
 
-	// does the remote server feature not support partials?
+	// the remote server feature must advertise write support
 	operation := d.featureRemote.Operations()[model.FunctionTypeDeviceConfigurationKeyValueListData]
-	if operation == nil || !operation.WritePartial() {
+	if operation == nil || !operation.Write() {
+		return nil, api.ErrNotSupported
+	}
+
+	// does the remote server feature not support partials?
+	if !operation.WritePartial() {
 		filters = nil
 		// we need to send all data
 		updateData := &model.DeviceConfigurationKeyValueListDataType{

--- a/features/client/deviceconfiguration_test.go
+++ b/features/client/deviceconfiguration_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/enbility/eebus-go/api"
 	shipmocks "github.com/enbility/ship-go/mocks"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/mocks"
@@ -167,6 +168,22 @@ func (s *DeviceConfigurationSuite) Test_WriteValues() {
 	counter, err = s.deviceConfiguration.WriteKeyValues(data)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
+
+	// remote does not advertise write support -> ErrNotSupported
+	mockWriter := shipmocks.NewShipConnectionDataWriterInterface(s.T())
+	mockWriter.EXPECT().WriteShipMessageWithPayload(mock.Anything).Return().Maybe()
+	localRO, remoteRO := setupFeatures(s.T(), mockWriter, []featureFunctions{
+		{
+			featureType: model.FeatureTypeTypeDeviceConfiguration,
+			functions:   []model.FunctionType{model.FunctionTypeDeviceConfigurationKeyValueListData},
+			readOnly:    true,
+		},
+	})
+	roDeviceConfiguration, err := NewDeviceConfiguration(localRO, remoteRO)
+	assert.Nil(s.T(), err)
+	counter, err = roDeviceConfiguration.WriteKeyValues(data)
+	assert.ErrorIs(s.T(), err, api.ErrNotSupported)
+	assert.Nil(s.T(), counter)
 }
 
 // test with partial support

--- a/features/client/helper_test.go
+++ b/features/client/helper_test.go
@@ -17,6 +17,7 @@ type featureFunctions struct {
 	featureType model.FeatureTypeType
 	functions   []model.FunctionType
 	partial     bool
+	readOnly    bool
 }
 
 type WriteMessageHandler struct {
@@ -160,6 +161,10 @@ func setupFeatures(
 				write = &model.PossibleOperationsWriteType{
 					Partial: &model.ElementTagType{},
 				}
+			}
+
+			if item.readOnly {
+				write = nil
 			}
 
 			supportedFct := model.FunctionPropertyType{

--- a/features/client/loadcontrol.go
+++ b/features/client/loadcontrol.go
@@ -86,9 +86,14 @@ func (l *LoadControl) WriteLimitData(
 	}
 	filters = append(filters, *partialFilter)
 
-	// does the remote server feature not support partials?
+	// the remote server feature must advertise write support
 	operation := l.featureRemote.Operations()[model.FunctionTypeLoadControlLimitListData]
-	if operation == nil || !operation.WritePartial() {
+	if operation == nil || !operation.Write() {
+		return nil, api.ErrNotSupported
+	}
+
+	// does the remote server feature not support partials?
+	if !operation.WritePartial() {
 		filters = nil
 		// we need to send all data
 		updateData := &model.LoadControlLimitListDataType{

--- a/features/client/loadcontrol_test.go
+++ b/features/client/loadcontrol_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/enbility/eebus-go/api"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -173,6 +174,20 @@ func (s *LoadControlSuite) Test_WriteLimitValues() {
 	counter, err = s.loadControl.WriteLimitData(data, nil, nil)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
+
+	// remote does not advertise write support -> ErrNotSupported
+	localRO, remoteRO := setupFeatures(s.T(), s, []featureFunctions{
+		{
+			featureType: model.FeatureTypeTypeLoadControl,
+			functions:   []model.FunctionType{model.FunctionTypeLoadControlLimitListData},
+			readOnly:    true,
+		},
+	})
+	roLoadControl, err := NewLoadControl(localRO, remoteRO)
+	assert.Nil(s.T(), err)
+	counter, err = roLoadControl.WriteLimitData(data, nil, nil)
+	assert.ErrorIs(s.T(), err, api.ErrNotSupported)
+	assert.Nil(s.T(), counter)
 }
 
 // test with partial support

--- a/features/client/smartenergymanagementps.go
+++ b/features/client/smartenergymanagementps.go
@@ -46,6 +46,12 @@ func (l *SmartEnergyManagementPs) WriteData(data *model.SmartEnergyManagementPsD
 		return nil, api.ErrMissingData
 	}
 
+	// the remote server feature must advertise write support
+	operation := l.featureRemote.Operations()[model.FunctionTypeSmartEnergyManagementPsData]
+	if operation == nil || !operation.Write() {
+		return nil, api.ErrNotSupported
+	}
+
 	cmd := model.CmdType{
 		Function:                    util.Ptr(model.FunctionTypeSmartEnergyManagementPsData),
 		Filter:                      []model.FilterType{*model.NewFilterTypePartial()},

--- a/features/client/smartenergymanagementps_test.go
+++ b/features/client/smartenergymanagementps_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/enbility/eebus-go/api"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -109,4 +110,18 @@ func (s *SmartEnergyManagementPsSuite) Test_WriteData() {
 	counter, err = s.smartenergymgmtps.WriteData(data)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
+
+	// remote does not advertise write support -> ErrNotSupported
+	localRO, remoteRO := setupFeatures(s.T(), s, []featureFunctions{
+		{
+			featureType: model.FeatureTypeTypeSmartEnergyManagementPs,
+			functions:   []model.FunctionType{model.FunctionTypeSmartEnergyManagementPsData},
+			readOnly:    true,
+		},
+	})
+	roSmartEnergyManagementPs, err := NewSmartEnergyManagementPs(localRO, remoteRO)
+	assert.Nil(s.T(), err)
+	counter, err = roSmartEnergyManagementPs.WriteData(data)
+	assert.ErrorIs(s.T(), err, api.ErrNotSupported)
+	assert.Nil(s.T(), counter)
 }

--- a/features/client/timeseries.go
+++ b/features/client/timeseries.go
@@ -66,6 +66,12 @@ func (t *TimeSeries) WriteData(data []model.TimeSeriesDataType) (*model.MsgCount
 		return nil, api.ErrMissingData
 	}
 
+	// the remote server feature must advertise write support
+	operation := t.featureRemote.Operations()[model.FunctionTypeTimeSeriesListData]
+	if operation == nil || !operation.Write() {
+		return nil, api.ErrNotSupported
+	}
+
 	cmd := model.CmdType{
 		TimeSeriesListData: &model.TimeSeriesListDataType{
 			TimeSeriesData: data,

--- a/features/client/timeseries_test.go
+++ b/features/client/timeseries_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/enbility/eebus-go/api"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -114,4 +115,18 @@ func (s *TimeSeriesSuite) Test_WriteData() {
 	counter, err = s.timeSeries.WriteData(data)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
+
+	// remote does not advertise write support -> ErrNotSupported
+	localRO, remoteRO := setupFeatures(s.T(), s, []featureFunctions{
+		{
+			featureType: model.FeatureTypeTypeTimeSeries,
+			functions:   []model.FunctionType{model.FunctionTypeTimeSeriesListData},
+			readOnly:    true,
+		},
+	})
+	roTimeSeries, err := NewTimeSeries(localRO, remoteRO)
+	assert.Nil(s.T(), err)
+	counter, err = roTimeSeries.WriteData(data)
+	assert.ErrorIs(s.T(), err, api.ErrNotSupported)
+	assert.Nil(s.T(), counter)
 }

--- a/usecases/cem/cevc/testhelper_test.go
+++ b/usecases/cem/cevc/testhelper_test.go
@@ -137,7 +137,8 @@ func setupDevices(
 			supportedFct := model.FunctionPropertyType{
 				Function: util.Ptr(fct),
 				PossibleOperations: &model.PossibleOperationsType{
-					Read: &model.PossibleOperationsReadType{},
+					Read:  &model.PossibleOperationsReadType{},
+					Write: &model.PossibleOperationsWriteType{},
 				},
 			}
 			supportedFcts = append(supportedFcts, supportedFct)

--- a/usecases/cem/ohpcf/testhelper_test.go
+++ b/usecases/cem/ohpcf/testhelper_test.go
@@ -113,7 +113,8 @@ func setupDevices(
 			supportedFct := model.FunctionPropertyType{
 				Function: util.Ptr(fct),
 				PossibleOperations: &model.PossibleOperationsType{
-					Read: &model.PossibleOperationsReadType{},
+					Read:  &model.PossibleOperationsReadType{},
+					Write: &model.PossibleOperationsWriteType{},
 				},
 			}
 			supportedFcts = append(supportedFcts, supportedFct)

--- a/usecases/eg/lpc/testhelper_test.go
+++ b/usecases/eg/lpc/testhelper_test.go
@@ -134,7 +134,8 @@ func setupDevices(
 			supportedFct := model.FunctionPropertyType{
 				Function: util.Ptr(fct),
 				PossibleOperations: &model.PossibleOperationsType{
-					Read: &model.PossibleOperationsReadType{},
+					Read:  &model.PossibleOperationsReadType{},
+					Write: &model.PossibleOperationsWriteType{},
 				},
 			}
 			supportedFcts = append(supportedFcts, supportedFct)

--- a/usecases/eg/lpp/testhelper_test.go
+++ b/usecases/eg/lpp/testhelper_test.go
@@ -134,7 +134,8 @@ func setupDevices(
 			supportedFct := model.FunctionPropertyType{
 				Function: util.Ptr(fct),
 				PossibleOperations: &model.PossibleOperationsType{
-					Read: &model.PossibleOperationsReadType{},
+					Read:  &model.PossibleOperationsReadType{},
+					Write: &model.PossibleOperationsWriteType{},
 				},
 			}
 			supportedFcts = append(supportedFcts, supportedFct)

--- a/usecases/internal/testhelper_test.go
+++ b/usecases/internal/testhelper_test.go
@@ -171,7 +171,8 @@ func setupDevices(
 			supportedFct := model.FunctionPropertyType{
 				Function: util.Ptr(fct),
 				PossibleOperations: &model.PossibleOperationsType{
-					Read: &model.PossibleOperationsReadType{},
+					Read:  &model.PossibleOperationsReadType{},
+					Write: &model.PossibleOperationsWriteType{},
 				},
 			}
 			supportedFcts = append(supportedFcts, supportedFct)


### PR DESCRIPTION
## What

Consistently applies the write-capability gate introduced for the HVAC/Setpoint helpers in #247 to the pre-existing client write helpers:

- `loadcontrol.WriteLimitData`
- `deviceconfiguration.WriteKeyValues`
- `timeseries.WriteData`
- `smartenergymanagementps.WriteData`

Each now returns `api.ErrNotSupported` unless the remote server feature advertises `operation.Write()`.

## Why

Follow-up to the consistency discussion in https://github.com/enbility/eebus-go/pull/247#issuecomment-5025410101. Previously these helpers fetched `Operations()[fn]` only to decide `WritePartial()` and never gated on `Write()`, so a write to a read-only remote was serialized and sent, then rejected remotely, instead of failing fast locally.

## Breaking

Minor breaking (as flagged in the PR-247 discussion): callers writing to a remote that does not advertise write support now receive `ErrNotSupported` instead of the write being attempted.

## Tests

- One read-only negative case per helper (new `readOnly` toggle in the client test helper) asserting `ErrNotSupported`.
- Usecase test setups (`eg/lpc`, `eg/lpp`, `cem/cevc`, `cem/ohpcf`, `usecases/internal`) now advertise `Write()` on remote features, matching real devices. Without this the gate caused those write tests to fail — and made `internal.Test_WriteLoadControlLimits` hang awaiting a response that no longer came.

Full `./usecases/... ./features/... ./api/... ./service/...` suite passes (26 packages, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)