### PR TITLE
Address the power sequence by id for process control

### DIFF
--- a/usecases/cem/ohpcf/public.go
+++ b/usecases/cem/ohpcf/public.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+const remoteDataStructureError = "The remote data structure is in an invalid state "
+
 // Scenario 1
 
 func (o *OHPCF) OptionalPowerConsumption(entity spineapi.EntityRemoteInterface) (*ucapi.OptionalPowerConsumptionInfo, error) {
@@ -29,7 +31,6 @@ func (o *OHPCF) OptionalPowerConsumption(entity spineapi.EntityRemoteInterface) 
 	if len(alt) == 0 {
 		return nil, api.ErrDataNotAvailable
 	}
-	remoteDataStructureError := "The remote data structure is in an invalid state "
 	if len(alt[0].PowerSequence) == 0 {
 		return nil, fmt.Errorf("%s(alternative attribute present but no power sequence defined)", remoteDataStructureError)
 	}
@@ -292,7 +293,7 @@ func (o *OHPCF) PowerConsumptionMinimalPauseDuration(entity spineapi.EntityRemot
 // parameters:
 //   - startIn: Delay from now until the power consumption starts (0 = start immediately)
 func (o *OHPCF) SchedulePowerConsumptionProcess(entity spineapi.EntityRemoteInterface, startIn time.Duration, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
-	info, err := o.OptionalPowerConsumption(entity)
+	seqId, err := o.powerSequenceId(entity)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +302,7 @@ func (o *OHPCF) SchedulePowerConsumptionProcess(entity spineapi.EntityRemoteInte
 		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
 			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{
 				Description: &model.PowerSequenceDescriptionDataType{
-					SequenceId: &info.PowerSequenceId,
+					SequenceId: seqId,
 				},
 				Schedule: &model.PowerSequenceScheduleDataType{
 					// relative start time (ISO 8601 duration); heat pumps advertise their
@@ -317,7 +318,7 @@ func (o *OHPCF) SchedulePowerConsumptionProcess(entity spineapi.EntityRemoteInte
 
 // stop (abort) the process [OHPCF-022/1].
 func (o *OHPCF) AbortPowerConsumptionProcess(entity spineapi.EntityRemoteInterface, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
-	info, err := o.OptionalPowerConsumption(entity)
+	seqId, err := o.powerSequenceId(entity)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +327,7 @@ func (o *OHPCF) AbortPowerConsumptionProcess(entity spineapi.EntityRemoteInterfa
 		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
 			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{
 				Description: &model.PowerSequenceDescriptionDataType{
-					SequenceId: util.Ptr(info.PowerSequenceId),
+					SequenceId: seqId,
 				},
 				State: &model.PowerSequenceStateDataType{
 					State: util.Ptr(model.PowerSequenceStateTypeInvalid),
@@ -340,7 +341,7 @@ func (o *OHPCF) AbortPowerConsumptionProcess(entity spineapi.EntityRemoteInterfa
 
 // pause the process [OHPCF-022/2].
 func (o *OHPCF) PausePowerConsumptionProcess(entity spineapi.EntityRemoteInterface, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
-	info, err := o.OptionalPowerConsumption(entity)
+	seqId, err := o.powerSequenceId(entity)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +350,7 @@ func (o *OHPCF) PausePowerConsumptionProcess(entity spineapi.EntityRemoteInterfa
 		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
 			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{
 				Description: &model.PowerSequenceDescriptionDataType{
-					SequenceId: util.Ptr(info.PowerSequenceId),
+					SequenceId: seqId,
 				},
 				State: &model.PowerSequenceStateDataType{
 					State: util.Ptr(model.PowerSequenceStateTypePaused),
@@ -363,7 +364,7 @@ func (o *OHPCF) PausePowerConsumptionProcess(entity spineapi.EntityRemoteInterfa
 
 // resume the process [OHPCF-022/3].
 func (o *OHPCF) ResumePowerConsumptionProcess(entity spineapi.EntityRemoteInterface, resultCB func(result model.ResultDataType, msgCounter model.MsgCounterType)) (*model.MsgCounterType, error) {
-	info, err := o.OptionalPowerConsumption(entity)
+	seqId, err := o.powerSequenceId(entity)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +373,7 @@ func (o *OHPCF) ResumePowerConsumptionProcess(entity spineapi.EntityRemoteInterf
 		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
 			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{
 				Description: &model.PowerSequenceDescriptionDataType{
-					SequenceId: util.Ptr(info.PowerSequenceId),
+					SequenceId: seqId,
 				},
 				State: &model.PowerSequenceStateDataType{
 					State: util.Ptr(model.PowerSequenceStateTypeRunning),
@@ -385,6 +386,26 @@ func (o *OHPCF) ResumePowerConsumptionProcess(entity spineapi.EntityRemoteInterf
 }
 
 // ------------------------ helper methods ------------------------ //
+
+// powerSequenceId returns the id of the announced power sequence, the only element
+// a process control request needs to address it [OHPCF-004], [OHPCF-022].
+func (o *OHPCF) powerSequenceId(entity spineapi.EntityRemoteInterface) (*model.PowerSequenceIdType, error) {
+	data, err := o.checkEntityTypeAndGetData(entity)
+	if err != nil {
+		return nil, err
+	}
+
+	if !o.isDataAvailable(data) {
+		return nil, api.ErrDataNotAvailable
+	}
+
+	seq := data.Alternatives[0].PowerSequence[0]
+	if seq.Description == nil || seq.Description.SequenceId == nil {
+		return nil, fmt.Errorf("%s(alternative attribute present but no power sequenceId defined)", remoteDataStructureError)
+	}
+
+	return util.Ptr(*seq.Description.SequenceId), nil
+}
 
 func (o *OHPCF) checkEntityTypeAndGetData(entity spineapi.EntityRemoteInterface) (*model.SmartEnergyManagementPsDataType, error) {
 	if !o.IsCompatibleEntityType(entity) {

--- a/usecases/cem/ohpcf/public_test.go
+++ b/usecases/cem/ohpcf/public_test.go
@@ -532,3 +532,65 @@ func (s *CemOhPCFSuite) Test_isDataAvailable() {
 	available = s.sut.isDataAvailable(fData)
 	assert.Equal(s.T(), true, available)
 }
+
+// A process control request only needs the sequence id, so it must work on a
+// sequence that does not announce the scenario 1 details.
+func (s *CemOhPCFSuite) Test_ProcessControlWithoutOptionalPowerConsumption() {
+	data := &model.SmartEnergyManagementPsDataType{
+		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
+			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{
+				Description: &model.PowerSequenceDescriptionDataType{
+					SequenceId: util.Ptr(model.PowerSequenceIdType(1)),
+				},
+				State: &model.PowerSequenceStateDataType{
+					State: util.Ptr(model.PowerSequenceStateTypeInactive),
+				},
+			}},
+		}},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeSmartEnergyManagementPs, model.RoleTypeServer)
+	_, fErr := rFeature.UpdateData(true, model.FunctionTypeSmartEnergyManagementPsData, data, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	// the scenario 1 overview is incomplete
+	_, err := s.sut.OptionalPowerConsumption(s.monitoredEntity)
+	assert.NotNil(s.T(), err)
+
+	// process control still addresses the sequence
+	msgCounter, err := s.sut.SchedulePowerConsumptionProcess(s.monitoredEntity, 0, nil)
+	assert.NotNil(s.T(), msgCounter)
+	assert.Nil(s.T(), err)
+
+	msgCounter, err = s.sut.ResumePowerConsumptionProcess(s.monitoredEntity, nil)
+	assert.NotNil(s.T(), msgCounter)
+	assert.Nil(s.T(), err)
+
+	msgCounter, err = s.sut.PausePowerConsumptionProcess(s.monitoredEntity, nil)
+	assert.NotNil(s.T(), msgCounter)
+	assert.Nil(s.T(), err)
+
+	msgCounter, err = s.sut.AbortPowerConsumptionProcess(s.monitoredEntity, nil)
+	assert.NotNil(s.T(), msgCounter)
+	assert.Nil(s.T(), err)
+}
+
+// The sequence id is mandatory for process control.
+func (s *CemOhPCFSuite) Test_ProcessControlWithoutSequenceId() {
+	data := &model.SmartEnergyManagementPsDataType{
+		Alternatives: []model.SmartEnergyManagementPsAlternativesType{{
+			PowerSequence: []model.SmartEnergyManagementPsPowerSequenceType{{
+				State: &model.PowerSequenceStateDataType{
+					State: util.Ptr(model.PowerSequenceStateTypeInactive),
+				},
+			}},
+		}},
+	}
+
+	rFeature := s.remoteDevice.FeatureByEntityTypeAndRole(s.monitoredEntity, model.FeatureTypeTypeSmartEnergyManagementPs, model.RoleTypeServer)
+	_, fErr := rFeature.UpdateData(true, model.FunctionTypeSmartEnergyManagementPsData, data, nil, nil)
+	assert.Nil(s.T(), fErr)
+
+	_, err := s.sut.SchedulePowerConsumptionProcess(s.monitoredEntity, 0, nil)
+	assert.NotNil(s.T(), err)
+}


### PR DESCRIPTION
The four scenario 2 process control methods each start with

```go
info, err := o.OptionalPowerConsumption(entity)
if err != nil {
	return nil, err
}
```

and then use exactly one field of the result — `info.PowerSequenceId`. Everything else the getter produces is discarded.

That getter belongs to scenario 1. Its result type cannot express "unknown": `State`, `IsPausable` and `IsStoppable` are value types, so a missing `operatingConstraintsInterrupt` would silently read as "neither pausable nor stoppable", which per OHPCF-011/7 is not a legal announcement. Erroring out is right for the overview call. It is not right for a request whose payload carries the sequence id and a state or a schedule, and nothing else.

The effect is that a remote which does not announce `operatingConstraintsInterrupt`, or announces a power sequence without a time slot value, cannot be scheduled, paused, resumed or aborted — while `PowerConsumptionProcessState` and the other readers keep working on the same data. The failure surfaces to the user as

```
The remote data structure is in an invalid state (alternative attribute present but no power sequence operating interrupt constraints defined)
```

on every control attempt (evcc-io/evcc#32252, a Vaillant aroTHERM plus whose stored sequence had lost that element).

This adds `powerSequenceId()`, which resolves the id through the same `isDataAvailable` check and the same "no power sequenceId defined" error, and points the four methods at it. `OptionalPowerConsumption` keeps its contract unchanged.

Note that the pausable/stoppable question is not lost: it was never enforced here. `PausePowerConsumptionProcess` validated that `operatingConstraintsInterrupt` exists and then ignored its values, so callers already have to consult `ConsumptionIsPausable`/`ConsumptionIsStoppable` themselves, which is what evcc does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)