### PR TITLE
Keep ErrOperationOnFunctionNotSupported matchable and stop logging it as an error

### DIFF
--- a/features/client/feature.go
+++ b/features/client/feature.go
@@ -136,8 +136,7 @@ func (f *Feature) requestData(function model.FunctionType, selectors any, elemen
 	fTypes := f.featureRemote.Operations()
 	op, exists := fTypes[function]
 	if !exists || !op.Read() {
-		errWithFunction := fmt.Sprintf("%s %s", api.ErrOperationOnFunctionNotSupported.Error(), function)
-		return nil, errors.New(errWithFunction)
+		return nil, fmt.Errorf("%w %s", api.ErrOperationOnFunctionNotSupported, function)
 	}
 
 	// remove the selectors if the remote does not allow partial reads

--- a/features/client/feature_test.go
+++ b/features/client/feature_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/enbility/eebus-go/api"
 	shipapi "github.com/enbility/ship-go/api"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -161,8 +162,9 @@ func (s *FeatureSuite) Test_requestData() {
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), counter)
 
+	// the remote does not support this function, the sentinel must stay matchable
 	counter, err = s.testFeature2.requestData(model.FunctionTypeMeasurementDescriptionListData, nil, nil)
-	assert.NotNil(s.T(), err)
+	assert.ErrorIs(s.T(), err, api.ErrOperationOnFunctionNotSupported)
 	assert.Nil(s.T(), counter)
 
 	counter, err = s.testFeature2.requestData(model.FunctionTypeLoadControlLimitListData, nil, nil)

--- a/usecases/cem/evcc/events.go
+++ b/usecases/cem/evcc/events.go
@@ -144,7 +144,7 @@ func (e *EVCC) evConfigurationDescriptionDataUpdate(entity spineapi.EntityRemote
 	if evDeviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
 		if _, err := evDeviceConfiguration.RequestKeyValues(nil, nil); err != nil {
-			logging.Log().Error("Error getting configuration key values:", err)
+			logging.Log().Debug("Error getting configuration key values:", err)
 		}
 	}
 }
@@ -201,7 +201,7 @@ func (e *EVCC) evManufacturerDataUpdate(payload spineapi.EventPayload) {
 func (e *EVCC) evElectricalParamerDescriptionUpdate(entity spineapi.EntityRemoteInterface) {
 	if evElectricalConnection, err := client.NewElectricalConnection(e.LocalEntity, entity); err == nil {
 		if _, err := evElectricalConnection.RequestPermittedValueSets(nil, nil); err != nil {
-			logging.Log().Error("Error getting electrical permitted values:", err)
+			logging.Log().Debug("Error getting electrical permitted values:", err)
 		}
 	}
 }

--- a/usecases/cem/vabd/events.go
+++ b/usecases/cem/vabd/events.go
@@ -47,11 +47,11 @@ func (e *VABD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get electrical connection parameter
 		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 
@@ -64,11 +64,11 @@ func (e *VABD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get measurement parameters
 		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 }
@@ -78,7 +78,7 @@ func (e *VABD) inverterMeasurementDescriptionDataUpdate(entity spineapi.EntityRe
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
 		if _, err := measurement.RequestData(nil, nil); err != nil {
-			logging.Log().Error("Error getting measurement list values:", err)
+			logging.Log().Debug("Error getting measurement list values:", err)
 		}
 	}
 }

--- a/usecases/cem/vapd/events.go
+++ b/usecases/cem/vapd/events.go
@@ -53,7 +53,7 @@ func (e *VAPD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get configuration data
 		if _, err := deviceConfiguration.RequestKeyValueDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 
@@ -66,11 +66,11 @@ func (e *VAPD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get electrical connection parameter
 		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 
@@ -83,11 +83,11 @@ func (e *VAPD) inverterConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get measurement parameters
 		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 }
@@ -97,7 +97,7 @@ func (e *VAPD) inverterConfigurationDescriptionDataUpdate(entity spineapi.Entity
 	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
 		if _, err := deviceConfiguration.RequestKeyValues(nil, nil); err != nil {
-			logging.Log().Error("Error getting configuration key values:", err)
+			logging.Log().Debug("Error getting configuration key values:", err)
 		}
 	}
 }
@@ -121,7 +121,7 @@ func (e *VAPD) inverterMeasurementDescriptionDataUpdate(entity spineapi.EntityRe
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
 		if _, err := measurement.RequestData(nil, nil); err != nil {
-			logging.Log().Error("Error getting measurement list values:", err)
+			logging.Log().Debug("Error getting measurement list values:", err)
 		}
 	}
 }

--- a/usecases/eg/lpc/events.go
+++ b/usecases/eg/lpc/events.go
@@ -180,7 +180,7 @@ func (e *LPC) configurationDescriptionDataUpdate(entity spineapi.EntityRemoteInt
 	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
 		if _, err := deviceConfiguration.RequestKeyValues(nil, nil); err != nil {
-			logging.Log().Error("Error getting configuration key values:", err)
+			logging.Log().Debug("Error getting configuration key values:", err)
 		}
 	}
 }

--- a/usecases/eg/lpp/events.go
+++ b/usecases/eg/lpp/events.go
@@ -181,7 +181,7 @@ func (e *LPP) configurationDescriptionDataUpdate(entity spineapi.EntityRemoteInt
 	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
 		if _, err := deviceConfiguration.RequestKeyValues(nil, nil); err != nil {
-			logging.Log().Error("Error getting configuration key values:", err)
+			logging.Log().Debug("Error getting configuration key values:", err)
 		}
 	}
 }

--- a/usecases/ma/mdt/events.go
+++ b/usecases/ma/mdt/events.go
@@ -45,11 +45,11 @@ func (e *MDT) deviceConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get measurement parameters
 		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 }
@@ -59,7 +59,7 @@ func (e *MDT) deviceMeasurementDescriptionDataUpdate(entity spineapi.EntityRemot
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
 		if _, err := measurement.RequestData(nil, nil); err != nil {
-			logging.Log().Error("Error getting measurement list values:", err)
+			logging.Log().Debug("Error getting measurement list values:", err)
 		}
 	}
 }

--- a/usecases/ma/mgcp/events.go
+++ b/usecases/ma/mgcp/events.go
@@ -53,7 +53,7 @@ func (e *MGCP) gridConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get configuration data
 		if _, err := deviceConfiguration.RequestKeyValueDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 
@@ -66,11 +66,11 @@ func (e *MGCP) gridConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get electrical connection parameter
 		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 
@@ -83,11 +83,11 @@ func (e *MGCP) gridConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get measurement parameters
 		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 }
@@ -97,7 +97,7 @@ func (e *MGCP) gridConfigurationDescriptionDataUpdate(entity spineapi.EntityRemo
 	if deviceConfiguration, err := client.NewDeviceConfiguration(e.LocalEntity, entity); err == nil {
 		// key value descriptions received, now get the data
 		if _, err := deviceConfiguration.RequestKeyValues(nil, nil); err != nil {
-			logging.Log().Error("Error getting configuration key values:", err)
+			logging.Log().Debug("Error getting configuration key values:", err)
 		}
 	}
 }
@@ -119,7 +119,7 @@ func (e *MGCP) gridMeasurementDescriptionDataUpdate(entity spineapi.EntityRemote
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
 		if _, err := measurement.RequestData(nil, nil); err != nil {
-			logging.Log().Error("Error getting measurement list values:", err)
+			logging.Log().Debug("Error getting measurement list values:", err)
 		}
 	}
 }

--- a/usecases/ma/mpc/events.go
+++ b/usecases/ma/mpc/events.go
@@ -47,11 +47,11 @@ func (e *MPC) deviceConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get electrical connection parameter
 		if _, err := electricalConnection.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := electricalConnection.RequestParameterDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 
@@ -64,11 +64,11 @@ func (e *MPC) deviceConnected(entity spineapi.EntityRemoteInterface) {
 
 		// get measurement parameters
 		if _, err := measurement.RequestDescriptions(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 
 		if _, err := measurement.RequestConstraints(nil, nil); err != nil {
-			logging.Log().Error(err)
+			logging.Log().Debug(err)
 		}
 	}
 }
@@ -78,7 +78,7 @@ func (e *MPC) deviceMeasurementDescriptionDataUpdate(entity spineapi.EntityRemot
 	if measurement, err := client.NewMeasurement(e.LocalEntity, entity); err == nil {
 		// measurement descriptions received, now get the data
 		if _, err := measurement.RequestData(nil, nil); err != nil {
-			logging.Log().Error("Error getting measurement list values:", err)
+			logging.Log().Debug("Error getting measurement list values:", err)
 		}
 	}
 }


### PR DESCRIPTION
`ErrOperationOnFunctionNotSupported` is declared in `api/errors.go` but has exactly one use, and that use throws the sentinel away:

```go
// features/client/feature.go
errWithFunction := fmt.Sprintf("%s %s", api.ErrOperationOnFunctionNotSupported.Error(), function)
return nil, errors.New(errWithFunction)
```

`errors.Is` can never match it, so neither the use cases nor any downstream consumer can distinguish "the remote does not implement this optional function" from a real failure. This wraps it instead. The rendered message is unchanged.

The second half is a consistency fix. Connect-time discovery requests are best-effort — the remote is free not to implement optional functions — and **most use cases already log their failures at debug level**: `cs/lpc`, `cs/lpp`, `eg/lpc`, `eg/lpp`, `cem/evcc`, `cem/evcem`, `cem/cevc`, `cem/opev`, `cem/evsoc`, `cem/ohpcf`. Five files still log the same class of request at error level, and `eg/lpc` / `eg/lpp` are inconsistent within themselves — every `Request*` call is debug except `RequestKeyValues`. This aligns the outliers.

What prompted it: a NIBE VVM S320 heat pump. Its Measurement server declares `measurementListData` and `measurementDescriptionListData` and nothing else, which is legal — `measurementConstraintsListData` is optional. `ma/mpc` requests constraints unconditionally on connect for every compatible entity, so the device produces two lines like this on every connection, forever:

```
ERROR operation is not supported on function measurementConstraintsListData
```

The use case works fine — descriptions arrive, `DataUpdatePower` streams normally — but users reasonably read a red ERROR as the reason their device is not working and open bug reports about it.

Verified: `go vet ./...` clean, `go test ./...` green. `usecases/api/types.go` is reported by `gofmt -l` on `dev` as well and is left untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
