### PR TITLE
fix: ignore useCaseAvailable flag on client (EG) side

### DIFF
--- a/usecases/usecase/events.go
+++ b/usecases/usecase/events.go
@@ -55,14 +55,12 @@ func (u *UseCaseBase) useCaseDataUpdate(
 		}
 
 		for _, support := range uc.UseCaseSupport {
-			// UseCaseAvailable should only be checkd for client functionality
-			// of a use acse. But as there are devices (e.g. Porsche PMCC) that
-			// also use it for the server side, we need to check it always.
+			// Per SPINE-TS-UCD-01 (TC_SPINE_RTC_003), the client (EG) side must
+			// ignore the UseCaseAvailable flag entirely and proceed with setup,
+			// even when the remote server reports UseCaseAvailable=false.
 			if support.UseCaseName == nil ||
 				*support.UseCaseName != u.UseCaseName ||
-				support.ScenarioSupport == nil &&
-					len(support.ScenarioSupport) == 0 ||
-				(support.UseCaseAvailable != nil && !*support.UseCaseAvailable) {
+				support.ScenarioSupport == nil {
 				continue
 			}
 

--- a/usecases/usecase/events_test.go
+++ b/usecases/usecase/events_test.go
@@ -66,6 +66,8 @@ func (s *UseCaseSuite) Test_useCaseDataUpdate() {
 	result = s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1)
 	assert.False(s.T(), result)
 
+	// TC_SPINE_RTC_003: even with useCaseAvailable=false the client (EG) must
+	// ignore the flag and register the use case support.
 	data = &model.NodeManagementUseCaseDataType{}
 	data.AddUseCaseSupport(
 		*feature.Address(),
@@ -80,7 +82,7 @@ func (s *UseCaseSuite) Test_useCaseDataUpdate() {
 	s.uc.useCaseDataUpdate(payload)
 
 	result = s.uc.IsScenarioAvailableAtEntity(s.monitoredEntity, 1)
-	assert.False(s.T(), result)
+	assert.True(s.T(), result)
 
 	data = &model.NodeManagementUseCaseDataType{}
 	data.AddUseCaseSupport(


### PR DESCRIPTION
Fixes #252 (TC_SPINE_RTC_003).

## Problem

Per SPINE-TS-UCD-01, a client acting as Energy Guard must **completely ignore** the `useCaseAvailable` flag received during Use Case discovery. The shared `UseCaseBase` event handler (`usecases/usecase/events.go`) instead gated on it and `continue`d past the use case support entry whenever the remote server sent `useCaseAvailable=false` — so the client aborted setup and never initiated node management operations. Affects all use cases routed through `useCaseDataUpdate()` (LPC, LPP, ...) in the EG role.

## Fix

- Remove the `useCaseAvailable` check from the guard condition.
- Simplify the redundant `ScenarioSupport == nil && len(...) == 0` to `ScenarioSupport == nil` (`len(nil) == 0` always).
- Replace the stale comment referencing the old behavior.

## Test

Updated `events_test.go`: the EV support entry with `useCaseAvailable=false` now asserts the use case registers instead of being dropped. All `usecases/...` suites pass, including `eg/lpc` and `eg/lpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
