### PR TITLE
test: annotate use-case tests with covered SPINE test-spec case

### DIFF
--- a/usecases/cs/lpc/events_test.go
+++ b/usecases/cs/lpc/events_test.go
@@ -91,6 +91,8 @@ func (s *CsLPCSuite) Test_deviceConnected() {
 	s.sut.subscribeHeartbeatWorkaround(payload)
 }
 
+// TC_SPINE_RTS_003: with multiple client entities the CS subscribes to the DeviceDiagnosis
+// server of the entity that created the binding, ignoring the other client entities.
 func (s *CsLPCSuite) Test_multipleDeviceDiagServer() {
 	// multiple entities each with DeviceDiagnosis server
 

--- a/usecases/cs/lpp/events_test.go
+++ b/usecases/cs/lpp/events_test.go
@@ -91,6 +91,8 @@ func (s *CsLPPSuite) Test_deviceConnected() {
 	s.sut.subscribeHeartbeatWorkaround(payload)
 }
 
+// TC_SPINE_RTS_003: with multiple client entities the CS subscribes to the DeviceDiagnosis
+// server of the entity that created the binding, ignoring the other client entities.
 func (s *CsLPPSuite) Test_multipleDeviceDiagServer() {
 	// multiple entities each with DeviceDiagnosis server
 

--- a/usecases/usecase/events_test.go
+++ b/usecases/usecase/events_test.go
@@ -30,6 +30,8 @@ func (s *UseCaseSuite) Test_HandleEvent() {
 	s.uc.HandleEvent(payload)
 }
 
+// TC_SPINE_RTS_003: deduce the client's use-case support per remote entity from its use-case
+// data (feature address + actor), so scenarios are made available only at the matching entity.
 func (s *UseCaseSuite) Test_useCaseDataUpdate() {
 	payload := spineapi.EventPayload{
 		Device:     s.remoteDevice,


### PR DESCRIPTION
Makes SPINE test-spec coverage explicit at the use-case layer: adds `// TC_SPINE_RTS_003` reference comments to the existing use-case tests that exercise the requirement. **Comment-only** — no behavior or assertion changes; the annotated packages stay green.

## Annotated

`TC_SPINE_RTS_003` — subscribe only to the required server feature of the client entity that actively created the binding, ignoring other available client entities:

| Test |
|------|
| `usecases/usecase/events_test.go` `Test_useCaseDataUpdate` (per-entity scenario deduction primitive) |
| `usecases/cs/lpc/events_test.go` `Test_multipleDeviceDiagServer` (most literal cover) |
| `usecases/cs/lpp/events_test.go` `Test_multipleDeviceDiagServer` (LPP side) |

Most SPINE protocol TCs are covered in spine-go (see enbility/spine-go); this repo's use-case tests cleanly cover RTS_003. RTC_003 is handled separately in #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
